### PR TITLE
First pass at Selection on GridHeatMap

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -1088,8 +1088,12 @@ class GridHeatMap(Mark):
         number of columns in `color` and the `column_scale` is not `OrdinalScale`.
         `start` aligns the column values passed to be aligned with the start of the
         tiles and `end` aligns the column values to the end of the tiles.
+    anchor_style: dict (default: {'fill': 'white', 'stroke': 'blue'})
+        Controls the style for the element which serves as the anchor duringi
+        selection.
 
     Data Attributes
+    ---------------
 
     color: numpy.ndarray
         color of the data points (2d array). The number of elements in this array
@@ -1129,6 +1133,7 @@ class GridHeatMap(Mark):
 
     stroke = Color('black', allow_none=True, sync=True)
     opacity = Float(default_value=1.0, min=0.2, max=1, sync=True, display_name='Opacity')
+    anchor_style = Dict({'fill': 'white', 'stroke': 'blue'}, sync=True)
 
     def __init__(self, **kwargs):
         data = kwargs['color']

--- a/bqplot/nbextension/Pie.js
+++ b/bqplot/nbextension/Pie.js
@@ -312,64 +312,63 @@ define(["./components/d3/d3", "./Mark", "./utils", "underscore"],
             var data = args.data;
             var index = args.index;
             var that = this;
-            // if(this.model.get("select_slices")) {
-                var idx = this.model.get("selected");
-                var selected = idx ? utils.deepCopy(idx) : [];
+            var idx = this.model.get("selected");
+            var selected = idx ? utils.deepCopy(idx) : [];
                 // index of slice i. Checking if it is already present in the list.
-                var elem_index = selected.indexOf(index);
-                // Replacement for "Accel" modifier.
-                var accelKey = d3.event.ctrlKey || d3.event.metaKey
-                if(elem_index > -1 && accelKey) {
-                    // if the index is already selected and if accel key is
-                    // pressed, remove the element from the list
-                    selected.splice(elem_index, 1);
-                } else {
-                    if(d3.event.shiftKey) {
-                        //If shift is pressed and the element is already
-                        //selected, do not do anything
-                        if(elem_index > -1) {
-                            return;
-                        }
-                        //Add elements before or after the index of the current
-                        //slice which has been clicked
-                        var min_index = (selected.length !== 0) ?
-                            d3.min(selected) : -1;
-                        var max_index = (selected.length !== 0) ?
-                            d3.max(selected) : that.model.mark_data.length;
-                        if(index > max_index){
-                            _.range(max_index+1, index).forEach(function(i) {
-                                selected.push(i);
-                            });
-                        } else if(index < min_index){
-                            _.range(index+1, min_index).forEach(function(i) {
-                                selected.push(i);
-                            });
-                        }
-                    } else if(!accelKey) {
-                        selected = [];
+            var elem_index = selected.indexOf(index);
+            // Replacement for "Accel" modifier.
+            var accelKey = d3.event.ctrlKey || d3.event.metaKey;
+            if(elem_index > -1 && accelKey) {
+                // if the index is already selected and if accel key is
+                // pressed, remove the element from the list
+                selected.splice(elem_index, 1);
+            } else {
+                if(d3.event.shiftKey) {
+                    //If shift is pressed and the element is already
+                    //selected, do not do anything
+                    if(elem_index > -1) {
+                        return;
                     }
-                    // updating the array containing the slice indexes selected
-                    // and updating the style
-                    selected.push(index);
+                    //Add elements before or after the index of the current
+                    //slice which has been clicked
+                    var min_index = (selected.length !== 0) ?
+                        d3.min(selected) : -1;
+                    var max_index = (selected.length !== 0) ?
+                        d3.max(selected) : that.model.mark_data.length;
+                    if(index > max_index){
+                        _.range(max_index+1, index).forEach(function(i) {
+                            selected.push(i);
+                        });
+                    } else if(index < min_index){
+                        _.range(index+1, min_index).forEach(function(i) {
+                            selected.push(i);
+                        });
+                    }
+                    } else if(!accelKey) {
+                    selected = [];
                 }
-                this.model.set("selected",
-                               ((selected.length === 0) ? null : selected),
-                               {updated_view: this});
-                this.touch();
-                if(!d3.event) {
-                    d3.event = window.event;
-                }
-                var e = d3.event;
-                if(e.cancelBubble !== undefined) { // IE
-                    e.cancelBubble = true;
-                }
-                if(e.stopPropagation) {
-                    e.stopPropagation();
-                }
-                e.preventDefault();
-                this.selected_indices = selected;
-                this.apply_styles();
-            // }
+                // updating the array containing the slice indexes selected
+                // and updating the style
+                selected.push(index);
+            }
+            this.model.set("selected",
+                ((selected.length === 0) ? null : selected),
+                {updated_view: this});
+            this.touch();
+            if(!d3.event) {
+                d3.event = window.event;
+            }
+            var e = d3.event;
+            if(e.cancelBubble !== undefined) { // IE
+                e.cancelBubble = true;
+            }
+            if(e.stopPropagation) {
+                e.stopPropagation();
+            }
+            e.preventDefault();
+            this.selected_indices = selected;
+            this.apply_styles();
+
         },
         reset_selection: function() {
             this.model.set("selected", null);

--- a/examples/GridHeatMap.ipynb
+++ b/examples/GridHeatMap.ipynb
@@ -268,6 +268,57 @@
     "fig = Figure(marks=[grid_map], padding_y=0.0)\n",
     "display(fig)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Selections on the grid map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Selection on the `GridHeatMap` works similar to excel. Clicking on a cell selects the cell, and deselects the previous selection. Using the `Ctrl` key allows multiple cells to be selected, while the `Shift` key selects the range from the last cell in the selection to the current cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "data = np.random.randn(10, 10)\n",
+    "\n",
+    "col_sc = ColorScale()\n",
+    "grid_map = GridHeatMap(color=data, scales={'color': col_sc}, interactions={'click':'select'},\n",
+    "                      selected_style={'opacity': '1.0'}, unselected_style={'opacity': 0.4}, anchor_style={'fill': 'white'})\n",
+    "\n",
+    "fig = Figure(marks=[grid_map], padding_y=0.0)\n",
+    "display(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `selected` trait of a `GridHeatMap` contains a list of lists, with each sub-list containing the row and column index of a selected cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "grid_map.selected"
+   ]
   }
  ],
  "metadata": {

--- a/examples/GridHeatMap.ipynb
+++ b/examples/GridHeatMap.ipynb
@@ -295,7 +295,7 @@
     "\n",
     "col_sc = ColorScale()\n",
     "grid_map = GridHeatMap(color=data, scales={'color': col_sc}, interactions={'click':'select'},\n",
-    "                      selected_style={'opacity': '1.0'}, unselected_style={'opacity': 0.4}, anchor_style={'fill': 'white'})\n",
+    "                      selected_style={'opacity': '1.0'}, unselected_style={'opacity': 0.4})\n",
     "\n",
     "fig = Figure(marks=[grid_map], padding_y=0.0)\n",
     "display(fig)"


### PR DESCRIPTION
This PR enables a click interaction for selection on the GridHeatMap. The selection works as in other marks but mimics Excel in that, the `ctrl` key allows additional selection, while the `Shift` key selects the entire range from the last selected cell to the current clicked cell.

![image](https://cloud.githubusercontent.com/assets/7892382/11574682/17891048-99db-11e5-9170-5d81142a2320.png)

The range selection allows arbitrary ranges to be selected with the `Shift` key. 

![image](https://cloud.githubusercontent.com/assets/7892382/11574723/477cf706-99db-11e5-888a-0d561da2cf1f.png)

The `grid_map.selected` trait returns a list of list containing the row index and the column index of each selected cell.