### PR TITLE
Area Chart

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -249,12 +249,12 @@ class Lines(Mark):
     fill: {'none', 'bottom', 'top', 'inside'}
         Fill in the area defined by the curves
     fill_colors: list of colors (default: [])
-        Fill colors for the patches. Defaults to stroke-colors when no color provided.
+        Fill colors for the areas. Defaults to stroke-colors when no color provided.
     opacities: list of floats (default: [])
         Opacity for the  lines and patches. Defaults to 1 when the list is too
         short, or the element of the list is set to None.
     fill_opacities: list of floats (default: [])
-        Opacity for the  lines and patches. Defaults to 1 when the list is too
+        Opacity for the areas. Defaults to 1 when the list is too
         short, or the element of the list is set to None.
     stroke_width: float (default: 1.5)
         Stroke width of the Lines
@@ -263,7 +263,7 @@ class Lines(Mark):
     curves_subset: list of integers or None (default: [])
         If set to None, all the lines are displayed. Otherwise, only the items
         in the list will have full opacity, while others will be faded.
-    line_style: {'solid', 'dashed', 'dotted'}
+    line_style: {'solid', 'dashed', 'dotted', 'dash_dotted'}
         Line style.
     interpolation: {'linear', 'basis', 'cardinal', 'monotone'}
         Interpolation scheme used for interpolation between the data points

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -246,12 +246,17 @@ class Lines(Mark):
         of lines, the colors are reused.
     close_path: bool (default: False)
         Whether to close the paths or not.
-    fill: list of colors (default: [])
-        Fill colors for the patches. Defaults to no-fill when no color provided.
+    fill: {'none', 'bottom', 'top', 'inside'}
+        Fill in the area defined by the curves
+    fill_colors: list of colors (default: [])
+        Fill colors for the patches. Defaults to stroke-colors when no color provided.
     opacities: list of floats (default: [])
         Opacity for the  lines and patches. Defaults to 1 when the list is too
         short, or the element of the list is set to None.
-    stroke_width: float (default: 2)
+    fill_opacities: list of floats (default: [])
+        Opacity for the  lines and patches. Defaults to 1 when the list is too
+        short, or the element of the list is set to None.
+    stroke_width: float (default: 1.5)
         Stroke width of the Lines
     labels_visibility: {'none', 'label'}
         Visibility of the curve labels
@@ -312,8 +317,11 @@ class Lines(Mark):
     scales_metadata = Dict({'x': {'orientation': 'horizontal', 'dimension': 'x'},
                             'y': {'orientation': 'vertical', 'dimension': 'y'},
                             'color': {'dimension': 'color'}}, sync=True)
-    colors = List(trait=Color(default_value=None, allow_none=True), default_value=CATEGORY10,
-                  sync=True, display_name='Colors')
+    colors = List(trait=Color(default_value=None, allow_none=True),
+                  default_value=CATEGORY10, sync=True, display_name='Colors')
+    fill_colors = List(trait=Color(default_value=None, allow_none=True),
+                       default_value=CATEGORY10, sync=True,
+                       display_name='Fill colors')
     stroke_width = Float(2.0, sync=True, display_name='Stroke width')
     labels_visibility = Enum(['none', 'label'], default_value='none',
                              sync=True, display_name='Labels visibility')
@@ -325,8 +333,8 @@ class Lines(Mark):
                          default_value='linear', sync=True,
                          display_name='Interpolation')
     close_path = Bool(sync=True, display_name='Close path')
