### PR TITLE
setup.py: fail with exception when bower cannot be found.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,8 @@ class Bower(Command):
                     cwd=here,
                     env=os.environ.copy(),
                 )
+            else:
+                raise RuntimeError("developer installation: Could not find 'bower' in path.")
 
         except OSError as e:
             print("Failed to run bower: %s" % e, file=sys.stderr)


### PR DESCRIPTION
In our installation, bower was not on the path and the installation quietly failed.  With the exception, it should stop.