### PR TITLE
examples: Use absolute paths for accessing the file system

### DIFF
--- a/examples/Market Map.ipynb
+++ b/examples/Market Map.ipynb
@@ -12,7 +12,8 @@
     "from IPython.display import display\n",
     "from ipywidgets import Latex\n",
     "from bqplot import *\n",
-    "from bqplot.market_map import MarketMap"
+    "from bqplot.market_map import MarketMap\n",
+    "import os"
    ]
   },
   {
@@ -30,7 +31,7 @@
    },
    "outputs": [],
    "source": [
-    "data = pd.read_csv('data_files/country_codes.csv', index_col=[0])\n",
+    "data = pd.read_csv(os.path.abspath('data_files/country_codes.csv'), index_col=[0])\n",
     "country_codes = data.index.values\n",
     "country_names = data['Name']"
    ]
@@ -73,7 +74,7 @@
    },
    "outputs": [],
    "source": [
-    "gdp_data = pd.read_csv('data_files/gdp_per_capita.csv', index_col=[0], parse_dates=True)\n",
+    "gdp_data = pd.read_csv(os.path.abspath('data_files/gdp_per_capita.csv'), index_col=[0], parse_dates=True)\n",
     "gdp_data.fillna(method='backfill', inplace=True)\n",
     "gdp_data.fillna(method='ffill', inplace=True)"
    ]


### PR DESCRIPTION
When running the kernel in the Chromium sandbox, filesystem access with
relative paths is rejected.