-    fill = List(trait=Color(default_value=None, allow_none=True), sync=True,
-                display_name='Fill Colors')
+    fill = Enum(['none', 'bottom', 'top', 'inside'], default_value='none',
+                sync=True, display_name='Fill')
     marker = Enum(['circle', 'cross', 'diamond', 'square', 'triangle-down',
                    'triangle-up', 'arrow', 'rectangle', 'ellipse'],
                   default_value=None, allow_none=True, sync=True,
@@ -334,6 +342,7 @@ class Lines(Mark):
     marker_size = Int(64, sync=True, display_name='Default size')
 
     opacities = List(sync=True, display_name='Opacity')
+    fill_opacities = List(sync=True, display_name='Fill Opacity')
     _view_name = Unicode('Lines', sync=True)
     _view_module = Unicode('nbextensions/bqplot/Lines', sync=True)
     _model_name = Unicode('LinesModel', sync=True)
@@ -598,8 +607,7 @@ class Hist(Mark):
 
     # Other attributes
     scales_metadata = Dict({'sample': {'orientation': 'horizontal', 'dimension': 'x'},
-                            'count': {'orientation': 'vertical', 'dimension': 'y'}},
-                            sync=True)
+                            'count': {'orientation': 'vertical', 'dimension': 'y'}}, sync=True)
     bins = Int(10, sync=True, display_name='Number of bins')
     midpoints = List(sync=True, read_only=True, display_name='Mid points')
     # midpoints is a read-only attribute that is set when the mark is drawn

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -256,7 +256,7 @@ class Lines(Mark):
     fill_opacities: list of floats (default: [])
         Opacity for the areas. Defaults to 1 when the list is too
         short, or the element of the list is set to None.
-    stroke_width: float (default: 1.5)
+    stroke_width: float (default: 2)
         Stroke width of the Lines
     labels_visibility: {'none', 'label'}
         Visibility of the curve labels

--- a/bqplot/nbextension/Lines.js
+++ b/bqplot/nbextension/Lines.js
@@ -88,11 +88,10 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
             // FIXME: multiple calls to update_style. Use on_some_change.
             this.listenTo(this.model, "change:colors", this.update_style, this);
             this.listenTo(this.model, "change:opacities", this.update_style, this);
+            this.listenTo(this.model, "change:fill_opacities", this.update_style, this);
+            this.listenTo(this.model, "change:fill_colors", this.update_style, this);
 
-            // FIXME: multiple calls to update_fill. Use on_some_change.
             this.listenTo(this.model, "change:fill", this.update_fill, this);
-            this.listenTo(this.model, "change:fill_opacities", this.update_fill, this);
-            this.listenTo(this.model, "change:fill_colors", this.update_fill, this);
 
             this.listenTo(this.model, "data_updated", function() {
                 var animate = true;
@@ -414,8 +413,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
         },
         update_fill: function() {
             var fill = this.model.get("fill"),
-                area = (fill === "top" || fill === "bottom"),
-                fill_opacities = this.model.get("fill_opacities");
+                area = (fill === "top" || fill === "bottom");
 
             this.area.y0(fill === "bottom" ? this.parent.plotarea_height : 0)
               .defined(function(d) { return area && d.y !== null; });
@@ -501,11 +499,6 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
               .on("click", _.bind(function() {
                   this.event_dispatcher("element_clicked");
               }, this));
-            // Fill in the areas above/below the lines
-            curves_sel.select(".area")
-              .attr("display", function(d) {
-                  return (fill === "none" || fill === "inside" ? "none" : "inline");
-              })
 
             this.draw_dots();
 

--- a/bqplot/nbextension/Lines.js
+++ b/bqplot/nbextension/Lines.js
@@ -174,7 +174,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
                         .style("opacity", opacities[i]);
                     curve.select(".line")
                         .style("fill", function(d, i) {
-                            return that.model.get("fill") === "inside" ? fill_color[i] : "";
+                            return that.model.get("fill") === "inside" ? that.get_fill_color(d, i) : "";
                         })
                     curve.select(".area")
                         .style("fill", function(d, i) { return that.get_fill_color(d, i); })
@@ -189,7 +189,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
                         return that.get_element_color(d, i) || fill_color[i];
                     })
                     .style("opacity", function(d, i) { return opacities[i]; })
