### PR TITLE
Use a secure address for cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This package depends on the following packages:
     or for a development installation,
 
     ```
-    $ git clone git@github.com:bloomberg/bqplot.git
+    $ git clone https://github.com/bloomberg/bqplot.git
     $ cd bqplot
     $ pip install -e .
     $ bower install


### PR DESCRIPTION
The current method gives me this:

```bash
$ git clone git@github.com:bloomberg/bqplot.git
Cloning into 'bqplot'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```