### PR TITLE
Cleaned up old commented-out code in OHLC.js

### DIFF
--- a/bqplot/nbextension/OHLC.js
+++ b/bqplot/nbextension/OHLC.js
@@ -154,20 +154,7 @@ define(["./components/d3/d3", "./Mark"], function(d3, MarkViewModule) {
 
             var mark_width = this.calculate_mark_width();
             if(mark_width instanceof Date) mark_width = mark_width.getTime();
-            var x_scale = this.scales.x;
-            /*
-             * I did not remove this as I was not sure of what this is doing.
-             * So I am not sure if the new code is equivalent to the old one.
-            // Avoid accounting for width if there is no width to account for
-            if(this.model.px.o !== -1) max += mark_width * 0.75 * 0.5;
-            if(this.model.px.c !== -1) min -= mark_width * 0.75 * 0.5;
-            if(x_scale.model.type === 'date') {
-                min = new Date(min);
-                max = new Date(max);
-            }
-            */
-            var idx_start = -1;
-            var idx_end = -1;
+
             var indices = _.range(this.model.mark_data.length);
             var that = this;
             var selected = _.filter(indices, function(index) {
@@ -175,6 +162,9 @@ define(["./components/d3/d3", "./Mark"], function(d3, MarkViewModule) {
                 return (elem >= start_pxl && elem <= end_pxl);
             });
 
+            var x_scale = this.scales.x;
+            var idx_start = -1;
+            var idx_end = -1;
             if(selected.length > 0 &&
                 (start_pxl !== x_scale.scale.range()[0] ||
                     end_pxl !== x_scale.scale.range()[1]))

--- a/bqplot/nbextension/OHLC.js
+++ b/bqplot/nbextension/OHLC.js
@@ -152,9 +152,6 @@ define(["./components/d3/d3", "./Mark"], function(d3, MarkViewModule) {
                 return selected;
             }
 
-            var mark_width = this.calculate_mark_width();
-            if(mark_width instanceof Date) mark_width = mark_width.getTime();
-
             var indices = _.range(this.model.mark_data.length);
             var that = this;
             var selected = _.filter(indices, function(index) {


### PR DESCRIPTION
I took out the old commented-out code that I wrote. I figured I would explain what it does here so that you do not feel guilty removing it.

A picture is worth 1,000 words, so take a look:
![highlightbehaviour](https://cloud.githubusercontent.com/assets/6856391/10386142/e405f406-6e07-11e5-8b59-955b8dafdeab.png)

Currently, the selection must be covering the centre of the mark in order for it to be highlighted. You can see that in this picture, the mark to the left of the cursor is not highlighted.

The old code would cause the mark to the left of the cursor to be highlighted because the selection is hitting its tail. Like this:
![highlight](https://cloud.githubusercontent.com/assets/6856391/10386739/a0337192-6e0f-11e5-8bd2-70efe64a7eff.png)


Side note: I moved some variables around so they were closer to the context they were being used in.