-                    .style("fill", function(d, i) { return fill_color[i]; });
+                    .style("fill", function(d, i) { return that.get_fill_color(d, i); });
                 this.legend_el.select(".dot")
                     .style("stroke", function(d, i) {
                         return that.get_element_color(d, i) || fill_color[i];

--- a/bqplot/nbextension/Lines.js
+++ b/bqplot/nbextension/Lines.js
@@ -169,17 +169,16 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
             this.el.selectAll(".curve")
                 .each(function(d, i) {
                     var curve = d3.select(this);
-                    curve.selectAll("path")
-                        .style("stroke", that.get_element_color(d, i) || fill_color[i])
-                        .style("opacity", opacities[i]);
                     curve.select(".line")
-                        .style("fill", function(d, i) {
-                            return that.model.get("fill") === "inside" ? that.get_fill_color(d, i) : "";
-                        })
+                        .style("opacity", opacities[i])
+                        .style("stroke", that.get_element_color(d, i) || fill_color[i])
+                        .style("fill", that.model.get("fill") === "inside" ?
+                                       that.get_fill_color(d, i) : "");
                     curve.select(".area")
-                        .style("fill", function(d, i) { return that.get_fill_color(d, i); })
-                        .style("opacity", function(d, i) { return fill_opacities[i];});
+                        .style("fill", that.get_fill_color(d, i))
+                        .style("opacity", fill_opacities[i]);
                     curve.selectAll(".dot")
+                        .style("opacity", opacities[i])
                         .style("fill", that.get_element_color(d, i) || fill_color[i]);
                 });
             // update legend style

--- a/bqplot/nbextension/Lines.js
+++ b/bqplot/nbextension/Lines.js
@@ -87,8 +87,13 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
 
             // FIXME: multiple calls to update_style. Use on_some_change.
             this.listenTo(this.model, "change:colors", this.update_style, this);
-            this.listenTo(this.model, "change:fill", this.update_style, this);
             this.listenTo(this.model, "change:opacities", this.update_style, this);
+
+            // FIXME: multiple calls to update_fill. Use on_some_change.
+            this.listenTo(this.model, "change:fill", this.update_fill, this);
+            this.listenTo(this.model, "change:fill_opacities", this.update_fill, this);
+            this.listenTo(this.model, "change:fill_colors", this.update_fill, this);
+
             this.listenTo(this.model, "data_updated", function() {
                 var animate = true;
                 this.draw(animate);
@@ -139,7 +144,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
         // Could be fused in a single function for increased readability
         // and to avoid code repetition
         update_line_style: function() {
-            this.el.selectAll(".curve").selectAll("path")
+            this.el.selectAll(".curve").select(".line")
               .style("stroke-dasharray", _.bind(this.get_line_style, this));
             if (this.legend_el) {
                 this.legend_el.select("path")
@@ -148,7 +153,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
         },
         update_stroke_width: function(model, stroke_width) {
             this.compute_view_padding();
-            this.el.selectAll(".curve").selectAll("path")
+            this.el.selectAll(".curve").select(".line")
               .style("stroke-width", stroke_width);
             if (this.legend_el) {
                 this.legend_el.select("path")
@@ -157,8 +162,9 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
         },
         update_style: function() {
             var that = this,
-                fill_color = this.model.get("fill"),
-                opacities = this.model.get("opacities");
+                fill_color = this.model.get("fill_colors"),
+                opacities = this.model.get("opacities"),
+                fill_opacities = this.model.get("fill_opacities");
             // update curve colors
             this.el.selectAll(".curve")
                 .each(function(d, i) {
@@ -167,7 +173,12 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
                         .style("stroke", that.get_element_color(d, i) || fill_color[i])
                         .style("opacity", opacities[i]);
                     curve.select(".line")
-                        .style("fill", fill_color[i]);
+                        .style("fill", function(d, i) {
+                            return that.model.get("fill") === "inside" ? fill_color[i] : "";
+                        })
+                    curve.select(".area")
+                        .style("fill", function(d, i) { return that.get_fill_color(d, i); })
+                        .style("opacity", function(d, i) { return fill_opacities[i];});
                     curve.selectAll(".dot")
                         .style("fill", that.get_element_color(d, i) || fill_color[i]);
                 });
@@ -204,11 +215,15 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
         update_path_style: function() {
             var interpolation = this.model.get("interpolation");
             this.line.interpolate(interpolation);
+            this.area.interpolate(interpolation);
             var that = this;
             this.el.selectAll(".curve").selectAll("path")
               .attr("d", function(d) {
                   return that.line(d.values) + that.path_closure();
               });
+            this.el.selectAll(".curve").select(".area")
+              .transition().duration(0) //FIXME
+              .attr("d", function(d) { return that.area(d.values); });
             if (this.legend_el) {
                 this.legend_line.interpolate(interpolation);
                 this.legend_el.selectAll("path")
@@ -226,7 +241,6 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
                 this.touch();
                 return [];
             }
-
             var x_scale = this.scales.x;
 
             var indices = _.range(this.x_pixels.length);
@@ -272,13 +286,11 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
                         opacity: d.opacity};
             });
             this.legend_el = elem.selectAll(".legend" + this.uuid)
-              .data(legend_data, function(d, i) {
-                  return d.name;
-              });
+              .data(legend_data, function(d, i) { return d.name; });
 
             var that = this,
                 rect_dim = inter_y_disp * 0.8,
-                fill_color = this.model.get("fill"),
+                fill_colors = this.model.get("fill_colors"),
                 opacities = this.model.get("opacities");
 
             this.legend_line = d3.svg.line()
@@ -311,10 +323,11 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
                 .attr("fill", "none")
                 .attr("d", this.legend_line(this.legend_path_data) + this.path_closure())
                 .style("stroke", function(d, i) {
-                    return that.get_element_color(d, i) || fill_color[i];
+                    return that.get_element_color(d, i) || fill_colors[i];
                 })
                 .style("fill", function(d, i) {
-                    return fill_color[i];
+                    return that.model.get("fill") === "none" ?
+                        "" : that.get_fill_color(d, i);
                 })
                 .style("opacity", function(d, i) { return opacities[i]; })
                 .style("stroke-width", this.model.get("stroke_width"))
@@ -335,7 +348,7 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
               .attr("dy", "0.35em")
               .text(function(d, i) { return curve_labels[i]; })
               .style("fill", function(d, i) {
-                  return that.get_element_color(d, i) || fill_color[i];
+                  return that.get_element_color(d, i) || fill_colors[i];
               })
               .style("opacity", function(d, i) { return opacities[i]; });
 
@@ -400,6 +413,31 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
                   });
             }
         },
+        update_fill: function() {
+            var fill = this.model.get("fill"),
+                area = (fill === "top" || fill === "bottom"),
+                fill_opacities = this.model.get("fill_opacities");
+
+            this.area.y0(fill === "bottom" ? this.parent.plotarea_height : 0)
+              .defined(function(d) { return area && d.y !== null; });
+
+            var that = this;
+            this.el.selectAll(".curve").select(".area")
+              .attr("d", function(d) {
+                  return that.area(d.values);
+              })
+            this.el.selectAll(".curve").select(".line")
+              .style("fill", function(d, i) {
+                  return fill === "inside" ? that.get_fill_color(d, i) : "";
+              })
+            // update legend fill
+            if (this.legend_el) {
+               this.legend_el.select("path")
+                 .style("fill", function(d, i) {
+                     return fill === "none" ? "" : that.get_fill_color(d, i);
+                 })
+            }
+        },
         get_element_color: function(data, index) {
             var color_scale = this.scales.color;
             if(color_scale && data.color !== undefined && data.color !== null) {
@@ -407,19 +445,25 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
             }
             return this.get_colors(index);
         },
+        get_fill_color: function(data, index) {
+            var fill_colors = this.model.get("fill_colors");
+            var that = this;
+            return fill_colors.length === 0 ?
+                that.get_element_color(data, index) : fill_colors[index];
+        },
         update_line_xy: function(animate) {
             var x_scale = this.scales.x, y_scale = this.scales.y;
             var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
-            this.line = d3.svg.line()
-              .interpolate(this.model.get("interpolation"))
-              .x(function(d) {
-                  return x_scale.scale(d.x) + x_scale.offset;
-              })
-              .y(function(d) {
-                  return y_scale.scale(d.y) + y_scale.offset;
-              })
-              .defined(function(d) { return d.y !== null; });
+            this.line
+              .x(function(d) { return x_scale.scale(d.x) + x_scale.offset; })
+              .y(function(d) { return y_scale.scale(d.y) + y_scale.offset; })
+
+            var fill = this.model.get("fill");
+            this.area
+              .x(function(d) { return x_scale.scale(d.x) + x_scale.offset; })
+              .y0(fill === "bottom" ? this.parent.plotarea_height : 0)
+              .y1(function(d) { return y_scale.scale(d.y) + y_scale.offset; })
 
             var that = this;
             this.el.selectAll(".curve").select(".line")
@@ -427,6 +471,10 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
               .attr("d", function(d) {
                   return that.line(d.values) + that.path_closure();
               });
+
+            this.el.selectAll(".curve").select(".area")
+              .transition().duration(animation_duration)
+              .attr("d", function(d) { return that.area(d.values); });
 
             this.update_dots_xy(animate);
             this.x_pixels = (this.model.mark_data.length > 0) ? this.model.mark_data[0].values.map(function(el)
@@ -443,17 +491,32 @@ define(["./components/d3/d3", "./Mark", "./utils", "./Markers", "underscore"],
             new_curves.append("path")
               .attr("class", "line")
               .attr("fill", "none");
+            new_curves.append("path")
+              .attr("class", "area");
 
-            var fill_color = this.model.get("fill");
-            var opacities = this.model.get("opacities");
+            var fill = this.model.get("fill"),
+                area = (fill === "top" || fill === "bottom");
             var that = this;
             curves_sel.select(".line")
               .attr("id", function(d, i) { return "curve" + (i+1); })
               .on("click", _.bind(function() {
                   this.event_dispatcher("element_clicked");
               }, this));
+            // Fill in the areas above/below the lines
+            curves_sel.select(".area")
+              .attr("display", function(d) {
+                  return (fill === "none" || fill === "inside" ? "none" : "inline");
+              })
 
             this.draw_dots();
+
+            this.line = d3.svg.line()
+              .interpolate(this.model.get("interpolation"))
+              .defined(function(d) { return d.y !== null; });
+
+            this.area = d3.svg.area()
+              .interpolate(this.model.get("interpolation"))
+              .defined(function(d) { return area && d.y !== null; });
 
             // Having a transition on exit is complicated. Please refer to
             // Scatter.js for detailed explanation.

--- a/examples/Lines.ipynb
+++ b/examples/Lines.ipynb
@@ -108,7 +108,8 @@
     "\n",
     "patch = Lines(x=[[0, 2, 1.2], [0.5, 2.5, 1.7], [4,5,6, 6, 5, 4, 3]], \n",
     "              y=[[0, 0, 1], [0.5, 0.5, -0.5], [1, 1.1, 1.2, 2.3, 2.2, 2.7, 1.0]],\n",
-    "              fill=['orange', 'blue', 'red'],\n",
+    "              fill_colors=['orange', 'blue', 'red'],\n",
+    "              fill='inside',\n",
     "              stroke_width=10,\n",
     "              close_path=True,\n",
     "              scales={'x': sc_x, 'y': sc_y},\n",
@@ -336,6 +337,19 @@
     "# increasing the width\n",
     "line.line_style = 'solid'\n",
     "line.stroke_width = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Filling the area\n",
+    "line.fill = 'bottom'\n",
+    "line.fill_opacities = [0.4]"
    ]
   },
   {


### PR DESCRIPTION
Added area chart functionalities to the `Lines` mark

* `fill` controls what area to fill
   * `none` is the default no-fill
   * `top`, `bottom` fills to the plot area upper and lower limits
   * `inside` is the previous behavior for filling, it closes the path and fills it in

* `fill_colors` and `fill_opacities` control the styling of the filling, they work as `opacities` and `colors` currently do
* If no `fill_colors` is provided, the fill color defaults to the corresponding line's color. 