### PR TITLE
Moved animate_dur attribute from marks to figure

### DIFF
--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -26,7 +26,8 @@ Figure
    Figure
 """
 
-from traitlets import Unicode, Instance, List, Dict, CFloat, Bool, Enum, Float
+from traitlets import (Unicode, Instance, List, Dict, CFloat, Bool, Enum,
+                       Float, Int)
 from ipywidgets import DOMWidget, register, Color, widget_serialization
 
 from .scales import Scale, LinearScale

--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -73,7 +73,7 @@ class Figure(DOMWidget):
         location of the legend relative to the center of the figure
     fig_color: Color (default: None)
         background color of the figure
-    animate_dur: nonnegative int (default: 0)
+    animation_duration: nonnegative int (default: 0)
         Duration of transition on change of data attributes, in milliseconds.
 
 
@@ -114,7 +114,7 @@ class Figure(DOMWidget):
                             'bottom-left', 'bottom', 'bottom-right', 'right'],
                            default_value='top-right', sync=True,
                            display_name='Legend position')
-    animate_dur = Int(0, sync=True, display_name='Animation duration')
+    animation_duration = Int(0, sync=True, display_name='Animation duration')
 
 
     def save(self):

--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -72,6 +72,9 @@ class Figure(DOMWidget):
         location of the legend relative to the center of the figure
     fig_color: Color (default: None)
         background color of the figure
+    animate_dur: nonnegative int (default: 0)
+        Duration of transition on change of data attributes, in milliseconds.
+
 
     Layout Attributes
 
@@ -110,6 +113,8 @@ class Figure(DOMWidget):
                             'bottom-left', 'bottom', 'bottom-right', 'right'],
                            default_value='top-right', sync=True,
                            display_name='Legend position')
+    animate_dur = Int(0, sync=True, display_name='Animation duration')
+
 
     def save(self):
         self.send({'type': 'save'})

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -103,8 +103,6 @@ class Mark(Widget):
         considered as False.
     display_legend: bool (default: False)
         Display toggle for the mark legend in the general figure legend
-    animate_dur: nonnegative int (default: 0)
-        Duration of transition on change of data attributes, in milliseconds.
     labels: list of unicode strings (default: [])
         Labels of the items of the mark. This attribute has different meanings
         depending on the type of mark.
@@ -146,7 +144,6 @@ class Mark(Widget):
     scales_metadata = Dict(sync=True)
     preserve_domain = Dict(sync=True)
     display_legend = Bool(False, sync=True, display_name='Display legend')
-    animate_dur = Int(0, sync=True, display_name='Animation duration')
     labels = List(trait=Unicode(), sync=True, display_name='Labels')
     apply_clip = Bool(True, sync=True)
     visible = Bool(True, sync=True)

--- a/bqplot/nbextension/Axis.js
+++ b/bqplot/nbextension/Axis.js
@@ -32,7 +32,6 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             var scale_promise = this.set_scale(this.model.get("scale"));
             this.side = this.model.get("side");
             this.padding = this.model.get("padding");
-            this.offset = 0;
             this.num_ticks = this.model.get("num_ticks");
             this.label_loc = this.model.get("label_location");
             this.label_offset = this.extract_label_offset(this.model.get("label_offset"));
@@ -74,6 +73,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
                     that.set_scales_range();
                     that.update_offset_scale_domain();
                     that.g_axisline.attr("transform", that.get_axis_transform());
+                    that.update_grid_lines();
                 });
             }, this);
             this.parent.on("margin_updated", this.parent_margin_updated, this);
@@ -89,7 +89,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             this.label_offset = this.extract_label_offset(this.model.get("label_offset"));
             this.rescale_axis();
         },
-        set_tick_values: function() {
+        set_tick_values: function(animate) {
             var tick_values = this.model.get_typed_field("tick_values");
             var useticks = [];
             if (tick_values !== undefined && tick_values !== null && tick_values.length > 0) {
@@ -141,8 +141,11 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
                     }
             }
             this.axis.tickFormat(this.tick_format);
+
             if(this.g_axisline) {
-                this.g_axisline.call(this.axis);
+                 this.g_axisline
+                    .transition().duration(animate ? this.parent.model.get("animate_dur") : 0)
+                    .call(this.axis);
             }
         },
         tickformat_changed: function() {
@@ -161,7 +164,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             this.axis.scale(this.axis_scale.scale);
         },
         update_offset_scale_domain: function() {
-            if(this.offset_scale) {
+            if (this.offset_scale) {
                 var initial_range = (!this.vertical) ?
                     this.parent.padded_range("y", this.offset_scale.model) :
                     this.parent.padded_range("x", this.offset_scale.model);
@@ -209,7 +212,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             }
         },
         create_axis_line: function() {
-            if(this.vertical) {
+            if (this.vertical) {
                 this.axis = d3.svg.axis().scale(this.axis_scale.scale)
                   .orient(this.side === "right" ? "right" : "left");
             } else {
@@ -223,15 +226,15 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             this.update_offset_scale_domain();
 
             this.g_axisline = this.el.append("g")
-              .attr("class", "axis")
-              .attr("transform", this.get_axis_transform())
-              .call(this.axis);
+                .attr("class", "axis")
+                .attr("transform", this.get_axis_transform())
+                .call(this.axis);
 
             this.g_axisline.append("text")
-              .attr("class", "axislabel")
-              .attr(this.get_label_attributes())
-              .style(this.get_text_styling())
-              .text(this.model.get("label"));
+                .attr("class", "axislabel")
+                .attr(this.get_label_attributes())
+                .style(this.get_text_styling())
+                .text(this.model.get("label"));
 
             this.set_tick_values();
             this.update_grid_lines();
@@ -246,7 +249,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             var that = this;
             var return_promise = Promise.resolve();
             var offset = this.model.get("offset");
-            if(offset.value !== undefined && offset.value !== null) {
+            if (offset.value !== undefined && offset.value !== null) {
                 //If scale is undefined but, the value is defined, then we have
                 //to
                 if(offset.scale === undefined) {
@@ -263,7 +266,9 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
                             that.offset_scale.on("domain_changed",
                                                  function() {
                                                     this.update_offset_scale_domain();
-                                                    this.g_axisline.attr("transform", this.get_axis_transform());
+                                                    this.g_axisline
+                                                        .transition().duration(this.parent.model.get("animate_dur"))
+                                                        .attr("transform", this.get_axis_transform());
                                                  }, that);
                         });
                 }
@@ -422,47 +427,49 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             this.el.remove();
             Axis.__super__.remove.apply(this);
         },
-        update_grid_lines: function() {
-            this.el.select("g." + "grid_lines").remove();
-            var grid_lines = this.el.append("g")
-                                   .attr("class", "grid_lines");
-            var that = this;
-
-            grid_lines.selectAll("line.grid-line").remove();
+        update_grid_lines: function(animate) {
             var grid_type = this.model.get("grid_lines");
-            var is_x = !(this.vertical) ;
+            var side = this.model.get("side");
+            var orientation = this.model.get("orientation");
+
+            var tickSize = orientation === "vertical" ? -this.width : -this.height;
+
+            //apply offsets if applicable
+            if (this.offset_scale) {
+                var offset = this.offset_scale.scale(this.offset_value);
+
+                if (side === "bottom" || side == "right") {
+                    tickSize = -offset;
+                } else {
+                    tickSize += offset;
+                }
+            }
+
+            if (grid_type !== "none") {
+                this.axis.innerTickSize(tickSize).outerTickSize(6);
+            }
+
+            this.g_axisline
+                .transition().duration(animate ? this.parent.model.get("animate_dur") : 0)
+                .call(this.axis)
+                .selectAll(".tick line")
+                .style("stroke-dasharray", grid_type === "dashed" ? ("5, 5") : null)
+                .style("opacity", grid_type === "none" ? 1.0 : 0.2);
 
             //will not work for ordinal scale
-            if(grid_type !== "none") {
-                grid_lines.selectAll("line.grid-line")
-                    .data(this.axis.tickValues())
-                    .enter().append("line")
-                    .attr("class", "grid-line")
-                    .attr("x1", is_x ? function(d) { return (that.axis_scale.scale(d) + that.axis_scale.offset);} : 0)
-                    .attr("x2", is_x ? function(d) { return (that.axis_scale.scale(d) + that.axis_scale.offset);} : this.width)
-                    .attr("y1", is_x ? 0 : function(d) { return (that.axis_scale.scale(d) + that.axis_scale.offset);})
-                    .attr("y2", is_x ? this.height : function(d) { return (that.axis_scale.scale(d) + that.axis_scale.offset);})
-                    .attr("stroke", "grey")
-                    .attr("stroke-opacity", 0.4)
-                    .attr("stroke-dasharray", grid_type === "solid" ?
-                          "none" : ("5, 5"));
-
-                if(this.model.get("grid_color") !== "" &&
-                   this.model.get("grid_color") !== null) {
-                    grid_lines.selectAll("line.grid-line")
-                      .attr("stroke", this.model.get("grid_color"));
-                }
+            if (grid_type !== "none" && this.model.get("grid_color")) {
+                this.g_axisline
+                    .selectAll(".tick line")
+                    .style("stroke", this.model.get("grid_color"));
             }
         },
         update_color: function() {
-            if(this.model.get("color") !== "" &&
-               this.model.get("color") !== null) {
-                this.el.selectAll(".tick").selectAll("line")
-                  .style("stroke", this.model.get("color"));
-                this.el.selectAll(".tick").selectAll("text")
-                  .style("fill", this.model.get("color"));
+            if (this.model.get("color")) {
+                this.el.selectAll(".tick")
+                    .selectAll("text")
+                    .style("fill", this.model.get("color"));
                 this.el.selectAll(".domain")
-                  .style("stroke", this.model.get("color"));
+                    .style("stroke", this.model.get("color"));
             }
         },
         redraw_axisline: function() {
@@ -472,8 +479,10 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             this.update_axis_domain();
             this.update_offset_scale_domain();
 
-            this.set_tick_values();
-            this.update_grid_lines();
+            //animate axis and grid lines on domain changes
+            var animate = true;
+            this.set_tick_values(animate);
+            this.update_grid_lines(animate);
         },
         rescale_axis: function() {
             //function to be called when the range of the axis has been updated

--- a/bqplot/nbextension/Axis.js
+++ b/bqplot/nbextension/Axis.js
@@ -266,9 +266,8 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
                             that.offset_scale.on("domain_changed",
                                                  function() {
                                                     this.update_offset_scale_domain();
-                                                    this.g_axisline
-                                                        .transition().duration(this.parent.model.get("animation_duration"))
-                                                        .attr("transform", this.get_axis_transform());
+                                                    this.g_axisline.attr("transform", this.get_axis_transform());
+                                                    this.update_grid_lines();
                                                  }, that);
                         });
                 }
@@ -465,7 +464,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
                 .style("stroke-dasharray", grid_type === "dashed" ? ("5, 5") : null)
                 .style("opacity", grid_type === "none" ? 1.0 : 0.2);
 
-            if (grid_type !== "none" && this.model.get("grid_color")) {
+            if (this.model.get("grid_color")) {
                 this.g_axisline
                     .selectAll(".tick line")
                     .style("stroke", this.model.get("grid_color"));

--- a/bqplot/nbextension/Axis.js
+++ b/bqplot/nbextension/Axis.js
@@ -431,8 +431,10 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             var grid_type = this.model.get("grid_lines");
             var side = this.model.get("side");
             var orientation = this.model.get("orientation");
+            var is_x = orientation !== "vertical";
 
             var tickSize = orientation === "vertical" ? -this.width : -this.height;
+            var tickOffset = 0;
 
             //apply offsets if applicable
             if (this.offset_scale) {
@@ -440,8 +442,10 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
 
                 if (side === "bottom" || side == "right") {
                     tickSize = -offset;
+                    tickOffset = is_x ? this.height - offset : this.width - offset;
                 } else {
                     tickSize += offset;
+                    tickOffset = -offset;
                 }
             }
 
@@ -453,6 +457,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
                 .transition().duration(animate ? this.parent.model.get("animation_duration") : 0)
                 .call(this.axis)
                 .selectAll(".tick line")
+                .attr(is_x ? "y1" : "x1", this.offset_scale ? tickOffset : null)
                 .style("stroke-dasharray", grid_type === "dashed" ? ("5, 5") : null)
                 .style("opacity", grid_type === "none" ? 1.0 : 0.2);
 

--- a/bqplot/nbextension/Axis.js
+++ b/bqplot/nbextension/Axis.js
@@ -144,7 +144,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
 
             if(this.g_axisline) {
                  this.g_axisline
-                    .transition().duration(animate ? this.parent.model.get("animation_duration") : 0)
+                    .transition().duration(animate === true ? this.parent.model.get("animation_duration") : 0)
                     .call(this.axis);
             }
         },

--- a/bqplot/nbextension/Axis.js
+++ b/bqplot/nbextension/Axis.js
@@ -144,7 +144,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
 
             if(this.g_axisline) {
                  this.g_axisline
-                    .transition().duration(animate ? this.parent.model.get("animate_dur") : 0)
+                    .transition().duration(animate ? this.parent.model.get("animation_duration") : 0)
                     .call(this.axis);
             }
         },
@@ -267,7 +267,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
                                                  function() {
                                                     this.update_offset_scale_domain();
                                                     this.g_axisline
-                                                        .transition().duration(this.parent.model.get("animate_dur"))
+                                                        .transition().duration(this.parent.model.get("animation_duration"))
                                                         .attr("transform", this.get_axis_transform());
                                                  }, that);
                         });
@@ -450,7 +450,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             }
 
             this.g_axisline
-                .transition().duration(animate ? this.parent.model.get("animate_dur") : 0)
+                .transition().duration(animate ? this.parent.model.get("animation_duration") : 0)
                 .call(this.axis)
                 .selectAll(".tick line")
                 .style("stroke-dasharray", grid_type === "dashed" ? ("5, 5") : null)

--- a/bqplot/nbextension/Axis.js
+++ b/bqplot/nbextension/Axis.js
@@ -432,6 +432,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
             var side = this.model.get("side");
             var orientation = this.model.get("orientation");
             var is_x = orientation !== "vertical";
+            var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
             var tickSize = orientation === "vertical" ? -this.width : -this.height;
             var tickOffset = 0;
@@ -451,13 +452,16 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
 
             if (grid_type !== "none") {
                 this.axis.innerTickSize(tickSize).outerTickSize(6);
+            } else {
+                this.axis.tickSize(6);
             }
 
             this.g_axisline
-                .transition().duration(animate ? this.parent.model.get("animation_duration") : 0)
+                .transition().duration(animation_duration)
                 .call(this.axis)
                 .selectAll(".tick line")
-                .attr(is_x ? "y1" : "x1", this.offset_scale ? tickOffset : null)
+                .attr(is_x ? "y1" : "x1",
+                      (this.offset_scale && grid_type !== "none")? tickOffset : null)
                 .style("stroke-dasharray", grid_type === "dashed" ? ("5, 5") : null)
                 .style("opacity", grid_type === "none" ? 1.0 : 0.2);
 

--- a/bqplot/nbextension/Axis.js
+++ b/bqplot/nbextension/Axis.js
@@ -456,7 +456,6 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./utils
                 .style("stroke-dasharray", grid_type === "dashed" ? ("5, 5") : null)
                 .style("opacity", grid_type === "none" ? 1.0 : 0.2);
 
-            //will not work for ordinal scale
             if (grid_type !== "none" && this.model.get("grid_color")) {
                 this.g_axisline
                     .selectAll(".tick line")

--- a/bqplot/nbextension/Bars.js
+++ b/bqplot/nbextension/Bars.js
@@ -234,7 +234,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             this.set_ranges();
             var colors = this.model.get("colors");
             var that = this;
-            var animate_dur = this.model.get("animate_dur");
+            var animate_dur = this.parent.model.get("animate_dur");
             var bar_groups = this.el.selectAll(".bargroup")
               .data(this.model.mark_data, function(d) {
                   return d.key;
@@ -318,7 +318,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                 });
             }
             if(this.model.get("type") === "stacked") {
-                bars_sel.transition().duration(this.model.get("animate_dur"))
+                bars_sel.transition().duration(this.parent.model.get("animate_dur"))
                     .attr("x", 0)
                     .attr("width", this.x.rangeBand().toFixed(2))
                     .attr("y", function(d) {
@@ -327,7 +327,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                         return Math.abs(y_scale.scale(d.y1 + d.y) - y_scale.scale(d.y1));
                     });
             } else {
-                bars_sel.transition().duration(this.model.get("animate_dur"))
+                bars_sel.transition().duration(this.parent.model.get("animate_dur"))
                   .attr("x", function(datum, index) {
                         return that.x1(index);
                   }).attr("width", this.x1.rangeBand().toFixed(2))

--- a/bqplot/nbextension/Bars.js
+++ b/bqplot/nbextension/Bars.js
@@ -306,7 +306,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
         draw_bars: function(animate) {
             var bar_groups = this.el.selectAll(".bargroup");
             var bars_sel = bar_groups.selectAll(".bar");
-            var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+            var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
             var that = this;
 
             var x_scale = this.scales.x, y_scale = this.scales.y;

--- a/bqplot/nbextension/Bars.js
+++ b/bqplot/nbextension/Bars.js
@@ -111,7 +111,11 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                   this.event_dispatcher("mouse_out");
               }, this));
 
-            this.listenTo(this.model, "data_updated", this.draw, this);
+            this.listenTo(this.model, "data_updated", function() {
+                //animate bars on data update
+                var animate = true;
+                this.draw(animate);
+            }, this);
             this.listenTo(this.model, "change:colors", this.update_colors, this);
             this.listenTo(this.model, "colors_updated", this.update_colors, this);
             this.listenTo(this.model, "change:type", this.update_type, this);
@@ -230,11 +234,10 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             this.selected_indices = value;
             this.apply_styles();
         },
-        draw: function() {
+        draw: function(animate) {
             this.set_ranges();
             var colors = this.model.get("colors");
             var that = this;
-            var animation_duration = this.parent.model.get("animation_duration");
             var bar_groups = this.el.selectAll(".bargroup")
               .data(this.model.mark_data, function(d) {
                   return d.key;
@@ -287,7 +290,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
               .attr("width", 0)
               .attr("height", 0);
 
-            this.draw_bars();
+            this.draw_bars(animate);
 
             this.apply_styles();
 
@@ -300,13 +303,14 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
               .attr("y1", y_scale.scale(this.model.base_value))
               .attr("y2", y_scale.scale(this.model.base_value));
         },
-        draw_bars: function() {
+        draw_bars: function(animate) {
             var bar_groups = this.el.selectAll(".bargroup");
             var bars_sel = bar_groups.selectAll(".bar");
+            var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
             var that = this;
 
             var x_scale = this.scales.x, y_scale = this.scales.y;
-            if(x_scale.model.type === "ordinal") {
+            if (x_scale.model.type === "ordinal") {
                 var x_max = d3.max(this.parent.range("x"));
                 bar_groups.attr("transform", function(d) {
                     return "translate(" + ((x_scale.scale(d.key) !== undefined ?
@@ -317,8 +321,8 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                     return "translate(" + (x_scale.scale(d.key) + that.x_offset) + ", 0)";
                 });
             }
-            if(this.model.get("type") === "stacked") {
-                bars_sel.transition().duration(this.parent.model.get("animation_duration"))
+            if (this.model.get("type") === "stacked") {
+                bars_sel.transition().duration(animation_duration)
                     .attr("x", 0)
                     .attr("width", this.x.rangeBand().toFixed(2))
                     .attr("y", function(d) {
@@ -327,7 +331,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                         return Math.abs(y_scale.scale(d.y1 + d.y) - y_scale.scale(d.y1));
                     });
             } else {
-                bars_sel.transition().duration(this.parent.model.get("animation_duration"))
+                bars_sel.transition().duration(animation_duration)
                   .attr("x", function(datum, index) {
                         return that.x1(index);
                   }).attr("width", this.x1.rangeBand().toFixed(2))

--- a/bqplot/nbextension/Bars.js
+++ b/bqplot/nbextension/Bars.js
@@ -234,7 +234,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             this.set_ranges();
             var colors = this.model.get("colors");
             var that = this;
-            var animate_dur = this.parent.model.get("animate_dur");
+            var animation_duration = this.parent.model.get("animation_duration");
             var bar_groups = this.el.selectAll(".bargroup")
               .data(this.model.mark_data, function(d) {
                   return d.key;
@@ -318,7 +318,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                 });
             }
             if(this.model.get("type") === "stacked") {
-                bars_sel.transition().duration(this.parent.model.get("animate_dur"))
+                bars_sel.transition().duration(this.parent.model.get("animation_duration"))
                     .attr("x", 0)
                     .attr("width", this.x.rangeBand().toFixed(2))
                     .attr("y", function(d) {
@@ -327,7 +327,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                         return Math.abs(y_scale.scale(d.y1 + d.y) - y_scale.scale(d.y1));
                     });
             } else {
-                bars_sel.transition().duration(this.parent.model.get("animate_dur"))
+                bars_sel.transition().duration(this.parent.model.get("animation_duration"))
                   .attr("x", function(datum, index) {
                         return that.x1(index);
                   }).attr("width", this.x1.rangeBand().toFixed(2))

--- a/bqplot/nbextension/FlexLine.js
+++ b/bqplot/nbextension/FlexLine.js
@@ -79,7 +79,7 @@ define(["./components/d3/d3", "./Lines"], function(d3, LinesViewModule) {
               .attr("class", "curve");
 
             curves_sel.exit()
-              .transition().duration(this.parent.model.get("animate_dur"))
+              .transition().duration(this.parent.model.get("animation_duration"))
               .remove();
 
             var x_scale = this.scales.x, y_scale = this.scales.y;
@@ -123,7 +123,7 @@ define(["./components/d3/d3", "./Lines"], function(d3, LinesViewModule) {
 
             var that = this;
             this.el.selectAll(".curve").selectAll(".line-elem")
-              .transition().duration(this.parent.model.get("animate_dur"))
+              .transition().duration(this.parent.model.get("animation_duration"))
               .attr({"x1": function(d) { return x_scale.scale(d.x1); },
                      "x2": function(d) { return x_scale.scale(d.x2); },
                      "y1": function(d) { return y_scale.scale(d.y1); },

--- a/bqplot/nbextension/FlexLine.js
+++ b/bqplot/nbextension/FlexLine.js
@@ -79,7 +79,7 @@ define(["./components/d3/d3", "./Lines"], function(d3, LinesViewModule) {
               .attr("class", "curve");
 
             curves_sel.exit()
-              .transition().duration(this.model.get("animate_dur"))
+              .transition().duration(this.parent.model.get("animate_dur"))
               .remove();
 
             var x_scale = this.scales.x, y_scale = this.scales.y;
@@ -123,7 +123,7 @@ define(["./components/d3/d3", "./Lines"], function(d3, LinesViewModule) {
 
             var that = this;
             this.el.selectAll(".curve").selectAll(".line-elem")
-              .transition().duration(this.model.get("animate_dur"))
+              .transition().duration(this.parent.model.get("animate_dur"))
               .attr({"x1": function(d) { return x_scale.scale(d.x1); },
                      "x2": function(d) { return x_scale.scale(d.x2); },
                      "y1": function(d) { return y_scale.scale(d.y1); },

--- a/bqplot/nbextension/Hist.js
+++ b/bqplot/nbextension/Hist.js
@@ -171,7 +171,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                 });
             var bar_width = this.calculate_bar_width();
             this.el.selectAll(".bargroup").select("rect")
-              .transition().duration(this.parent.model.get("animate_dur"))
+              .transition().duration(this.parent.model.get("animation_duration"))
               .attr("x", 2)
               .attr("width", bar_width)
               .attr("height", function(d) {
@@ -219,7 +219,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
               })
               .attr("id", function(d, i) { return "rect" + i; })
               .transition()
-              .duration(this.parent.model.get("animate_dur"))
+              .duration(this.parent.model.get("animation_duration"))
               .attr("width", bar_width)
               .attr("height", function(d) {
                   return y_scale.scale(0) - y_scale.scale(d.y);

--- a/bqplot/nbextension/Hist.js
+++ b/bqplot/nbextension/Hist.js
@@ -171,7 +171,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                 });
             var bar_width = this.calculate_bar_width();
             this.el.selectAll(".bargroup").select("rect")
-              .transition().duration(this.model.get("animate_dur"))
+              .transition().duration(this.parent.model.get("animate_dur"))
               .attr("x", 2)
               .attr("width", bar_width)
               .attr("height", function(d) {
@@ -219,7 +219,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
               })
               .attr("id", function(d, i) { return "rect" + i; })
               .transition()
-              .duration(this.model.get("animate_dur"))
+              .duration(this.parent.model.get("animate_dur"))
               .attr("width", bar_width)
               .attr("height", function(d) {
                   return y_scale.scale(0) - y_scale.scale(d.y);

--- a/bqplot/nbextension/Lines.js
+++ b/bqplot/nbextension/Lines.js
@@ -35,7 +35,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                 that.event_listeners = {};
                 that.process_interactions();
                 that.create_listeners();
-				that.compute_view_padding();
+                that.compute_view_padding();
                 that.draw();
             });
         },
@@ -198,7 +198,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             var x_scale = this.scales.x;
             var that = this;
             this.el.selectAll(".curve").selectAll("path")
-              .transition().duration(this.model.get("animate_dur"))
+              .transition().duration(this.parent.model.get("animate_dur"))
               .attr("d", function(d) {
                   return that.line(d.values) + that.path_closure();
               });
@@ -400,7 +400,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
 
             var that = this;
             this.el.selectAll(".curve").select("path")
-              .transition().duration(this.model.get("animate_dur"))
+              .transition().duration(this.parent.model.get("animate_dur"))
               .attr("d", function(d) {
                   return that.line(d.values) + that.path_closure();
               });
@@ -476,7 +476,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                 this.y_padding = y_padding;
                 this.trigger("mark_padding_updated");
             }
-		},
+        },
         update_selected_in_lasso: function(lasso_name, lasso_vertices,
                                            point_in_lasso_func)
         {

--- a/bqplot/nbextension/Lines.js
+++ b/bqplot/nbextension/Lines.js
@@ -201,6 +201,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             var x_scale = this.scales.x;
             var that = this;
             this.el.selectAll(".curve").selectAll("path")
+              .transition().duration(0) //FIXME: this is a temporary fix to make the lines displace according to the padding
               .attr("d", function(d) {
                   return that.line(d.values) + that.path_closure();
               });

--- a/bqplot/nbextension/Lines.js
+++ b/bqplot/nbextension/Lines.js
@@ -198,7 +198,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             var x_scale = this.scales.x;
             var that = this;
             this.el.selectAll(".curve").selectAll("path")
-              .transition().duration(this.parent.model.get("animate_dur"))
+              .transition().duration(this.parent.model.get("animation_duration"))
               .attr("d", function(d) {
                   return that.line(d.values) + that.path_closure();
               });
@@ -400,7 +400,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
 
             var that = this;
             this.el.selectAll(".curve").select("path")
-              .transition().duration(this.parent.model.get("animate_dur"))
+              .transition().duration(this.parent.model.get("animation_duration"))
               .attr("d", function(d) {
                   return that.line(d.values) + that.path_closure();
               });

--- a/bqplot/nbextension/Lines.js
+++ b/bqplot/nbextension/Lines.js
@@ -391,7 +391,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
         },
         update_line_xy: function(animate) {
             var x_scale = this.scales.x, y_scale = this.scales.y;
-            var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+            var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
             this.line = d3.svg.line()
               .interpolate(this.model.get("interpolation"))

--- a/bqplot/nbextension/Lines.js
+++ b/bqplot/nbextension/Lines.js
@@ -83,7 +83,10 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             this.listenTo(this.model, "change:colors", this.update_style, this);
             this.listenTo(this.model, "change:fill", this.update_style, this);
             this.listenTo(this.model, "change:opacities", this.update_style, this);
-            this.listenTo(this.model, "data_updated", this.draw, this);
+            this.listenTo(this.model, "data_updated", function() {
+                var animate = true;
+                this.draw(animate);
+            }, this);
             this.listenTo(this.model, "change:stroke_width", this.update_stroke_width, this);
             this.listenTo(this.model, "change:labels_visibility", this.update_legend_labels, this);
             this.listenTo(this.model, "change:line_style", this.update_line_style, this);
@@ -198,7 +201,6 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             var x_scale = this.scales.x;
             var that = this;
             this.el.selectAll(".curve").selectAll("path")
-              .transition().duration(this.parent.model.get("animation_duration"))
               .attr("d", function(d) {
                   return that.line(d.values) + that.path_closure();
               });
@@ -386,8 +388,10 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             }
             return this.get_colors(index);
         },
-        update_line_xy: function() {
+        update_line_xy: function(animate) {
             var x_scale = this.scales.x, y_scale = this.scales.y;
+            var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+
             this.line = d3.svg.line()
               .interpolate(this.model.get("interpolation"))
               .x(function(d) {
@@ -400,7 +404,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
 
             var that = this;
             this.el.selectAll(".curve").select("path")
-              .transition().duration(this.parent.model.get("animation_duration"))
+              .transition().duration(animation_duration)
               .attr("d", function(d) {
                   return that.line(d.values) + that.path_closure();
               });
@@ -409,7 +413,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                                                                         { return x_scale.scale(el.x) + x_scale.offset; })
                                                               : [];
         },
-        draw: function() {
+        draw: function(animate) {
             this.set_ranges();
             var curves_sel = this.el.selectAll(".curve")
               .data(this.model.mark_data, function(d, i) { return d.name; });
@@ -441,7 +445,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             // Having a transition on exit is complicated. Please refer to
             // Scatter.js for detailed explanation.
             curves_sel.exit().remove();
-            this.update_line_xy();
+            this.update_line_xy(animate);
 
             curves_sel.select(".curve_label")
               .attr("display", function(d) {

--- a/bqplot/nbextension/Pie.js
+++ b/bqplot/nbextension/Pie.js
@@ -165,17 +165,16 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             var transform = "translate(" + (x_scale.scale(x) + x_scale.offset) +
                                     ", " + (y_scale.scale(y) + y_scale.offset) + ")";
             this.el.select(".pielayout").transition()
-              .duration(this.model.get("animate_dur"))
+              .duration(this.parent.model.get("animate_dur"))
               .attr("transform", transform);
         },
         update_radii: function() {
-
             var arc = d3.svg.arc()
               .outerRadius(this.model.get("radius"))
               .innerRadius(this.model.get("inner_radius"));
 
             var elements = this.el.select(".pielayout").selectAll(".slice");
-            var animate_dur = this.model.get("animate_dur");
+            var animate_dur = this.parent.model.get("animate_dur");
 
             elements.select("path")
               .transition().duration(animate_dur)

--- a/bqplot/nbextension/Pie.js
+++ b/bqplot/nbextension/Pie.js
@@ -270,7 +270,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
         update_colors: function() {
             var that = this;
             var color_scale = this.scales.color;
-            this.el.select(".pielayout").selectAll("path")
+            this.el.select(".pielayout").selectAll(".pie_slice")
               .style("fill", function(d, i) {
                   return (d.data.color !== undefined && color_scale !== undefined) ?
                       color_scale.scale(d.data.color) : that.get_colors(d.data.index);

--- a/bqplot/nbextension/Pie.js
+++ b/bqplot/nbextension/Pie.js
@@ -169,7 +169,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             var transform = "translate(" + (x_scale.scale(x) + x_scale.offset) +
                                     ", " + (y_scale.scale(y) + y_scale.offset) + ")";
             this.el.select(".pielayout")
-                .transition().duration(this.parent.model.get("animate_dur"))
+                .transition().duration(this.parent.model.get("animation_duration"))
                 .attr("transform", transform);
         },
         update_radii: function() {
@@ -177,15 +177,15 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                 .innerRadius(this.model.get("inner_radius"));
 
             var slices = this.el.select(".pielayout").selectAll(".slice");
-            var animate_dur = this.parent.model.get("animate_dur");
+            var animation_duration = this.parent.model.get("animation_duration");
 
             slices.select("path")
-                .transition().duration(animate_dur)
+                .transition().duration(animation_duration)
                 .attr("d", this.arc);
 
             var that = this;
             slices.select("text")
-                .transition().duration(animate_dur)
+                .transition().duration(animation_duration)
                 .attr("transform", function(d) {
                     return "translate(" + that.arc.centroid(d) + ")";
                 });
@@ -220,9 +220,9 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                         .style("text-anchor", "middle");
                 });
 
-            var animate_dur = this.parent.model.get("animate_dur");
+            var animation_duration = this.parent.model.get("animation_duration");
             //animate slices on data changes using custom tween
-            var t = slices.transition().duration(animate_dur);
+            var t = slices.transition().duration(animation_duration);
             t.select("path").attrTween("d", updateTween);
             t.select("text").attr("transform", function(d) {
                 return "translate(" + that.arc.centroid(d) + ")";

--- a/bqplot/nbextension/Pie.js
+++ b/bqplot/nbextension/Pie.js
@@ -168,7 +168,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
             this.update_radii();
         },
         position_center: function(animate) {
-            var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+            var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
             var x_scale = this.scales.x ? this.scales.x : this.parent.scale_x;
             var y_scale = this.scales.y ? this.scales.y : this.parent.scale_y;
             var x = (x_scale.model.type === "date") ?
@@ -186,7 +186,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                 .innerRadius(this.model.get("inner_radius"));
 
             var slices = this.el.select(".pielayout").selectAll(".slice");
-            var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+            var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
             slices.select("path")
                 .transition().duration(animation_duration)
@@ -229,7 +229,7 @@ define(["./components/d3/d3", "./Mark", "./utils"], function(d3, MarkViewModule,
                         .style("text-anchor", "middle");
                 });
 
-            var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+            var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
             //animate slices on data changes using custom tween
             var t = slices.transition().duration(animation_duration);
             t.select("path").attrTween("d", updateTween);

--- a/bqplot/nbextension/PieModel.js
+++ b/bqplot/nbextension/PieModel.js
@@ -24,6 +24,7 @@ define(["./components/d3/d3", "./MarkModel"], function(d3, MarkModelModule) {
                 this.update_color();
                 this.trigger("colors_updated");
             }, this);
+            this.on("change:labels", this.update_labels, this);
 
             this.on_some_change(["preserve_domain"], this.update_domains, this);
         },

--- a/bqplot/nbextension/Scatter.js
+++ b/bqplot/nbextension/Scatter.js
@@ -276,7 +276,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
                 var default_colors = this.model.get("default_colors");
                 var len = default_colors.length;
                 var len_opac = default_opacities.length;
-                var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+                var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
                 // update opacity scale range?
                 var that = this;
@@ -309,7 +309,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
         },
         update_default_skew: function(animate) {
             if (!this.model.dirty) {
-                var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+                var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
                 var that = this;
                 this.el.selectAll(".dot")
                     .transition()
@@ -323,7 +323,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
             this.compute_view_padding();
             // update size scale range?
             if (!this.model.dirty) {
-                var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+                var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
                 var that = this;
                 this.el.selectAll(".dot")
                     .transition()
@@ -379,7 +379,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
             var that = this,
                 fill = this.model.get("fill"),
                 stroke = this.model.get("stroke");
-                var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+                var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
             this.el.selectAll(".dot_grp")
               .select("path")
@@ -400,7 +400,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
         update_xy_position: function(animate) {
             var x_scale = this.scales.x, y_scale = this.scales.y;
             var that = this;
-            var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+            var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
             this.el.selectAll(".dot_grp").transition()
                 .duration(animation_duration)
@@ -418,7 +418,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
             var that = this,
                 fill = this.model.get("fill");
 
-            var animation_duration = animate ? this.parent.model.get("animation_duration") : 0;
+            var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
             var elements = this.el.selectAll(".dot_grp")
                 .data(this.model.mark_data, function(d) { return d.unique_id; });

--- a/bqplot/nbextension/Scatter.js
+++ b/bqplot/nbextension/Scatter.js
@@ -290,7 +290,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
             if(!this.model.dirty) {
                 var that = this;
                 this.el.selectAll(".dot").transition()
-                  .duration(this.parent.model.get("animate_dur"))
+                  .duration(this.parent.model.get("animation_duration"))
                   .attr("d", this.dot.skew(function(data) {
                     return that.get_element_skew(data);
                   }));
@@ -302,7 +302,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
             if(!this.model.dirty) {
                 var that = this;
                 this.el.selectAll(".dot").transition()
-                  .duration(this.parent.model.get("animate_dur"))
+                  .duration(this.parent.model.get("animation_duration"))
                   .attr("d", this.dot.size(function(data) {
                     return that.get_element_size(data);
                   }));
@@ -373,7 +373,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
             var x_scale = this.scales.x, y_scale = this.scales.y;
             var that = this;
             this.el.selectAll(".dot_grp").transition()
-              .duration(this.parent.model.get("animate_dur"))
+              .duration(this.parent.model.get("animation_duration"))
               .attr("transform", function(d) {
                     return "translate(" + (x_scale.scale(d.x) + x_scale.offset) +
                                     "," + (y_scale.scale(d.y) + y_scale.offset) + ")" +
@@ -401,7 +401,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
             elements_added.append("path").attr("class", "dot");
             elements_added.append("text").attr("class", "dot_text");
             elements.select("path").transition()
-              .duration(this.parent.model.get("animate_dur"))
+              .duration(this.parent.model.get("animation_duration"))
               .attr("d", this.dot
                     .size(function(d) { return that.get_element_size(d); })
                     .skew(function(d) { return that.get_element_skew(d); }));

--- a/bqplot/nbextension/Scatter.js
+++ b/bqplot/nbextension/Scatter.js
@@ -290,7 +290,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
             if(!this.model.dirty) {
                 var that = this;
                 this.el.selectAll(".dot").transition()
-                  .duration(this.model.get("animate_dur"))
+                  .duration(this.parent.model.get("animate_dur"))
                   .attr("d", this.dot.skew(function(data) {
                     return that.get_element_skew(data);
                   }));
@@ -302,7 +302,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
             if(!this.model.dirty) {
                 var that = this;
                 this.el.selectAll(".dot").transition()
-                  .duration(this.model.get("animate_dur"))
+                  .duration(this.parent.model.get("animate_dur"))
                   .attr("d", this.dot.size(function(data) {
                     return that.get_element_size(data);
                   }));
@@ -373,7 +373,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
             var x_scale = this.scales.x, y_scale = this.scales.y;
             var that = this;
             this.el.selectAll(".dot_grp").transition()
-              .duration(this.model.get("animate_dur"))
+              .duration(this.parent.model.get("animate_dur"))
               .attr("transform", function(d) {
                     return "translate(" + (x_scale.scale(d.x) + x_scale.offset) +
                                     "," + (y_scale.scale(d.y) + y_scale.offset) + ")" +
@@ -401,7 +401,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers"], function(d3, Ma
             elements_added.append("path").attr("class", "dot");
             elements_added.append("text").attr("class", "dot_text");
             elements.select("path").transition()
-              .duration(this.model.get("animate_dur"))
+              .duration(this.parent.model.get("animate_dur"))
               .attr("d", this.dot
                     .size(function(d) { return that.get_element_size(d); })
                     .skew(function(d) { return that.get_element_skew(d); }));

--- a/examples/Animations.ipynb
+++ b/examples/Animations.ipynb
@@ -206,6 +206,59 @@
     "y1, y2 = np.random.rand(2, n)\n",
     "bar.y = [y1, y2]"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiple Mark Animations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from traitlets import link\n",
+    "\n",
+    "xs = bq.LinearScale()\n",
+    "ys1 = bq.LinearScale()\n",
+    "ys2 = bq.LinearScale()\n",
+    "\n",
+    "x = np.arange(20)\n",
+    "y = np.cumsum(np.random.randn(20))\n",
+    "y1 = np.random.rand(20)\n",
+    "\n",
+    "line = bq.Lines(x=x, y=y, scales={'x': xs, 'y': ys1}, colors=['magenta'])\n",
+    "dots = bq.Scatter(x=x, y=y, scales={'x': xs, 'y': ys1}, default_colors=['magenta'], marker='square')\n",
+    "bar = bq.Bars(x=x, y=y1, scales={'x': xs, 'y': ys2}, colorpadding=0.2, colors=['steelblue'])\n",
+    "\n",
+    "xax = bq.Axis(scale=xs, label='x', grid_lines='solid')\n",
+    "yax1 = bq.Axis(scale=ys1, orientation='vertical', tick_format='0.1f', label='y', grid_lines='solid')\n",
+    "yax2 = bq.Axis(scale=ys2, orientation='vertical', side='right', tick_format='0.0%', label='y1', grid_lines='none')\n",
+    "\n",
+    "fig = bq.Figure(marks=[bar, line, dots], axes=[xax, yax1, yax2], animation_duration=1000)\n",
+    "display(fig)\n",
+    "\n",
+    "# link dots with lines\n",
+    "l = link((line, 'y'), (dots, 'y'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#update mark data\n",
+    "line.y = np.cumsum(np.random.randn(20)) #updating lines also updates dots since they are linked\n",
+    "bar.y = np.random.rand(20)"
+   ]
   }
  ],
  "metadata": {

--- a/examples/Animations.ipynb
+++ b/examples/Animations.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Animations of marks and axes can be enabled by setting 'animation_duration' property of the figure"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Line Animations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import bqplot as bq\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "xs = bq.LinearScale()\n",
+    "ys = bq.LinearScale()\n",
+    "x = np.arange(100)\n",
+    "y = np.cumsum(np.random.randn(2, 100), axis=1) #two random walks\n",
+    "\n",
+    "line = bq.Lines(x=x, y=y, scales={'x': xs, 'y': ys}, colors=['red', 'green'])\n",
+    "xax = bq.Axis(scale=xs, label='x', grid_lines='solid')\n",
+    "yax = bq.Axis(scale=ys, orientation='vertical', tick_format='0.2f', label='y', grid_lines='solid')\n",
+    "\n",
+    "fig = bq.Figure(marks=[line], axes=[xax, yax], animation_duration=1000)\n",
+    "display(fig)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#update data of the line mark\n",
+    "line.y = np.cumsum(np.random.randn(2, 100), axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scatter Animations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "xs = bq.LinearScale()\n",
+    "ys = bq.LinearScale()\n",
+    "x, y = np.random.rand(2, 20)\n",
+    "scatt = bq.Scatter(x=x, y=y, scales={'x': xs, 'y': ys}, default_colors=['blue'])\n",
+    "xax = bq.Axis(scale=xs, label='x', grid_lines='solid')\n",
+    "yax = bq.Axis(scale=ys, orientation='vertical', tick_format='0.2f', label='y', grid_lines='solid')\n",
+    "\n",
+    "fig = bq.Figure(marks=[scatt], axes=[xax, yax], animation_duration=1000)\n",
+    "display(fig)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#data updates\n",
+    "scatt.x = np.random.rand(20) * 10\n",
+    "scatt.y = np.random.rand(20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Pie Animations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = np.random.rand(10)\n",
+    "pie = bq.Pie(sizes=data, radius=150, sort=False, labels=list('ABCDEFGHIJ'))\n",
+    "bq.Figure(marks=[pie], animation_duration=1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pie.sizes = np.random.rand(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pie.sort = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#make pie a donut\n",
+    "pie.radius = 150\n",
+    "pie.inner_radius = 50"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bar animations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "n = 10\n",
+    "x = list('ABCDEFGHIJ')\n",
+    "y1, y2 = np.random.rand(2, n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "xs = bq.OrdinalScale()\n",
+    "ys = bq.LinearScale()\n",
+    "\n",
+    "bar = bq.Bars(x=x, y=[y1, y2], scales={'x': xs, 'y': ys}, padding=0.2, type='grouped')\n",
+    "xax = bq.Axis(scale=xs)\n",
+    "yax = bq.Axis(scale=ys, orientation='vertical', tick_format='0.0%', grid_lines='solid')\n",
+    "\n",
+    "fig = bq.Figure(marks=[bar], axes=[xax, yax], animation_duration=1000)\n",
+    "display(fig)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "y1, y2 = np.random.rand(2, n)\n",
+    "bar.y = [y1, y2]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/Axis Properties.ipynb
+++ b/examples/Axis Properties.ipynb
@@ -122,6 +122,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#change the grid colors\n",
+    "ax_x.grid_color = 'red'"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/examples/Candles.ipynb
+++ b/examples/Candles.ipynb
@@ -93,9 +93,9 @@
     "\n",
     "# Construct the marks\n",
     "ohlc = OHLC(x=dates_all, y=prices, marker='candle', scales={'x': dt_scale, 'y': sc}, format='ohlc',\n",
-    "            stroke='blue', animate_dur=50, display_legend=True, labels=['IBM US Equity'])\n",
+    "            stroke='blue', display_legend=True, labels=['IBM US Equity'])\n",
     "ohlc2 = OHLC(x=dates_all2, y=prices2, marker='bar', scales={'x': dt_scale, 'y': sc}, colors=['dodgerblue', 'orange'],\n",
-    "            stroke='orange', animate_dur=50, display_legend=True, labels=['AAPL US Equity'], format='ohlc')"
+    "            stroke='orange', display_legend=True, labels=['AAPL US Equity'], format='ohlc')"
    ]
   },
   {

--- a/examples/Lines.ipynb
+++ b/examples/Lines.ipynb
@@ -82,12 +82,11 @@
     "              y=[[0, 0, 1], [0.5, 0.5, -0.5], [1, 1.1, 1.2, 2.3, 2.2, 2.7, 1.0]],\n",
     "              fill=['orange', 'blue', 'red'],\n",
     "              stroke_width=10,\n",
-    "              animate_dur=1000,\n",
     "              close_path=True,\n",
     "              scales={'x': sc_x, 'y': sc_y},\n",
     "              display_legend=True)\n",
     "\n",
-    "fig = Figure(marks=[patch])\n",
+    "fig = Figure(marks=[patch], animate_dur=1000)\n",
     "display(fig) "
    ]
   },

--- a/examples/Lines.ipynb
+++ b/examples/Lines.ipynb
@@ -86,7 +86,7 @@
     "              scales={'x': sc_x, 'y': sc_y},\n",
     "              display_legend=True)\n",
     "\n",
-    "fig = Figure(marks=[patch], animate_dur=1000)\n",
+    "fig = Figure(marks=[patch], animation_duration=1000)\n",
     "display(fig) "
    ]
   },

--- a/examples/Pie.ipynb
+++ b/examples/Pie.ipynb
@@ -28,8 +28,8 @@
    "outputs": [],
    "source": [
     "data = range(1, 6)\n",
-    "pie = Pie(sizes=data, select_slices=True, opacities=[0.2], animate_dur=1000)\n",
-    "Figure(marks=[pie])"
+    "pie = Pie(sizes=data, select_slices=True, opacities=[0.2])\n",
+    "Figure(marks=[pie], animate_dur=1000)"
    ]
   },
   {
@@ -107,8 +107,8 @@
    },
    "outputs": [],
    "source": [
-    "pie = Pie(sizes=np.abs(normal1), inner_radius=0.05, animate_dur=1000)\n",
-    "Figure(marks=[pie])"
+    "pie = Pie(sizes=np.abs(normal1), inner_radius=0.05)\n",
+    "Figure(marks=[pie], animate_dur=1000)"
    ]
   },
   {

--- a/examples/Pie.ipynb
+++ b/examples/Pie.ipynb
@@ -29,7 +29,7 @@
    "source": [
     "data = range(1, 6)\n",
     "pie = Pie(sizes=data, select_slices=True, opacities=[0.2])\n",
-    "Figure(marks=[pie], animate_dur=1000)"
+    "Figure(marks=[pie], animation_duration=1000)"
    ]
   },
   {
@@ -108,7 +108,7 @@
    "outputs": [],
    "source": [
     "pie = Pie(sizes=np.abs(normal1), inner_radius=0.05)\n",
-    "Figure(marks=[pie], animate_dur=1000)"
+    "Figure(marks=[pie], animation_duration=1000)"
    ]
   },
   {

--- a/examples/Scatter.ipynb
+++ b/examples/Scatter.ipynb
@@ -443,7 +443,7 @@
     "ax_y = Axis(label='Security 1', scale=sc_y, orientation='vertical', side='left')\n",
     "ax_x = Axis(label='Security 2', scale=sc_x)\n",
     "\n",
-    "Figure(axes=[ax_x, ax_y], marks=[scatter], animate_dur=1000)"
+    "Figure(axes=[ax_x, ax_y], marks=[scatter], animation_duration=1000)"
    ]
   },
   {
@@ -497,7 +497,7 @@
     "                  x=x, y=y, rotation=rot, color=color,\n",
     "                  stroke=\"black\", default_size=200, \n",
     "                  marker='arrow', default_skew=0.5,)\n",
-    "Figure(marks=[scatter], animate_dur=1000)"
+    "Figure(marks=[scatter], animation_duration=1000)"
    ]
   },
   {

--- a/examples/Scatter.ipynb
+++ b/examples/Scatter.ipynb
@@ -443,7 +443,7 @@
     "ax_y = Axis(label='Security 1', scale=sc_y, orientation='vertical', side='left')\n",
     "ax_x = Axis(label='Security 2', scale=sc_x)\n",
     "\n",
-    "Figure(axes=[ax_x, ax_y], marks=[scatter])"
+    "Figure(axes=[ax_x, ax_y], marks=[scatter], animate_dur=1000)"
    ]
   },
   {
@@ -454,7 +454,6 @@
    },
    "outputs": [],
    "source": [
-    "scatter.animate_dur = 1000\n",
     "scatter.skew=None"
    ]
   },
@@ -496,9 +495,9 @@
     "color=x-y\n",
     "scatter = Scatter(scales={'x': sc_x, 'y': sc_y, 'color': sc_c, 'rotation': sc_e}, \n",
     "                  x=x, y=y, rotation=rot, color=color,\n",
-    "                  stroke=\"black\", animate_dur=1000, default_size=200, \n",
+    "                  stroke=\"black\", default_size=200, \n",
     "                  marker='arrow', default_skew=0.5,)\n",
-    "Figure(marks=[scatter])"
+    "Figure(marks=[scatter], animate_dur=1000)"
    ]
   },
   {


### PR DESCRIPTION
1. Moved animate_dur attribute from marks to figure. Since figure contains axis and multiple marks it makes sense for all of them to transition together.
2. Updated the example notebooks to reflect the above change
3. Fixed couple of bugs in Pie mark
4. Added a custom tween for Pie transitions

Note: Axis gridlines and ticks should also transition when individual marks transition. I am working on it and will create a separate PR for that.