### PR TITLE
Added bower link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This package depends on the following packages:
 -   `numpy`
 -   `IPython` (version >=4.0)
 
+Make sure you have `bower` installed. [See `bower`'s installation instructions.](http://bower.io/)
+
 ### Installation
 
 1. Installing `bqplot`:


### PR DESCRIPTION
When installing from PyPI I got a cryptic error. The fix turned out to be installing Bower on my system through npm install. This pr just adds it to the dependency list in the README.

Please let me know if this pr format is incorrect, or my adjustment was in error.

Will Farmer