### PR TITLE
No need to specify background color

### DIFF
--- a/bqplot/nbextension/bqplot.less
+++ b/bqplot/nbextension/bqplot.less
@@ -124,7 +124,6 @@
 .theme-light {
     .common();
     svg.bqplot {
-        background: white;
         .axis {
             rect, path, line {
                 stroke: black;


### PR DESCRIPTION
There is no need to specify the white background color in the case of the light theme, especially with the new multiple selection feature of notebook 4.1.