### PR TITLE
Remove calls to deprecated `widget.after_displayed`

### DIFF
--- a/bqplot/nbextension/Axis.js
+++ b/bqplot/nbextension/Axis.js
@@ -552,9 +552,9 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             if (this.axis_scale) { this.axis_scale.remove(); }
             return this.create_child_view(model).then(function(view) {
                 // Trigger the displayed event of the child view.
-                that.after_displayed(function() {
+                that.displayed.then(function() {
                     view.trigger("displayed");
-                }, that);
+                });
                 that.axis_scale = view;
                 that.axis_scale.on("domain_changed", that.redraw_axisline, that);
                 that.axis_scale.on("highlight_axis", that.highlight, that);

--- a/bqplot/nbextension/Bars.js
+++ b/bqplot/nbextension/Bars.js
@@ -21,23 +21,24 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             this.padding = this.model.get("padding");
             var base_creation_promise = Bars.__super__.render.apply(this);
             this.set_internal_scales();
-            var self = this;
             this.selected_indices = this.model.get("selected");
             this.selected_style = this.model.get("selected_style");
             this.unselected_style = this.model.get("unselected_style");
 
             this.display_el_classes = ["bar", "legendtext"];
-            this.after_displayed(function() {
-                self.parent.tooltip_div.node().appendChild(self.tooltip_div.node());
-                self.create_tooltip();
+
+            var that = this;
+            this.displayed.then(function() {
+                that.parent.tooltip_div.node().appendChild(that.tooltip_div.node());
+                that.create_tooltip();
             });
 
             return base_creation_promise.then(function() {
-                self.event_listeners = {};
-                self.process_interactions();
-                self.create_listeners();
-                self.compute_view_padding();
-                self.draw();
+                that.event_listeners = {};
+                that.process_interactions();
+                that.create_listeners();
+                that.compute_view_padding();
+                that.draw();
             });
         },
         set_ranges: function() {

--- a/bqplot/nbextension/ColorAxis.js
+++ b/bqplot/nbextension/ColorAxis.js
@@ -80,9 +80,9 @@ define(["./components/d3/d3", "./utils", "./ColorUtils", "./Axis"], function(d3,
             if (this.axis_scale) { this.axis_scale.remove(); }
             return this.create_child_view(model).then(function(view) {
                 // Trigger the displayed event of the child view.
-                that.after_displayed(function() {
+                that.displayed.then(function() {
                     view.trigger("displayed");
-                }, that);
+                });
                 that.axis_scale = view;
                 // TODO: eventually removes what follows
                 if(that.axis_scale.model.type === "date_color_linear") {

--- a/bqplot/nbextension/Figure.js
+++ b/bqplot/nbextension/Figure.js
@@ -164,7 +164,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "base/js
                     that.update_layout();
                 });
 
-                that.after_displayed(function() {
+                that.displayed.then(function() {
                     that.el.parentNode.appendChild(that.tooltip_div.node());
                     that.create_listeners();
                     that.update_layout();
@@ -178,7 +178,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "base/js
                     view.dummy_node.parentNode.replaceChild(view.el.node(),
                                                             view.dummy_node);
                     view.dummy_node = null;
-                    this.after_displayed(function() {
+                    this.displayed.then(function() {
                         view.trigger("displayed");
                     });
                 }
@@ -274,7 +274,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "base/js
             return this.create_child_view(model)
               .then(function(view) {
                 that.fig_axes.node().appendChild(view.el.node());
-                that.after_displayed(function() {
+                that.displayed.then(function() {
                     view.trigger("displayed");
                 });
                 return view;
@@ -540,9 +540,9 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "base/js
                         }
                         self.interaction_view = view;
                         self.interaction.node().appendChild(view.el.node());
-                        self.after_displayed(function() {
+                        self.displayed.then(function() {
                             view.trigger("displayed");
-                        }, self);
+                        });
                     });
                 });
             }

--- a/bqplot/nbextension/GridHeatMap.js
+++ b/bqplot/nbextension/GridHeatMap.js
@@ -25,10 +25,9 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             // because some of the functions depend on child scales being
             // created. Make sure none of the event handler functions make that
             // assumption.
-            var self = this;
-            this.after_displayed(function() {
-                self.parent.tooltip_div.node().appendChild(self.tooltip_div.node());
-                self.create_tooltip();
+            this.displayed.then(function() {
+                that.parent.tooltip_div.node().appendChild(that.tooltip_div.node());
+                that.create_tooltip();
             });
 
             this.selected_style = this.model.get("selected_style");

--- a/bqplot/nbextension/Hist.js
+++ b/bqplot/nbextension/Hist.js
@@ -22,18 +22,19 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             this.bars_selected = [];
 
             this.display_el_classes = ["rect", "legendtext"];
-            var self = this;
-            this.after_displayed(function() {
-                self.parent.tooltip_div.node().appendChild(self.tooltip_div.node());
-                self.create_tooltip();
+
+            var that = this;
+            this.displayed.then(function() {
+                that.parent.tooltip_div.node().appendChild(that.tooltip_div.node());
+                that.create_tooltip();
             });
 
             return base_creation_promise.then(function() {
-                self.event_listeners = {};
-                self.process_interactions();
-                self.create_listeners();
-                self.draw();
-                self.update_selected(self.model, self.model.get("selected"));
+                that.event_listeners = {};
+                that.process_interactions();
+                that.create_listeners();
+                that.draw();
+                that.update_selected(that.model, that.model.get("selected"));
             });
         },
         set_ranges: function() {

--- a/bqplot/nbextension/Lines.js
+++ b/bqplot/nbextension/Lines.js
@@ -25,7 +25,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             // because some of the functions depend on child scales being
             // created. Make sure none of the event handler functions make that
             // assumption.
-            this.after_displayed(function() {
+            this.displayed.then(function() {
                 that.parent.tooltip_div.node().appendChild(that.tooltip_div.node());
                 that.create_tooltip();
             });

--- a/bqplot/nbextension/Map.js
+++ b/bqplot/nbextension/Map.js
@@ -29,7 +29,7 @@ define(["./components/d3/d3", "./components/topojson/topojson", "./Figure", "bas
             this.enable_hover = this.model.get("enable_hover");
             this.display_el_classes = ["event_layer"];
             var that = this;
-            this.after_displayed(function() {
+            this.displayed.then(function() {
                 that.parent.tooltip_div.node().appendChild(that.tooltip_div.node());
                 that.create_tooltip();
             });

--- a/bqplot/nbextension/MarketMap.js
+++ b/bqplot/nbextension/MarketMap.js
@@ -83,7 +83,6 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./Figur
 
             this.update_plotarea_dimensions();
 
-
             var scale_creation_promise = this.create_scale_views();
             scale_creation_promise.then(function() {
                 var color_scale = self.scales.color;
@@ -99,15 +98,16 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./Figur
                     self.axis_views.update(value);
                 });
             });
-            this.after_displayed(function() {
+
+            this.displayed.then(function() {
                 // Adding the tooltip to the parent of the el so as to not
                 // pollute the DOM
-                this.el.parentNode.appendChild(this.tooltip_div.node());
-                this.update_layout();
-                this.draw_group_names();
-                this.create_tooltip_widget();
-            }, this);
-            $(this.options.cell).on("output_area_resize"+this.id, function() {
+                self.el.parentNode.appendChild(self.tooltip_div.node());
+                self.update_layout();
+                self.draw_group_names();
+                self.create_tooltip_widget();
+            });
+            $(this.options.cell).on("output_area_resize" + this.id, function() {
                 self.update_layout();
             });
         },

--- a/bqplot/nbextension/OHLC.js
+++ b/bqplot/nbextension/OHLC.js
@@ -21,7 +21,7 @@ define(["./components/d3/d3", "./Mark"], function(d3, MarkViewModule) {
             var base_creation_promise = OHLC.__super__.render.apply(this);
 
             var that = this;
-            this.after_displayed(function() {
+            this.displayed.then(function() {
                 that.parent.tooltip_div.node().appendChild(that.tooltip_div.node());
                 that.create_tooltip();
             });

--- a/bqplot/nbextension/Pie.js
+++ b/bqplot/nbextension/Pie.js
@@ -24,20 +24,20 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             this.unselected_style = this.model.get("unselected_style");
 
             this.display_el_classes = ["pie_slice", "pie_text"];
-            var self = this;
+            var that = this;
             this.el.append("g")
               .attr("class", "pielayout");
-            this.after_displayed(function() {
-                self.parent.tooltip_div.node().appendChild(self.tooltip_div.node());
-                self.create_tooltip();
+            this.displayed.then(function() {
+                that.parent.tooltip_div.node().appendChild(that.tooltip_div.node());
+                that.create_tooltip();
             });
 
             return base_creation_promise.then(function() {
-                self.event_listeners = {};
-                self.process_interactions();
-                self.create_listeners();
-                self.compute_view_padding();
-                self.draw();
+                that.event_listeners = {};
+                that.process_interactions();
+                that.create_listeners();
+                that.compute_view_padding();
+                that.draw();
             }, null);
         },
         set_ranges: function() {

--- a/bqplot/nbextension/Scatter.js
+++ b/bqplot/nbextension/Scatter.js
@@ -57,7 +57,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
                     "hit_test": false
                 }
             };
-            this.after_displayed(function() {
+            this.displayed.then(function() {
                 self.parent.tooltip_div.node().appendChild(self.tooltip_div.node());
                 self.create_tooltip();
             });


### PR DESCRIPTION
Ready-to-go.