### PR TITLE
explicitly say the install file is utf-8

### DIFF
--- a/bqplot/install.py
+++ b/bqplot/install.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import argparse
 from os.path import dirname, abspath, join


### PR DESCRIPTION
Attempts to address #36, though it's weird that it seems that we can happily encode the file to ascii.