### PR TITLE
Use country name as chart title in example.

### DIFF
--- a/examples/Market Map.ipynb
+++ b/examples/Market Map.ipynb
@@ -224,8 +224,8 @@
     "        hovered_symbol = symbol\n",
     "        if(gdp_data.get(hovered_symbol) is not None):\n",
     "            line.y = gdp_data[hovered_symbol].values\n",
-    "            fig_tooltip.title = hovered_symbol\n",
-    "               \n",
+    "            fig_tooltip.title = content.get('ref_data', {}).get('Name', '')\n",
+    "\n",
     "# Custom msg sent when a particular cell is hovered on\n",
     "market_map.on_hover(hover_handler)\n",
     "display(market_map)"

--- a/examples/Pie.ipynb
+++ b/examples/Pie.ipynb
@@ -107,7 +107,7 @@
    },
    "outputs": [],
    "source": [
-    "pie = Pie(sizes=np.abs(normal1), radius=300, inner_radius=0.05, animate_dur=1000)\n",
+    "pie = Pie(sizes=np.abs(normal1), inner_radius=0.05, animate_dur=1000)\n",
     "Figure(marks=[pie])"
    ]
   },
@@ -134,7 +134,7 @@
     "pie.start_angle = -90\n",
     "pie.end_angle = 90\n",
     "pie.y = 0.1\n",
-    "pie.radius = 400"
+    "pie.radius = 320"
    ]
   },
   {
@@ -167,8 +167,7 @@
    "source": [
     "sc = ColorScale(scheme='Reds')\n",
     "ax = ColorAxis(scale=sc)\n",
-    "pie = Pie(sizes=np.abs(normal1), radius=300, \n",
-    "          scales={'color': sc}, color=normal2)\n",
+    "pie = Pie(sizes=np.abs(normal1),scales={'color': sc}, color=normal2)\n",
     "Figure(marks=[pie], axes=[ax])"
    ]
   },
@@ -240,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Use the country full name as title in the chart for the MarketMap example
- better default radius in Pie example.