### PR TITLE
Use .tag to specify metadata

### DIFF
--- a/bqplot/axes.py
+++ b/bqplot/axes.py
@@ -61,7 +61,6 @@ class Axis(BaseAxis):
 
     Attributes
     ----------
-
     icon: string (class-level attribute)
         The font-awesome icon name for this object.
     axis_types: dict (class-level attribute)
@@ -103,31 +102,27 @@ class Axis(BaseAxis):
         A visibility toggle for the axis
     """
     icon = 'fa-arrows'
-    orientation = Enum(['horizontal', 'vertical'], default_value='horizontal',
-                       sync=True)
-    side = Enum(['bottom', 'top', 'left', 'right'], allow_none=True, default_value=None,
-                sync=True)
-    label = Unicode(sync=True)
-    grid_lines = Enum(['none', 'solid', 'dashed'], default_value='none',
-                      sync=True)
-    tick_format = Unicode(None, allow_none=True, sync=True)
-    scale = Instance(Scale, sync=True, **widget_serialization)
-    num_ticks = Int(default_value=None, sync=True, allow_none=True)
-    tick_values = NdArray(sync=True, allow_none=True)
-    offset = Dict(sync=True, **widget_serialization)
-    label_location = Enum(['middle', 'start', 'end'], default_value='middle',
-                          sync=True)
-    label_color = Color(None, sync=True, allow_none=True)
-    grid_color = Color(None, sync=True, allow_none=True)
-    color = Color(None, sync=True, allow_none=True)
-    label_offset = Unicode(default_value=None, sync=True, allow_none=True)
+    orientation = Enum(['horizontal', 'vertical'], default_value='horizontal').tag(sync=True)
+    side = Enum(['bottom', 'top', 'left', 'right'], allow_none=True, default_value=None).tag(sync=True)
+    label = Unicode().tag(sync=True)
+    grid_lines = Enum(['none', 'solid', 'dashed'], default_value='none').tag(sync=True)
+    tick_format = Unicode(None, allow_none=True).tag(sync=True)
+    scale = Instance(Scale).tag(sync=True, **widget_serialization)
+    num_ticks = Int(default_value=None, allow_none=True).tag(sync=True)
+    tick_values = NdArray(allow_none=True).tag(sync=True)
+    offset = Dict().tag(sync=True, **widget_serialization)
+    label_location = Enum(['middle', 'start', 'end'], default_value='middle').tag(sync=True)
+    label_color = Color(None, allow_none=True).tag(sync=True)
+    grid_color = Color(None, allow_none=True).tag(sync=True)
+    color = Color(None, allow_none=True).tag(sync=True)
+    label_offset = Unicode(default_value=None, allow_none=True).tag(sync=True)
 
-    visible = Bool(True, sync=True)
+    visible = Bool(True).tag(sync=True)
 
-    _view_name = Unicode('Axis', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Axis', sync=True)
-    _model_name = Unicode('AxisModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/AxisModel', sync=True)
+    _view_name = Unicode('Axis').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Axis').tag(sync=True)
+    _model_name = Unicode('AxisModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/AxisModel').tag(sync=True)
     _ipython_display_ = None  # We cannot display an axis outside of a figure.
 
 
@@ -140,7 +135,6 @@ class ColorAxis(Axis):
 
     Attributes
     ----------
-
     orientation: {'horizontal', 'vertical'}
         Orientation of the color axis
     side: {'bottom', 'top', 'left', right}
@@ -152,13 +146,11 @@ class ColorAxis(Axis):
     tick_format: string (default: '')
         The axis tick format
     """
-    orientation = Enum(['horizontal', 'vertical'], default_value='horizontal',
-                       sync=True)
-    side = Enum(['bottom', 'top', 'left', 'right'], default_value='bottom',
-                sync=True)
-    label = Unicode(sync=True)
-    scale = Instance(ColorScale, sync=True, **widget_serialization)
-    _view_name = Unicode('ColorAxis', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/ColorAxis', sync=True)
-    _model_name = Unicode('AxisModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/AxisModel', sync=True)
+    orientation = Enum(['horizontal', 'vertical'], default_value='horizontal').tag(sync=True)
+    side = Enum(['bottom', 'top', 'left', 'right'], default_value='bottom').tag(sync=True)
+    label = Unicode().tag(sync=True)
+    scale = Instance(ColorScale).tag(sync=True, **widget_serialization)
+    _view_name = Unicode('ColorAxis').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/ColorAxis').tag(sync=True)
+    _model_name = Unicode('AxisModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/AxisModel').tag(sync=True)

--- a/bqplot/default_tooltip.py
+++ b/bqplot/default_tooltip.py
@@ -35,7 +35,6 @@ class Tooltip(DOMWidget):
 
     Attributes
     ----------
-
     fields: list (default: [])
         list of names of fields to be displayed in the tooltip
         All the attributes  of the mark are accesible in the tooltip
@@ -51,10 +50,10 @@ class Tooltip(DOMWidget):
         as the first column along with the value
     """
 
-    fields = List(sync=True)
-    formats = List(sync=True)
-    show_labels = Bool(True, sync=True)
-    labels = List(sync=True)
+    fields = List().tag(sync=True)
+    formats = List().tag(sync=True)
+    show_labels = Bool(True).tag(sync=True)
+    labels = List().tag(sync=True)
 
-    _view_name = Unicode('Tooltip', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Tooltip', sync=True)
+    _view_name = Unicode('Tooltip').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Tooltip').tag(sync=True)

--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -50,7 +50,6 @@ class Figure(DOMWidget):
 
     Attributes
     ----------
-
     title: string (default: '')
         title of the figure
     axes: List of Axes (default: [])
@@ -76,7 +75,6 @@ class Figure(DOMWidget):
     animation_duration: nonnegative int (default: 0)
         Duration of transition on change of data attributes, in milliseconds.
 
-
     Layout Attributes
 
     min_width: CFloat (default: 800.0)
@@ -94,27 +92,26 @@ class Figure(DOMWidget):
         than the sum of the margins.
 
     """
-    title = Unicode(sync=True, display_name='Title')
-    axes = List(Instance(Axis), sync=True, **widget_serialization)
-    marks = List(Instance(Mark), sync=True, **widget_serialization)
-    interaction = Instance(Interaction, allow_none=True, sync=True,
+    title = Unicode().tag(sync=True, display_name='Title')
+    axes = List(Instance(Axis)).tag(sync=True, **widget_serialization)
+    marks = List(Instance(Mark)).tag(sync=True, **widget_serialization)
+    interaction = Instance(Interaction, allow_none=True).tag(sync=True,
                            **widget_serialization)
-    scale_x = Instance(Scale, sync=True, **widget_serialization)
-    scale_y = Instance(Scale, sync=True, **widget_serialization)
-    fig_color = Color(None, allow_none=True, sync=True)
+    scale_x = Instance(Scale).tag(sync=True, **widget_serialization)
+    scale_y = Instance(Scale).tag(sync=True, **widget_serialization)
+    fig_color = Color(None, allow_none=True).tag(sync=True)
 
-    min_width = CFloat(800.0, sync=True)
-    min_height = CFloat(500.0, sync=True)
-    preserve_aspect = Bool(False, sync=True, display_name='Preserve aspect ratio')
+    min_width = CFloat(800.0).tag(sync=True)
+    min_height = CFloat(500.0).tag(sync=True)
+    preserve_aspect = Bool().tag(sync=True, display_name='Preserve aspect ratio')
 
-    fig_margin = Dict(dict(top=60, bottom=60, left=60, right=60), sync=True)
-    padding_x = Float(default_value=0.0, min=0.0, max=1.0, sync=True)
-    padding_y = Float(default_value=0.025, min=0.0, max=1.0, sync=True)
+    fig_margin = Dict(dict(top=60, bottom=60, left=60, right=60)).tag(sync=True)
+    padding_x = Float(0.0, min=0.0, max=1.0).tag(sync=True)
+    padding_y = Float(0.025, min=0.0, max=1.0).tag(sync=True)
     legend_location = Enum(['top-right', 'top', 'top-left', 'left',
                             'bottom-left', 'bottom', 'bottom-right', 'right'],
-                           default_value='top-right', sync=True,
-                           display_name='Legend position')
-    animation_duration = Int(0, sync=True, display_name='Animation duration')
+                           default_value='top-right').tag(sync=True, display_name='Legend position')
+    animation_duration = Int().tag(sync=True, display_name='Animation duration')
 
     def _scale_x_default(self):
         return LinearScale(min=0, max=1)
@@ -122,7 +119,7 @@ class Figure(DOMWidget):
     def _scale_y_default(self):
         return LinearScale(min=0, max=1)
 
-    _view_name = Unicode('Figure', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Figure', sync=True)
-    _model_name = Unicode('FigureModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/FigureModel', sync=True)
+    _view_name = Unicode('Figure').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Figure').tag(sync=True)
+    _model_name = Unicode('FigureModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/FigureModel').tag(sync=True)

--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -74,16 +74,15 @@ class Interaction(Widget):
 
     Attributes
     ----------
-
     types: dict (class-level attribute) representing interaction types
         A registry of existing interaction types.
     """
     types = {}
 
-    _view_name = Unicode('Interaction', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Interaction', sync=True)
-    _model_name = Unicode('BaseModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/BaseModel', sync=True)
+    _view_name = Unicode('Interaction').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Interaction').tag(sync=True)
+    _model_name = Unicode('BaseModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/BaseModel').tag(sync=True)
     _ipython_display_ = None  # We cannot display an interaction outside of a
                               # figure
 
@@ -103,7 +102,6 @@ class HandDraw(Interaction):
 
     Attributes
     ----------
-
     lines: an instance Lines mark or None (default: None)
         The instance of Lines which is edited using the hand-draw interaction.
         The 'y' values of the line are changed according to the path of the
@@ -117,20 +115,18 @@ class HandDraw(Interaction):
     max_x: float or Date or None (default: None)
         The maximum value of 'x' which should be edited via the handdraw.
     """
-    lines = Instance(Lines, sync=True, **widget_serialization)
-    line_index = Int(0, sync=True)
+    lines = Instance(Lines).tag(sync=True, **widget_serialization)
+    line_index = Int().tag(sync=True)
     # TODO: Handle infinity in a meaningful way (json does not)
-    # TODO: Once the new Union is merged in IPython, the sync on the whole
-    # trait can be removed
-    min_x = (Float(allow_none=True, default_value=None, sync=True) |
-             Date(allow_none=True, default_value=None, sync=True))
-    max_x = (Float(allow_none=True, default_value=None, sync=True) |
-             Date(default_value=None, allow_none=True, sync=True))
+    min_x = (Float(None, allow_none=True).tag(sync=True) |
+             Date(None, allow_none=True).tag(sync=True))
+    max_x = (Float(None, allow_none=True).tag(sync=True) |
+             Date(None, allow_none=True).tag(sync=True))
 
-    _view_name = Unicode('HandDraw', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/HandDraw', sync=True)
-    _model_name = Unicode('HandDrawModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/HandDrawModel', sync=True)
+    _view_name = Unicode('HandDraw').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/HandDraw').tag(sync=True)
+    _model_name = Unicode('HandDrawModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/HandDrawModel').tag(sync=True)
 
 
 @register_interaction('bqplot.PanZoom')
@@ -140,7 +136,6 @@ class PanZoom(Interaction):
 
     Attributes
     ----------
-
     allow_pan: bool (default: True)
         Toggle the ability to pan.
     allow_zoom: bool (default: True)
@@ -150,15 +145,15 @@ class PanZoom(Interaction):
         the corresponding direction (dimensions) which should be panned or
         zoomed.
     """
-    allow_pan = Bool(True, sync=True)
-    allow_zoom = Bool(True, sync=True)
-    scales = Dict(trait=List(trait=Instance(Scale)), sync=True,
+    allow_pan = Bool(True).tag(sync=True)
+    allow_zoom = Bool(True).tag(sync=True)
+    scales = Dict(trait=List(trait=Instance(Scale))).tag(sync=True,
                   **widget_serialization)
 
-    _view_name = Unicode('PanZoom', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/PanZoom', sync=True)
-    _model_name = Unicode('PanZoomModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/PanZoomModel', sync=True)
+    _view_name = Unicode('PanZoom').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/PanZoom').tag(sync=True)
+    _model_name = Unicode('PanZoomModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/PanZoomModel').tag(sync=True)
 
 
 def panzoom(marks):
@@ -181,15 +176,14 @@ class Selector(Interaction):
 
     Attributes
     ----------
-
     marks: list (default: [])
         list of marks for which the `selected` attribute is updated based on
         the data selected by the selector.
     """
-    marks = List(sync=True, **widget_serialization)
+    marks = List().tag(sync=True, **widget_serialization)
 
-    _view_name = Unicode('Selector', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Selector', sync=True)
+    _view_name = Unicode('Selector').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Selector').tag(sync=True)
 
     def reset(self):
         self.send({"type": "reset"})
@@ -204,15 +198,14 @@ class OneDSelector(Selector):
 
     Attributes
     ----------
-
     scale: An instance of Scale
         This is the scale which is used for inversion from the pixels to data
         co-ordinates. This scale is used for setting the selected attribute for
         the selector.
     """
-    scale = Instance(Scale, allow_none=True, sync=True, dimension='x', **widget_serialization)
-    _model_name = Unicode('OneDSelectorModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/OneDSelectorModel', sync=True)
+    scale = Instance(Scale, allow_none=True).tag(sync=True, dimension='x', **widget_serialization)
+    _model_name = Unicode('OneDSelectorModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/OneDSelectorModel').tag(sync=True)
 
 
 class TwoDSelector(Selector):
@@ -224,7 +217,6 @@ class TwoDSelector(Selector):
 
     Attributes
     ----------
-
     x_scale: An instance of Scale
         This is the scale which is used for inversion from the pixels to data
         co-ordinates in the x-direction. This scale is used for setting the
@@ -234,13 +226,13 @@ class TwoDSelector(Selector):
         co-ordinates in the y-direction. This scale is used for setting the
         selected attribute for the selector along with ``x_scale``.
     """
-    x_scale = Instance(Scale, allow_none=True, sync=True, dimension='x',
+    x_scale = Instance(Scale, allow_none=True).tag(sync=True, dimension='x',
                        **widget_serialization)
-    y_scale = Instance(Scale, allow_none=True, sync=True, dimension='y',
+    y_scale = Instance(Scale, allow_none=True).tag(sync=True, dimension='y',
                        **widget_serialization)
 
-    _model_name = Unicode('TwoDSelectorModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/TwoDSelectorModel', sync=True)
+    _model_name = Unicode('TwoDSelectorModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/TwoDSelectorModel').tag(sync=True)
 
 
 @register_interaction('bqplot.FastIntervalSelector')
@@ -269,7 +261,6 @@ class FastIntervalSelector(OneDSelector):
 
     Attributes
     ----------
-
     selected: numpy.ndarray
         Two-element array containing the start and end of the interval selected
         in terms of the scale of the selector. This is a read-only attribute.
@@ -278,12 +269,12 @@ class FastIntervalSelector(OneDSelector):
     size: Float or None (default: None)
         if not None, this is the fixed pixel-width of the interval selector
     """
-    selected = NdArray(sync=True)
-    color = Color(None, sync=True, allow_none=True)
-    size = Float(None, allow_none=True, sync=True)
+    selected = NdArray().tag(sync=True)
+    color = Color(None, allow_none=True).tag(sync=True)
+    size = Float(None, allow_none=True).tag(sync=True)
 
-    _view_name = Unicode('FastIntervalSelector', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/FastIntervalSelector', sync=True)
+    _view_name = Unicode('FastIntervalSelector').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/FastIntervalSelector').tag(sync=True)
 
 
 @register_interaction('bqplot.IndexSelector')
@@ -303,7 +294,6 @@ class IndexSelector(OneDSelector):
 
     Attributes
     ----------
-
     selected: numpy.ndarray
         A single element array containing the point corresponding the
         x-position of the mouse. This attribute is updated as you move the
@@ -313,12 +303,12 @@ class IndexSelector(OneDSelector):
     line_width: nonnegative integer (default: 0)
         Width of the line represetning the index selector.
     """
-    selected = NdArray(sync=True)
-    line_width = Int(2, sync=True)
-    color = Color(None, sync=True, allow_none=True)
+    selected = NdArray().tag(sync=True)
+    line_width = Int(2).tag(sync=True)
+    color = Color(None, allow_none=True).tag(sync=True)
 
-    _view_name = Unicode('IndexSelector', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/IndexSelector', sync=True)
+    _view_name = Unicode('IndexSelector').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/IndexSelector').tag(sync=True)
 
 
 @register_interaction('bqplot.BrushIntervalSelector')
@@ -339,7 +329,6 @@ class BrushIntervalSelector(OneDSelector):
 
     Attributes
     ----------
-
     selected: numpy.ndarray
         Two element array containing the start and end of the interval selected
         in terms of the scale of the selector. This is a read-only attribute.
@@ -354,12 +343,12 @@ class BrushIntervalSelector(OneDSelector):
     color: Color or None (default: None)
         Color of the rectangle representing the brush selector.
     """
-    brushing = Bool(False, sync=True)
-    selected = NdArray(sync=True)
-    color = Color(None, sync=True, allow_none=True)
+    brushing = Bool().tag(sync=True)
+    selected = NdArray().tag(sync=True)
+    color = Color(None, allow_none=True).tag(sync=True)
 
-    _view_name = Unicode('BrushIntervalSelector', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/BrushSelector', sync=True)
+    _view_name = Unicode('BrushIntervalSelector').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/BrushSelector').tag(sync=True)
 
 
 @register_interaction('bqplot.BrushSelector')
@@ -380,7 +369,6 @@ class BrushSelector(TwoDSelector):
 
     Attributes
     ----------
-
     selected: numpy.ndarray
         Two element array containing the start and end of the interval selected
         in terms of the scales of the selector. This is a read-only attribute.
@@ -395,10 +383,10 @@ class BrushSelector(TwoDSelector):
     color: Color or None (default: None)
         Color of the rectangle representing the brush selector.
     """
-    clear = Bool(False, sync=True)
-    brushing = Bool(False, sync=True)
-    selected = List(sync=True)
-    color = Color(None, sync=True, allow_none=True)
+    clear = Bool().tag(sync=True)
+    brushing = Bool().tag(sync=True)
+    selected = List().tag(sync=True)
+    color = Color(None, allow_none=True).tag(sync=True)
 
     def __init__(self, **kwargs):
         # Stores information regarding the scales. The date scaled values have
@@ -423,8 +411,8 @@ class BrushSelector(TwoDSelector):
                 self.selected[0][1] = self.read_json_y(self.selected[0][1])
                 self.selected[1][1] = self.read_json_y(self.selected[1][1])
 
-    _view_name = Unicode('BrushSelector', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/BrushSelector', sync=True)
+    _view_name = Unicode('BrushSelector').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/BrushSelector').tag(sync=True)
 
 
 @register_interaction('bqplot.MultiSelector')
@@ -460,7 +448,6 @@ class MultiSelector(OneDSelector):
 
     Attributes
     ----------
-
     selected: dict
         A dictionary with keys being the names of the intervals and values
         being the two element arrays containing the start and end of the
@@ -482,14 +469,14 @@ class MultiSelector(OneDSelector):
         Attribute to indicate if the names of the intervals are to be displayed
         along with the interval.
     """
-    names = List(sync=True)
-    brushing = Bool(False, sync=True)
-    selected = Dict(sync=True)
-    _selected = Dict(sync=True)  # TODO: UglyHack. Hidden variable to get
+    names = List().tag(sync=True)
+    brushing = Bool().tag(sync=True)
+    selected = Dict().tag(sync=True)
+    _selected = Dict().tag(sync=True)  # TODO: UglyHack. Hidden variable to get
     # around the even more ugly hack to have a trait which converts dates,
     # if present, into strings and send it across. It means writing a trait
     # which does that on top of a dictionary. I don't like that
-    show_names = Bool(True, sync=True)  # TODO: Not a trait. The value has to
+    show_names = Bool(True).tag(sync=True)  # TODO: Not a trait. The value has to
                                         # be set at declaration time.
 
     def __init__(self, **kwargs):
@@ -511,8 +498,8 @@ class MultiSelector(OneDSelector):
                                         for elem in self._selected[key]]
             self.selected = actual_selected
 
-    _view_name = Unicode('MultiSelector', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/BrushSelector', sync=True)
+    _view_name = Unicode('MultiSelector').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/BrushSelector').tag(sync=True)
 
 
 @register_interaction('bqplot.LassoSelector')
@@ -532,16 +519,15 @@ class LassoSelector(TwoDSelector):
 
     Attributes
     ----------
-
     marks: List of marks which are instances of {Lines, Scatter} (default: [])
         List of marks on which lasso selector will be applied.
     color: Color (default: None)
         Color of the lasso.
 
     """
-    marks = List(Instance(Lines) | Instance(Scatter), sync=True,
+    marks = List(Instance(Lines) | Instance(Scatter)).tag(sync=True,
                  **widget_serialization)
-    color = Color(None, sync=True, allow_none=True)
+    color = Color(None, allow_none=True).tag(sync=True)
 
     def __init__(self, marks=None, **kwargs):
         _marks = []
@@ -556,5 +542,5 @@ class LassoSelector(TwoDSelector):
         kwargs['marks'] = _marks
         super(LassoSelector, self).__init__(**kwargs)
 
-    _view_name = Unicode('LassoSelector', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/LassoSelector', sync=True)
+    _view_name = Unicode('LassoSelector').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/LassoSelector').tag(sync=True)

--- a/bqplot/market_map.py
+++ b/bqplot/market_map.py
@@ -28,7 +28,7 @@ Market Map
 """
 
 from traitlets import Int, Unicode, List, Dict, Enum, Bool, Instance
-from ipywidgets import DOMWidget, CallbackDispatcher, widget_serialization
+from ipywidgets import DOMWidget, CallbackDispatcher, Color, widget_serialization
 
 from .traits import NdArray, PandasDataFrame
 from .marks import CATEGORY10
@@ -40,7 +40,6 @@ class MarketMap(DOMWidget):
 
     Attributes
     ----------
-
     names: numpy.ndarray of strings or objects convertible to strings (default: [])
         primary key for the data of the map. One rectangle is created for each
         unique entry in this array
@@ -57,7 +56,7 @@ class MarketMap(DOMWidget):
         Data to represent the color for each of the cells. If the value of the
         data is NaN for a cell, then the color of the cell is the color of the
         group it belongs to in absence of data for color
-    scales: Dictionary of , scales holding a scale for each data attribute
+    scales: Dictionary of scales holding a scale for each data attribute
         If the map has data being passed as color, then a corresponding color
         scale is required
     axes: List of axes
@@ -130,42 +129,38 @@ class MarketMap(DOMWidget):
         boolean to control if the map should be aware of which cell is being
         hovered on. If it is set to False, tooltip will not be displayed
     """
-    map_width = Int(1080, sync=True)
-    map_height = Int(800, sync=True)
+    map_width = Int(1080).tag(sync=True)
+    map_height = Int(800).tag(sync=True)
 
-    names = NdArray(sync=True)
-    groups = NdArray(sync=True)
-    display_text = NdArray(sync=True)
-    ref_data = PandasDataFrame(sync=True)
+    names = NdArray().tag(sync=True)
+    groups = NdArray().tag(sync=True)
+    display_text = NdArray().tag(sync=True)
+    ref_data = PandasDataFrame().tag(sync=True)
 
-    tooltip_fields = List(sync=True)
-    tooltip_formats = List(sync=True)
-    show_groups = Bool(False, sync=True)
+    tooltip_fields = List().tag(sync=True)
+    tooltip_formats = List().tag(sync=True)
+    show_groups = Bool().tag(sync=True)
 
-    cols = Int(sync=True, allow_none=True)
-    rows = Int(sync=True, allow_none=True)
+    cols = Int(allow_none=True).tag(sync=True)
+    rows = Int(allow_none=True).tag(sync=True)
 
-    row_groups = Int(1, sync=True)
-    colors = List(CATEGORY10, sync=True)
-    scales = Dict(sync=True, allow_none=True,
-                  **widget_serialization)
-    axes = List(sync=True, allow_none=True,
-                **widget_serialization)
-    color = NdArray(sync=True)
-    map_margin = Dict(dict(top=50, right=50, left=50, bottom=50), sync=True)
-    preserve_aspect = Bool(False, sync=True,
-                           display_name='Preserve aspect ratio')
+    row_groups = Int(1).tag(sync=True)
+    colors = List(CATEGORY10).tag(sync=True)
+    scales = Dict().tag(sync=True, **widget_serialization)
+    axes = List().tag(sync=True, **widget_serialization)
+    color = NdArray().tag(sync=True)
+    map_margin = Dict(dict(top=50, right=50, left=50, bottom=50)).tag(sync=True)
+    preserve_aspect = Bool().tag(sync=True, display_name='Preserve aspect ratio')
 
-    stroke = Unicode('white', sync=True)
-    group_stroke = Unicode('black', sync=True)
-    selected_stroke = Unicode('dodgerblue', sync=True)
-    hovered_stroke = Unicode('orangered', sync=True)
+    stroke = Color('white').tag(sync=True)
+    group_stroke = Color('black').tag(sync=True)
+    selected_stroke = Color('dodgerblue').tag(sync=True)
+    hovered_stroke = Color('orangered').tag(sync=True)
 
-    selected = List(sync=True)
-    enable_hover = Bool(True, sync=True)
-    enable_select = Bool(True, sync=True)
-    tooltip_widget = Instance(DOMWidget, allow_none=True, sync=True,
-                              **widget_serialization)
+    selected = List().tag(sync=True)
+    enable_hover = Bool(True).tag(sync=True)
+    enable_select = Bool(True).tag(sync=True)
+    tooltip_widget = Instance(DOMWidget, allow_none=True).tag(sync=True, **widget_serialization)
 
     def __init__(self, **kwargs):
         super(MarketMap, self).__init__(**kwargs)
@@ -179,17 +174,16 @@ class MarketMap(DOMWidget):
         if content.get('event', '') == 'hover':
             self._hover_handlers(self, content)
 
-    _view_name = Unicode('MarketMap', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/MarketMap', sync=True)
-    _model_name = Unicode('MarketMapModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/MarketMapModel', sync=True)
+    _view_name = Unicode('MarketMap').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/MarketMap').tag(sync=True)
+    _model_name = Unicode('MarketMapModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/MarketMapModel').tag(sync=True)
 
 
 class SquareMarketMap(MarketMap):
-    margin = Dict(dict(top=50, right=50, left=50, bottom=50), sync=True)
-    data = Dict(sync=True)
-    mode = Enum(['squarify', 'slice', 'dice', 'slice-dice'],
-                default_value='squarify', sync=True)
+    margin = Dict(dict(top=50, right=50, left=50, bottom=50)).tag(sync=True)
+    data = Dict().tag(sync=True)
+    mode = Enum(['squarify', 'slice', 'dice', 'slice-dice'], default_value='squarify').tag(sync=True)
 
-    _view_name = Unicode('SquareMarketMap', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/SquareMarketMap', sync=True)
+    _view_name = Unicode('SquareMarketMap').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/SquareMarketMap').tag(sync=True)

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -79,7 +79,6 @@ class Mark(Widget):
 
     Attributes
     ----------
-
     display_name: string
         Holds a user-friendly name for the trait attribute.
     mark_types: dict (class-level attribute)
@@ -115,7 +114,7 @@ class Mark(Widget):
     unselected_style: dict (default: {})
         CSS style to be applied to items that are not selected in the mark,
         when a selection exists.
-    selected: list (default: [])
+    selected: list of integers or None (default: None)
         Indices of the selected items in the mark.
     tooltip: DOMWidget or None (default: None)
         Widget to be displayed as tooltip when elements of the scatter are
@@ -139,31 +138,31 @@ class Mark(Widget):
         that triggered the tooltip to be visible.
     """
     mark_types = {}
-    scales = Dict(trait=Instance(Scale), sync=True, **widget_serialization)
-    scales_metadata = Dict(sync=True)
-    preserve_domain = Dict(sync=True)
-    display_legend = Bool(False, sync=True, display_name='Display legend')
-    labels = List(trait=Unicode(), sync=True, display_name='Labels')
-    apply_clip = Bool(True, sync=True)
-    visible = Bool(True, sync=True)
-    selected_style = Dict(sync=True)
-    unselected_style = Dict(sync=True)
-    selected = List(sync=True, allow_none=True)
+    scales = Dict(trait=Instance(Scale)).tag(sync=True, **widget_serialization)
+    scales_metadata = Dict().tag(sync=True)
+    preserve_domain = Dict().tag(sync=True)
+    display_legend = Bool().tag(sync=True, display_name='Display legend')
+    labels = List(trait=Unicode()).tag(sync=True, display_name='Labels')
+    apply_clip = Bool(True).tag(sync=True)
+    visible = Bool(True).tag(sync=True)
+    selected_style = Dict().tag(sync=True)
+    unselected_style = Dict().tag(sync=True)
+    selected = List(None, allow_none=True).tag(sync=True)
 
-    enable_hover = Bool(True, sync=True)
-    tooltip = Instance(DOMWidget, allow_none=True, sync=True, **widget_serialization)
-    tooltip_style = Dict({'opacity': 0.9}, sync=True)
-    interactions = Dict({'hover': 'tooltip'}, sync=True)
-    tooltip_location = Enum(['mouse', 'center'], default_value='mouse', sync=True)
+    enable_hover = Bool(True).tag(sync=True)
+    tooltip = Instance(DOMWidget, allow_none=True).tag(sync=True, **widget_serialization)
+    tooltip_style = Dict({'opacity': 0.9}).tag(sync=True)
+    interactions = Dict({'hover': 'tooltip'}).tag(sync=True)
+    tooltip_location = Enum(['mouse', 'center'], default_value='mouse').tag(sync=True)
 
-    _model_name = Unicode('MarkModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/MarkModel', sync=True)
+    _model_name = Unicode('MarkModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/MarkModel').tag(sync=True)
     _ipython_display_ = None
 
     def _scales_validate(self, scales, scales_trait):
         """validates the dictionary of scales based on the mark's scaled
         attributes metadata. First checks for missing scale and then for
-        'rtype' compatibility """
+        'rtype' compatibility."""
         # Validate scales' 'rtype' versus data attribute 'rtype' decoration
         # At this stage it is already validated that all values in self.scales
         # are instances of Scale.
@@ -236,7 +235,6 @@ class Lines(Mark):
 
     Attributes
     ----------
-
     icon: string (class-level attribute)
         Font-awesome icon for the respective mark
     name: string (class-level attribute)
@@ -289,7 +287,6 @@ class Lines(Mark):
 
     Notes
     -----
-
     The fields which can be passed to the default tooltip are:
         name: label of the line
         index: index of the line being hovered on
@@ -305,48 +302,44 @@ class Lines(Mark):
     name = 'Lines'
 
     # Scaled attributes
-    x = NdArray(sync=True, min_dim=1, max_dim=2,
+    x = NdArray().tag(sync=True, min_dim=1, max_dim=2,
                 scaled=True, rtype='Number', atype='bqplot.Axis')
-    y = NdArray(sync=True, min_dim=1, max_dim=2,
+    y = NdArray().tag(sync=True, min_dim=1, max_dim=2,
                 scaled=True, rtype='Number', atype='bqplot.Axis')
-    color = NdArray(None, sync=True, allow_none=True,
-                    scaled=True, rtype='Color', atype='bqplot.ColorAxis',
-                    min_dim=1, max_dim=1)
+    color = NdArray(None, allow_none=True).tag(sync=True, scaled=True,
+                    rtype='Color', atype='bqplot.ColorAxis', min_dim=1, max_dim=1)
 
     # Other attributes
-    scales_metadata = Dict({'x': {'orientation': 'horizontal', 'dimension': 'x'},
-                            'y': {'orientation': 'vertical', 'dimension': 'y'},
-                            'color': {'dimension': 'color'}}, sync=True)
+    scales_metadata = Dict({
+        'x': {'orientation': 'horizontal', 'dimension': 'x'},
+        'y': {'orientation': 'vertical', 'dimension': 'y'},
+        'color': {'dimension': 'color'}
+    }).tag(sync=True)
     colors = List(trait=Color(default_value=None, allow_none=True),
-                  default_value=CATEGORY10, sync=True, display_name='Colors')
+                  default_value=CATEGORY10).tag(sync=True, display_name='Colors')
     fill_colors = List(trait=Color(default_value=None, allow_none=True),
-                       default_value=CATEGORY10, sync=True,
-                       display_name='Fill colors')
-    stroke_width = Float(2.0, sync=True, display_name='Stroke width')
-    labels_visibility = Enum(['none', 'label'], default_value='none',
-                             sync=True, display_name='Labels visibility')
-    curves_subset = List(sync=True)
+                       default_value=CATEGORY10).tag(sync=True, display_name='Fill colors')
+    stroke_width = Float(2.0).tag(sync=True, display_name='Stroke width')
+    labels_visibility = Enum(['none', 'label'], default_value='none').tag(sync=True, display_name='Labels visibility')
+    curves_subset = List().tag(sync=True)
     line_style = Enum(['solid', 'dashed', 'dotted', 'dash_dotted'],
-                      default_value='solid', sync=True,
-                      display_name='Line style')
-    interpolation = Enum(['linear', 'basis', 'cardinal', 'monotone'],
-                         default_value='linear', sync=True,
+                      default_value='solid').tag(sync=True, display_name='Line style')
+    interpolation = Enum(['linear', 'basis', 'cardinal', 'monotone'], default_value='linear').tag(sync=True,
                          display_name='Interpolation')
-    close_path = Bool(sync=True, display_name='Close path')
-    fill = Enum(['none', 'bottom', 'top', 'inside'], default_value='none',
-                sync=True, display_name='Fill')
+    close_path = Bool().tag(sync=True, display_name='Close path')
+    fill = Enum(['none', 'bottom', 'top', 'inside'], default_value='none').tag(sync=True, display_name='Fill')
     marker = Enum(['circle', 'cross', 'diamond', 'square', 'triangle-down',
                    'triangle-up', 'arrow', 'rectangle', 'ellipse'],
-                  default_value=None, allow_none=True, sync=True,
+                  default_value=None, allow_none=True).tag(sync=True,
                   display_name='Marker')
-    marker_size = Int(64, sync=True, display_name='Default size')
+    marker_size = Int(64).tag(sync=True, display_name='Default size')
 
-    opacities = List(sync=True, display_name='Opacity')
-    fill_opacities = List(sync=True, display_name='Fill Opacity')
-    _view_name = Unicode('Lines', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Lines', sync=True)
-    _model_name = Unicode('LinesModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/LinesModel', sync=True)
+    opacities = List().tag(sync=True, display_name='Opacity')
+    fill_opacities = List().tag(sync=True, display_name='Fill Opacity')
+    _view_name = Unicode('Lines').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Lines').tag(sync=True)
+    _model_name = Unicode('LinesModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/LinesModel').tag(sync=True)
 
 
 @register_mark('bqplot.FlexLine')
@@ -361,7 +354,6 @@ class FlexLine(Mark):
 
     Attributes
     ----------
-
     name: string (class-level attributes)
         user-friendly name of the mark
     colors: list of colors (default: CATEGORY10)
@@ -385,21 +377,23 @@ class FlexLine(Mark):
     name = 'Flexible lines'
 
     # Scaled attributes
-    x = NdArray(sync=True, min_dim=1, max_dim=1, scaled=True, rtype='Number', atype='bqplot.Axis')
-    y = NdArray(sync=True, min_dim=1, max_dim=1, scaled=True, rtype='Number', atype='bqplot.Axis')
-    color = NdArray(None, allow_none=True, sync=True, scaled=True, rtype='Color', atype='bqplot.ColorAxis')
-    width = NdArray(None, allow_none=True, sync=True, scaled=True, rtype='Number')
+    x = NdArray().tag(sync=True, min_dim=1, max_dim=1, scaled=True, rtype='Number', atype='bqplot.Axis')
+    y = NdArray().tag(sync=True, min_dim=1, max_dim=1, scaled=True, rtype='Number', atype='bqplot.Axis')
+    color = NdArray(None, allow_none=True).tag(sync=True, scaled=True, rtype='Color', atype='bqplot.ColorAxis')
+    width = NdArray(None, allow_none=True).tag(sync=True, scaled=True, rtype='Number')
 
     # Other attributes
-    scales_metadata = Dict({'x': {'orientation': 'horizontal', 'dimension': 'x'},
-                            'y': {'orientation': 'vertical', 'dimension': 'y'},
-                            'color': {'dimension': 'color'}}, sync=True)
-    stroke_width = Float(1.5, sync=True, exposed=True, display_name='Stroke width')
-    colors = List(trait=Color(default_value=None, allow_none=True), default_value=CATEGORY10, sync=True)
-    _view_name = Unicode('FlexLine', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/FlexLine', sync=True)
-    _model_name = Unicode('FlexLineModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/LinesModel', sync=True)
+    scales_metadata = Dict({
+        'x': {'orientation': 'horizontal', 'dimension': 'x'},
+        'y': {'orientation': 'vertical', 'dimension': 'y'},
+        'color': {'dimension': 'color'}
+    }).tag(sync=True)
+    stroke_width = Float(1.5).tag(sync=True, display_name='Stroke width')
+    colors = List(trait=Color(default_value=None, allow_none=True), default_value=CATEGORY10).tag(sync=True)
+    _view_name = Unicode('FlexLine').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/FlexLine').tag(sync=True)
+    _model_name = Unicode('FlexLineModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/LinesModel').tag(sync=True)
 
 
 @register_mark('bqplot.Scatter')
@@ -414,7 +408,6 @@ class Scatter(Mark):
 
     Attributes
     ----------
-
     icon: string (class-level attribute)
         Font-awesome icon for that mark
     name: string (class-level attribute)
@@ -468,7 +461,6 @@ class Scatter(Mark):
 
     Notes
     -----
-
     The fields which can be passed to the default tooltip are:
         All the data attributes
         index: index of the marker being hovered on
@@ -484,51 +476,52 @@ class Scatter(Mark):
     name = 'Scatter'
 
     # Scaled attribtes
-    x = NdArray(sync=True, min_dim=1, max_dim=1, scaled=True,
+    x = NdArray().tag(sync=True, min_dim=1, max_dim=1, scaled=True,
                 rtype='Number', atype='bqplot.Axis')
-    y = NdArray(sync=True, min_dim=1, max_dim=1,
+    y = NdArray().tag(sync=True, min_dim=1, max_dim=1,
                 scaled=True, rtype='Number', atype='bqplot.Axis')
-    color = NdArray(None, allow_none=True, sync=True, scaled=True,
+    color = NdArray(None, allow_none=True).tag(sync=True, scaled=True,
                     rtype='Color', atype='bqplot.ColorAxis', min_dim=1, max_dim=1)
-    opacity = NdArray(None, allow_none=True, sync=True, scaled=True,
+    opacity = NdArray(None, allow_none=True).tag(sync=True, scaled=True,
                       rtype='Number', min_dim=1, max_dim=1)
-    size = NdArray(None, allow_none=True, sync=True, scaled=True,
+    size = NdArray(None, allow_none=True).tag(sync=True, scaled=True,
                    rtype='Number', min_dim=1, max_dim=1)
-    skew = NdArray(None, allow_none=True, sync=True, scaled=True, rtype='Number',
+    skew = NdArray(None, allow_none=True).tag(sync=True, scaled=True, rtype='Number',
                    min_dim=1, max_dim=1)
-    rotation = NdArray(None, allow_none=True, sync=True, scaled=True,
+    rotation = NdArray(None, allow_none=True).tag(sync=True, scaled=True,
                        rtype='Number', min_dim=1, max_dim=1)
 
     # Other attributes
-    scales_metadata = Dict({'x': {'orientation': 'horizontal', 'dimension': 'x'},
-                            'y': {'orientation': 'vertical', 'dimension': 'y'},
-                            'color': {'dimension': 'color'},
-                            'size': {'dimension': 'size'},
-                            'opacity': {'dimension': 'opacity'}}, sync=True)
+    scales_metadata = Dict({
+        'x': {'orientation': 'horizontal', 'dimension': 'x'},
+        'y': {'orientation': 'vertical', 'dimension': 'y'},
+        'color': {'dimension': 'color'},
+        'size': {'dimension': 'size'},
+        'opacity': {'dimension': 'opacity'}
+    }).tag(sync=True)
     marker = Enum(['circle', 'cross', 'diamond', 'square', 'triangle-down',
-                  'triangle-up', 'arrow', 'rectangle', 'ellipse'],
-                  default_value='circle', sync=True, display_name='Marker')
+                   'triangle-up', 'arrow', 'rectangle', 'ellipse'],
+                  default_value='circle').tag(sync=True, display_name='Marker')
     default_colors = List(trait=Color(default_value=None, allow_none=True),
-                          default_value=['DeepSkyBlue'], sync=True,
+                          default_value=['DeepSkyBlue']).tag(sync=True,
                           display_name='Colors')
-    stroke = Color(None, allow_none=True, sync=True, display_name='Stroke color')
-    stroke_width = Float(1.5, sync=True, display_name='Stroke width')
-    default_opacities = List(trait=Float(default_value=1.0, min=0, max=1,
-                             allow_none=True), sync=True, display_name='Opacities')
-    default_skew = Float(default_value=0.5, min=0, max=1, sync=True)
-    default_size = Int(64, sync=True, display_name='Default size')
+    stroke = Color(None, allow_none=True).tag(sync=True, display_name='Stroke color')
+    stroke_width = Float(1.5).tag(sync=True, display_name='Stroke width')
+    default_opacities = List(trait=Float(1.0, min=0, max=1, allow_none=True)).tag(sync=True, display_name='Opacities')
+    default_skew = Float(0.5, min=0, max=1).tag(sync=True)
+    default_size = Int(64).tag(sync=True, display_name='Default size')
 
-    names = NdArray(sync=True)
-    display_names = Bool(True, sync=True, display_name='Display names')
-    fill = Bool(True, sync=True)
-    drag_color = Color(None, allow_none=True, sync=True)
-    names_unique = Bool(True, sync=True)
+    names = NdArray().tag(sync=True)
+    display_names = Bool(True).tag(sync=True, display_name='Display names')
+    fill = Bool(True).tag(sync=True)
+    drag_color = Color(None, allow_none=True).tag(sync=True)
+    names_unique = Bool(True).tag(sync=True)
 
-    enable_move = Bool(False, sync=True)
-    enable_delete = Bool(False, sync=True)
-    restrict_x = Bool(False, sync=True)
-    restrict_y = Bool(False, sync=True)
-    update_on_move = Bool(False, sync=True)
+    enable_move = Bool().tag(sync=True)
+    enable_delete = Bool().tag(sync=True)
+    restrict_x = Bool().tag(sync=True)
+    restrict_y = Bool().tag(sync=True)
+    update_on_move = Bool().tag(sync=True)
 
     def __init__(self, **kwargs):
         self._drag_end_handlers = CallbackDispatcher()
@@ -542,10 +535,10 @@ class Scatter(Mark):
             self._drag_end_handlers(self, content)
         super(Scatter, self)._handle_custom_msgs(self, content)
 
-    _view_name = Unicode('Scatter', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Scatter', sync=True)
-    _model_name = Unicode('ScatterModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/ScatterModel', sync=True)
+    _view_name = Unicode('Scatter').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Scatter').tag(sync=True)
+    _model_name = Unicode('ScatterModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/ScatterModel').tag(sync=True)
 
 
 @register_mark('bqplot.Hist')
@@ -558,7 +551,6 @@ class Hist(Mark):
 
     Attributes
     ----------
-
     icon: string (class-level attribute)
         font-awesome icon for that mark
     name: string (class-level attribute)
@@ -584,8 +576,7 @@ class Hist(Mark):
         number of sample points per bin. It is a read-only attribute.
 
     Notes
-    ----
-
+    -----
     The fields which can be passed to the default tooltip are:
         midpoint: mid-point of the bin related to the rectangle hovered on
         count: number of elements in the bin hovered on
@@ -598,29 +589,31 @@ class Hist(Mark):
     name = 'Histogram'
 
     # Scaled attributes
-    sample = NdArray(sync=True, min_dim=1, max_dim=1, display_name='Sample',
-                     scaled=True, rtype='Number', atype='bqplot.Axis')
-    count = NdArray(sync=True, display_name='Count', scaled=True,
-                    rtype='Number', read_only=True, atype='bqplot.Axis')
+    sample = NdArray().tag(sync=True, min_dim=1, max_dim=1, display_name='Sample',
+                           scaled=True, rtype='Number', atype='bqplot.Axis')
+    count = NdArray(read_only=True).tag(sync=True, display_name='Count', scaled=True,
+                                        rtype='Number', atype='bqplot.Axis')
     # FIXME: Should we allow None for count?
     # count is a read-only attribute that is set when the mark is drawn
 
     # Other attributes
-    scales_metadata = Dict({'sample': {'orientation': 'horizontal', 'dimension': 'x'},
-                            'count': {'orientation': 'vertical', 'dimension': 'y'}}, sync=True)
-    bins = Int(10, sync=True, display_name='Number of bins')
-    midpoints = List(sync=True, read_only=True, display_name='Mid points')
+    scales_metadata = Dict({
+        'sample': {'orientation': 'horizontal', 'dimension': 'x'},
+        'count': {'orientation': 'vertical', 'dimension': 'y'}
+    }).tag(sync=True)
+
+    bins = Int(10).tag(sync=True, display_name='Number of bins')
+    midpoints = List(read_only=True).tag(sync=True, display_name='Mid points')
     # midpoints is a read-only attribute that is set when the mark is drawn
     colors = List(trait=Color(default_value=None, allow_none=True),
-                  default_value=CATEGORY10, sync=True, display_name='Colors')
-    stroke = Color(None, allow_none=True, sync=True)
-    opacities = List(trait=Float(default_value=1.0, min=0, max=1,
-                                 allow_none=True), sync=True, display_name='Opacities')
+                  default_value=CATEGORY10).tag(sync=True, display_name='Colors')
+    stroke = Color(None, allow_none=True).tag(sync=True)
+    opacities = List(trait=Float(1.0, min=0, max=1, allow_none=True)).tag(sync=True, display_name='Opacities')
 
-    _view_name = Unicode('Hist', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Hist', sync=True)
-    _model_name = Unicode('HistModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/HistModel', sync=True)
+    _view_name = Unicode('Hist').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Hist').tag(sync=True)
+    _model_name = Unicode('HistModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/HistModel').tag(sync=True)
 
 
 @register_mark('bqplot.Boxplot')
@@ -630,7 +623,6 @@ class Boxplot(Mark):
 
     Attributes
     ----------
-
     stroke: Color or None
         stroke color of the marker
     color: Color
@@ -656,28 +648,28 @@ class Boxplot(Mark):
     name = 'Boxplot chart'
 
     # Scaled attributestop
-    x = NdArray(sync=True, scaled=True, rtype='Number', min_dim=1, max_dim=1, atype='bqplot.Axis')
+    x = NdArray().tag(sync=True, scaled=True, rtype='Number', min_dim=1, max_dim=1, atype='bqplot.Axis')
 
     # Second dimension must contain OHLC data, otherwise the behavior is
     # undefined.
-    y = NdArray(sync=True, scaled=True, rtype='Number', min_dim=1, max_dim=2, atype='bqplot.Axis')
+    y = NdArray().tag(sync=True, scaled=True, rtype='Number', min_dim=1, max_dim=2, atype='bqplot.Axis')
 
     # Other attributes
     # marker = Enum([boxplottype], sync=True, default_value='candle', display_name='Marker')
-    scales_metadata = Dict({'x': {'orientation': 'horizontal', 'dimension': 'x'},
-                            'y': {'orientation': 'vertical', 'dimension': 'y'}}, sync=True)
+    scales_metadata = Dict({
+        'x': {'orientation': 'horizontal', 'dimension': 'x'},
+        'y': {'orientation': 'vertical', 'dimension': 'y'}
+    }).tag(sync=True)
 
-    stroke = Color(None, allow_none=True, sync=True, display_name='Stroke color')
+    stroke = Color(None, allow_none=True).tag(sync=True, display_name='Stroke color')
     box_fill_color = Color('dodgerblue', sync=True, display_name='Fill color for the box')
-    outlier_fill_color = Color('gray', sync=True, display_name='Outlier fill color')
-    opacities = List(trait=Float(default_value=1.0, min=0, max=1,
-                     allow_none=True), sync=True,
-                     display_name='Opacities')
+    outlier_fill_color = Color('gray').tag(sync=True, display_name='Outlier fill color')
+    opacities = List(trait=Float(1.0, min=0, max=1, allow_none=True)).tag(sync=True, display_name='Opacities')
 
-    _view_name = Unicode('Boxplot', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Boxplot', sync=True)
-    _model_name = Unicode('BoxplotModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/BoxplotModel', sync=True)
+    _view_name = Unicode('Boxplot').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Boxplot').tag(sync=True)
+    _model_name = Unicode('BoxplotModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/BoxplotModel').tag(sync=True)
 
 
 @register_mark('bqplot.Bars')
@@ -692,7 +684,6 @@ class Bars(Mark):
 
     Attributes
     ----------
-
     icon: string (class-level attribute)
         font-awesome icon for that mark
     name: string (class-level attribute)
@@ -732,8 +723,7 @@ class Bars(Mark):
         provided or when a value is NaN
 
     Notes
-    ----
-
+    -----
     The fields which can be passed to the default tooltip are:
         All the data attributes
         index: index of the bar being hovered on
@@ -744,36 +734,32 @@ class Bars(Mark):
     name = 'Bar chart'
 
     # Scaled attributes
-    x = NdArray(sync=True, scaled=True,
-                rtype='Number', min_dim=1, max_dim=1, atype='bqplot.Axis')
-    y = NdArray(sync=True, scaled=True,
-                rtype='Number', min_dim=1, max_dim=2, atype='bqplot.Axis')
-    color = NdArray(None, allow_none=True,  sync=True,
+    x = NdArray().tag(sync=True, scaled=True, rtype='Number', min_dim=1, max_dim=1, atype='bqplot.Axis')
+    y = NdArray().tag(sync=True, scaled=True, rtype='Number', min_dim=1, max_dim=2, atype='bqplot.Axis')
+    color = NdArray(None, allow_none=True).tag(sync=True,
                     scaled=True, rtype='Color', atype='bqplot.ColorAxis',
                     min_dim=1, max_dim=1)
 
     # Other attributes
-    scales_metadata = Dict({'x': {'orientation': 'horizontal', 'dimension': 'x'},
-                            'y': {'orientation': 'vertical', 'dimension': 'y'},
-                            'color': {'dimension': 'color'}}, sync=True)
-    color_mode = Enum(['auto', 'group', 'element'], default_value='auto',
-                      sync=True)
-    type = Enum(['stacked', 'grouped'], default_value='stacked', sync=True,
+    scales_metadata = Dict({
+        'x': {'orientation': 'horizontal', 'dimension': 'x'},
+        'y': {'orientation': 'vertical', 'dimension': 'y'},
+        'color': {'dimension': 'color'}
+    }).tag(sync=True)
+    color_mode = Enum(['auto', 'group', 'element'], default_value='auto').tag(sync=True)
+    type = Enum(['stacked', 'grouped'], default_value='stacked').tag(sync=True,
                 display_name='Type')
-    colors = List(trait=Color(default_value=None, allow_none=True), default_value=CATEGORY10,
-                  sync=True, display_name='Colors')
-    padding = Float(0.05, sync=True)
-    stroke = Color(None, allow_none=True, sync=True)
-    base = Float(default_value=0.0, sync=True)
-    opacities = List(trait=Float(default_value=1.0, min=0, max=1,
-                     allow_none=True), sync=True, display_name='Opacities')
-    align = Enum(['center', 'left', 'right'], default_value='center',
-                 sync=True)
+    colors = List(trait=Color(default_value=None, allow_none=True), default_value=CATEGORY10).tag(sync=True, display_name='Colors')
+    padding = Float(0.05).tag(sync=True)
+    stroke = Color(None, allow_none=True).tag(sync=True)
+    base = Float().tag(sync=True)
+    opacities = List(trait=Float(1.0, min=0, max=1, allow_none=True)).tag(sync=True, display_name='Opacities')
+    align = Enum(['center', 'left', 'right'], default_value='center').tag(sync=True)
 
-    _view_name = Unicode('Bars', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Bars', sync=True)
-    _model_name = Unicode('BarsModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/BarsModel', sync=True)
+    _view_name = Unicode('Bars').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Bars').tag(sync=True)
+    _model_name = Unicode('BarsModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/BarsModel').tag(sync=True)
 
 
 @register_mark('bqplot.Label')
@@ -783,7 +769,6 @@ class Label(Mark):
 
     Attributes
     ----------
-
     x: Date or float
         horizontal position of the label, in data coordinates or in figure
         coordinates
@@ -807,24 +792,24 @@ class Label(Mark):
     align: {'start', 'middle', 'end'}
         alignment of the text with respect to the provided location
     """
-    x = Date(sync=True) | Float(sync=True) | Unicode(sync=True)  # TODO: check validation order, and default value
-    y = Date(sync=True) | Float(sync=True) | Unicode(sync=True)
-    x_offset = Int(sync=True)
-    y_offset = Int(sync=True)
-    scales_metadata = Dict({'x': {'orientation': 'horizontal', 'dimension': 'x'},
-                            'y': {'orientation': 'vertical', 'dimension': 'y'},
-                            'color': {'dimension': 'color'}}, sync=True)
-    color = Color(None, allow_none=True, sync=True)
-    rotate_angle = Float(sync=True)
-    text = Unicode(sync=True)
-    font_size = Unicode(default_value='14px', sync=True)
-    font_weight = Enum(['bold', 'normal', 'bolder'], default_value='bold',
-                       sync=True)
-    align = Enum(['start', 'middle', 'end'], default_value='start',
-                 sync=True)
+    x = Date().tag(sync=True) | Float().tag(sync=True) | Unicode().tag(sync=True)  # TODO: check validation order, and default value
+    y = Date().tag(sync=True) | Float().tag(sync=True) | Unicode().tag(sync=True)
+    x_offset = Int().tag(sync=True)
+    y_offset = Int().tag(sync=True)
+    scales_metadata = Dict({
+        'x': {'orientation': 'horizontal', 'dimension': 'x'},
+        'y': {'orientation': 'vertical', 'dimension': 'y'},
+        'color': {'dimension': 'color'}
+    }).tag(sync=True)
+    color = Color(None, allow_none=True).tag(sync=True)
+    rotate_angle = Float().tag(sync=True)
+    text = Unicode().tag(sync=True)
+    font_size = Unicode(default_value='14px').tag(sync=True)
+    font_weight = Enum(['bold', 'normal', 'bolder'], default_value='bold').tag(sync=True)
+    align = Enum(['start', 'middle', 'end'], default_value='start').tag(sync=True)
 
-    _view_name = Unicode('Label', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Label', sync=True)
+    _view_name = Unicode('Label').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Label').tag(sync=True)
 
 
 @register_mark('bqplot.OHLC')
@@ -834,7 +819,6 @@ class OHLC(Mark):
 
     Attributes
     ----------
-
     icon: string (class-level attribute)
         font-awesome icon for that mark
     name: string (class-level attribute)
@@ -863,9 +847,8 @@ class OHLC(Mark):
     y: numpy.ndarray
         Open/High/Low/Close ordinates of the data points (2d array)
 
-    Note
-    ----
-
+    Notes
+    -----
     The fields which can be passed to the default tooltip are:
         x: the x value associated with the bar/candle
         open: open value for the bar/candle
@@ -880,31 +863,30 @@ class OHLC(Mark):
     name = 'OHLC chart'
 
     # Scaled attributes
-    x = NdArray(sync=True, scaled=True,
+    x = NdArray().tag(sync=True, scaled=True,
                 rtype='Number', min_dim=1, max_dim=1, atype='bqplot.Axis')
-    y = NdArray(sync=True, scaled=True,
+    y = NdArray().tag(sync=True, scaled=True,
                 rtype='Number', min_dim=2, max_dim=2, atype='bqplot.Axis')
     # FIXME Future warnings
     _y_default = None
 
     # Other attributes
-    scales_metadata = Dict({'x': {'orientation': 'horizontal', 'dimension': 'x'},
-                            'y': {'orientation': 'vertical', 'dimension': 'y'}},
-                            sync=True)
-    marker = Enum(['candle', 'bar'], default_value='candle', display_name='Marker', sync=True)
-    stroke = Color(None, sync=True, display_name='Stroke color', allow_none=True)
-    stroke_width = Float(1.0, sync=True, display_name='Stroke Width')
-    colors = List(trait=Color(default_value=None, allow_none=True), default_value=['limegreen', 'red'],
-                  sync=True, display_name='Colors')
-    opacities = List(trait=Float(default_value=1.0, min=0, max=1,
-                     allow_none=True), sync=True,
-                     display_name='Opacities')
-    format = Unicode(default_value='ohlc', display_name='Format', sync=True)
+    scales_metadata = Dict({
+        'x': {'orientation': 'horizontal', 'dimension': 'x'},
+        'y': {'orientation': 'vertical', 'dimension': 'y'}
+    }).tag(sync=True)
+    marker = Enum(['candle', 'bar'], default_value='candle', display_name='Marker').tag(sync=True)
+    stroke = Color(None, display_name='Stroke color', allow_none=True).tag(sync=True)
+    stroke_width = Float(1.0).tag(sync=True, display_name='Stroke Width')
+    colors = List(trait=Color(default_value=None, allow_none=True),
+                  default_value=['limegreen', 'red']).tag(sync=True, display_name='Colors')
+    opacities = List(trait=Float(1.0, min=0, max=1, allow_none=True)).tag(sync=True, display_name='Opacities')
+    format = Unicode('ohlc').tag(sync=True, display_name='Format')
 
-    _view_name = Unicode('OHLC', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/OHLC', sync=True)
-    _model_name = Unicode('OHLCModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/OHLCModel', sync=True)
+    _view_name = Unicode('OHLC').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/OHLC').tag(sync=True)
+    _model_name = Unicode('OHLCModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/OHLCModel').tag(sync=True)
 
 
 @register_mark('bqplot.Pie')
@@ -914,7 +896,6 @@ class Pie(Mark):
 
     Attributes
     ----------
-
     colors: list of colors (default: CATEGORY10)
         list of colors for the slices.
     stroke: color (default: 'white')
@@ -947,9 +928,8 @@ class Pie(Mark):
         color of the data points (1d array). Defaults to colors when not
         provided
 
-    Note
-    ----
-
+    Notes
+    -----
     The fields which can be passed to the default tooltip are:
         : the x value associated with the bar/candle
         open: open value for the bar/candle
@@ -963,31 +943,29 @@ class Pie(Mark):
     name = 'Pie chart'
 
     # Scaled attributes
-    sizes = NdArray(sync=True, rtype='Number', min_dim=1, max_dim=1)
-    color = NdArray(sync=True, allow_none=True, scaled=True, rtype='Color',
-                    atype='bqplot.ColorAxis', min_dim=1, max_dim=1)
+    sizes = NdArray().tag(sync=True, rtype='Number', min_dim=1, max_dim=1)
+    color = NdArray(allow_none=True).tag(sync=True, scaled=True, rtype='Color',
+                          atype='bqplot.ColorAxis', min_dim=1, max_dim=1)
 
     # Other attributes
-    x = Float(default_value=0.5, sync=True) | Date(sync=True) | Unicode(sync=True)
-    y = Float(default_value=0.5, sync=True) | Date(sync=True) | Unicode(sync=True)
+    x = Float(0.5).tag(sync=True) | Date().tag(sync=True) | Unicode().tag(sync=True)
+    y = Float(0.5).tag(sync=True) | Date().tag(sync=True) | Unicode().tag(sync=True)
 
-    scales_metadata = Dict({'color': {'dimension': 'color'}}, sync=True)
-    sort = Bool(False, sync=True)
+    scales_metadata = Dict({'color': {'dimension': 'color'}}).tag(sync=True)
+    sort = Bool().tag(sync=True)
     colors = List(trait=Color(default_value=None, allow_none=True),
-                  default_value=CATEGORY10, sync=True, display_name='Colors')
-    stroke = Color(None, allow_none=True, sync=True)
-    opacities = List(trait=Float(default_value=1.0, min=0, max=1,
-                     allow_none=True), sync=True,
-                     display_name='Opacities')
-    radius = Float(default_value=180.0, min=0.0, max=float('inf'), sync=True)
-    inner_radius = Float(default_value=0.1, min=0.0, max=float('inf'), sync=True)
-    start_angle = Float(default_value=0.0, sync=True)
-    end_angle = Float(default_value=360.0, sync=True)
+                  default_value=CATEGORY10).tag(sync=True, display_name='Colors')
+    stroke = Color(None, allow_none=True).tag(sync=True)
+    opacities = List(trait=Float(1.0, min=0, max=1, allow_none=True)).tag(sync=True, display_name='Opacities')
+    radius = Float(180.0, min=0.0, max=float('inf')).tag(sync=True)
+    inner_radius = Float(0.1, min=0.0, max=float('inf')).tag(sync=True)
+    start_angle = Float().tag(sync=True)
+    end_angle = Float(360.0).tag(sync=True)
 
-    _view_name = Unicode('Pie', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Pie', sync=True)
-    _model_name = Unicode('PieModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/PieModel', sync=True)
+    _view_name = Unicode('Pie').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Pie').tag(sync=True)
+    _model_name = Unicode('PieModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/PieModel').tag(sync=True)
 
 
 import os
@@ -1008,7 +986,6 @@ class Map(Mark):
 
     Attributes
     ----------
-
     default_color: Color or None (default: None)
         default color for items of the map when no color data is passed
     selected_styles: Dict (default: {'selected_fill': 'Red', 'selected_stroke': None, 'selected_stroke_width': 2.0})
@@ -1035,39 +1012,44 @@ class Map(Mark):
     name = 'Map'
 
     # Scaled attributes
-    color = Dict(sync=True, allow_none=True, scaled=True, rtype='Color',
+    color = Dict(allow_none=True).tag(sync=True, scaled=True, rtype='Color',
                  atype='bqplot.ColorAxis')
 
     # Other attributes
-    scales_metadata = Dict({'color': {'dimension': 'color'}}, sync=True)
-    hover_highlight = Bool(True, sync=True)
-    hovered_styles = Dict({'hovered_fill': 'Orange', 'hovered_stroke': None,
-                           'hovered_stroke_width': 2.0}, allow_none=True,
-                          sync=True)
+    scales_metadata = Dict({'color': {'dimension': 'color'}}).tag(sync=True)
+    hover_highlight = Bool(True).tag(sync=True)
+    hovered_styles = Dict({
+        'hovered_fill': 'Orange',
+        'hovered_stroke': None,
+        'hovered_stroke_width': 2.0},
+    allow_none=True).tag(sync=True)
 
-    stroke_color = Color(default_value=None, sync=True, allow_none=True)
-    default_color = Color(default_value=None, sync=True, allow_none=True)
+    stroke_color = Color(default_value=None, allow_none=True).tag(sync=True)
+    default_color = Color(default_value=None, allow_none=True).tag(sync=True)
     scales_metadata = Dict({
         'color': {'dimension': 'color'},
         'projection': {'dimension': 'geo'}
-    }, sync=True)
-    selected = List(sync=True)
-    selected_styles = Dict({'selected_fill': 'Red', 'selected_stroke': None,
-                            'selected_stroke_width': 2.0},
-                           allow_none=True, sync=True)
+    }).tag(sync=True)
+    selected = List(sync=True)  # TODO: Overloaded to prevent None.
+    selected_styles = Dict({
+        'selected_fill': 'Red',
+        'selected_stroke': None,
+        'selected_stroke_width': 2.0
+    }).tag(sync=True)
 
-    map_data = Tuple(topo_load('WorldMapData.json'), sync=True)
+    map_data = Tuple(topo_load('WorldMapData.json')).tag(sync=True)
 
-    _view_name = Unicode('Map', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Map', sync=True)
-    _model_name = Unicode('MapModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/MapModel', sync=True)
+    _view_name = Unicode('Map').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Map').tag(sync=True)
+    _model_name = Unicode('MapModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/MapModel').tag(sync=True)
 
 
 @register_mark('bqplot.GridHeatMap')
 class GridHeatMap(Mark):
 
     """GridHeatMap mark.
+
     Alignment: The tiles can be aligned so that the data matches either the
     start, the end or the midpoints of the tiles. This is controlled by the
     align attribute.
@@ -1085,7 +1067,6 @@ class GridHeatMap(Mark):
 
     Attributes
     ----------
-
     row_align: Enum(['start', 'end'])
         This is only valid if the number of entries in `row` exactly match the
         number of rows in `color` and the `row_scale` is not `OrdinalScale`.
@@ -1101,7 +1082,6 @@ class GridHeatMap(Mark):
         selection.
 
     Data Attributes
-    ---------------
 
     color: numpy.ndarray
         color of the data points (2d array). The number of elements in this array
@@ -1124,24 +1104,26 @@ class GridHeatMap(Mark):
         the column direction.
     """
     # Scaled attributes
-    row = NdArray(sync=True, scaled=True, allow_none=True,
+    row = NdArray(allow_none=True).tag(sync=True, scaled=True,
                   rtype='Number', min_dim=1, max_dim=1, atype='bqplot.Axis')
-    column = NdArray(sync=True, scaled=True, allow_none=True,
+    column = NdArray(allow_none=True).tag(sync=True, scaled=True,
                      rtype='Number', min_dim=1, max_dim=1, atype='bqplot.Axis')
-    color = NdArray(None, allow_none=True, sync=True, scaled=True, rtype='Color',
+    color = NdArray(None, allow_none=True).tag(sync=True, scaled=True, rtype='Color',
                     atype='bqplot.ColorAxis', min_dim=1, max_dim=2)
 
     # Other attributes
-    scales_metadata = Dict({'row': {'orientation': 'vertical', 'dimension': 'y'},
-                            'column': {'orientation': 'horizontal', 'dimension': 'x'},
-                            'color': {'dimension': 'color'}}, sync=True)
+    scales_metadata = Dict({
+        'row': {'orientation': 'vertical', 'dimension': 'y'},
+        'column': {'orientation': 'horizontal', 'dimension': 'x'},
+        'color': {'dimension': 'color'}
+    }).tag(sync=True)
 
-    row_align = Enum(['start', 'end'], default_value='start', sync=True)
-    column_align = Enum(['start', 'end'], default_value='start', sync=True)
+    row_align = Enum(['start', 'end'], default_value='start').tag(sync=True)
+    column_align = Enum(['start', 'end'], default_value='start').tag(sync=True)
 
-    stroke = Color('black', allow_none=True, sync=True)
-    opacity = Float(default_value=1.0, min=0.2, max=1, sync=True, display_name='Opacity')
-    anchor_style = Dict({'fill': 'white', 'stroke': 'blue'}, sync=True)
+    stroke = Color('black', allow_none=True).tag(sync=True)
+    opacity = Float(1.0, min=0.2, max=1).tag(sync=True, display_name='Opacity')
+    anchor_style = Dict({'fill': 'white', 'stroke': 'blue'}).tag(sync=True)
 
     def __init__(self, **kwargs):
         data = kwargs['color']
@@ -1163,7 +1145,7 @@ class GridHeatMap(Mark):
         kwargs['scales'] = scales
         super(GridHeatMap, self).__init__(**kwargs)
 
-    _view_name = Unicode('GridHeatMap', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/GridHeatMap', sync=True)
-    _model_name = Unicode('GridHeatMapModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/GridHeatMapModel', sync=True)
+    _view_name = Unicode('GridHeatMap').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/GridHeatMap').tag(sync=True)
+    _model_name = Unicode('GridHeatMapModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/GridHeatMapModel').tag(sync=True)

--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -206,7 +206,6 @@ def scales(key=None, scales={}):
 
     Parameters
     ----------
-
     key: hashable, optional
         Any variable that can be used as a key for a dictionary
     scales: dictionary
@@ -228,7 +227,6 @@ def scales(key=None, scales={}):
 
     Notes
     -----
-
     Every call to the function figure triggers a call to scales.
 
     The `scales` parameter is ignored if the `key` argument is not Keep and
@@ -264,13 +262,11 @@ def set_lim(min, max, name):
 
     Parameters
     ----------
-
     name: hashable
         Any variable that can be used as a key for a dictionary
 
     Raises
     ------
-
     KeyError
         When no context figure is associated with the provided key.
 
@@ -289,7 +285,6 @@ def axes(mark=None, options={}, **kwargs):
 
     Parameters
     ----------
-
     mark: Mark or None (default: None)
         The mark to inspect to create axes. If None, the last mark drawn is
         used instead.
@@ -342,7 +337,6 @@ def _draw_mark(mark_type, options={}, axes_options={}, **kwargs):
 
     Parameters
     ----------
-
     mark_type: type
         The type of mark to be drawn
     options: dict (default: {})
@@ -407,7 +401,6 @@ def plot(*args, **kwargs):
 
     Parameters
     ----------
-
     x: numpy.ndarray or list, 1d or 2d (optional)
         The x-coordinates of the plotted line. When not provided, the function
         defaults to `numpy.arange(len(y))`
@@ -477,7 +470,6 @@ def ohlc(*args, **kwargs):
 
     Parameters
     ----------
-
     x: numpy.ndarray or list, 1d (optional)
         The x-coordinates of the plotted line. When not provided, the function
         defaults to `numpy.arange(len(y))`.
@@ -532,7 +524,6 @@ def hist(sample, options={}, **kwargs):
 
     Parameters
     ----------
-
     sample: numpy.ndarray, 1d
         The sample for which the histogram must be generated.
     options: dict (default: {})
@@ -586,7 +577,6 @@ def pie(sizes, **kwargs):
 
     Parameters
     ----------
-
     sizes: numpy.ndarray, 1d
         The proportions to be represented by the Pie.
     options: dict (default: {})
@@ -628,7 +618,6 @@ def geo(map_data, **kwargs):
 
     Parameters
     ----------
-
     options: dict (default: {})
         Options for the scales to be created. If a scale labeled 'x' is
         required for that mark, options['x'] contains optional keyword
@@ -658,7 +647,6 @@ def _add_interaction(int_type, **kwargs):
 
     Parameters
     ----------
-
     int_type: type
         The type of interaction to be added.
     """

--- a/bqplot/scales.py
+++ b/bqplot/scales.py
@@ -69,7 +69,6 @@ class Scale(Widget):
 
     Attributes
     ----------
-
     scale_types: dict (class-level attribute)
         A registry of existing scale types.
     domain_class: type (default: Float)
@@ -81,14 +80,14 @@ class Scale(Widget):
         or not
     """
     scale_types = {}
-    domain_class = Type(Float, sync=False)
-    reverse = Bool(False, sync=True)
-    allow_padding = Bool(True, sync=True)
+    domain_class = Type(Float)
+    reverse = Bool().tag(sync=True)
+    allow_padding = Bool(True).tag(sync=True)
 
-    _view_name = Unicode('Scale', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Scale', sync=True)
-    _model_name = Unicode('ScaleModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/ScaleModel', sync=True)
+    _view_name = Unicode('Scale').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Scale').tag(sync=True)
+    _model_name = Unicode('ScaleModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/ScaleModel').tag(sync=True)
     _ipython_display_ = None  # We cannot display a scale outside of a figure
 
 
@@ -99,9 +98,9 @@ class GeoScale(Scale):
     The GeoScale represents a mapping between topographic data and a
     2d visual representation.
     """
-    _view_module = Unicode('nbextensions/bqplot/GeoScale', sync=True)
-    _model_name = Unicode('GeoScaleModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/GeoScaleModel', sync=True)
+    _view_module = Unicode('nbextensions/bqplot/GeoScale').tag(sync=True)
+    _model_name = Unicode('GeoScaleModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/GeoScaleModel').tag(sync=True)
 
 
 @register_scale('bqplot.Mercator')
@@ -114,7 +113,6 @@ class Mercator(GeoScale):
 
     Attributes
     ----------
-
     scale_factor: float (default: 190)
         Specifies the scale value for the projection
     center: list (default: (0, 60))
@@ -128,13 +126,13 @@ class Mercator(GeoScale):
         the associated data type / domain type
     """
 
-    scale_factor = Float(190., sync=True)
-    center = Tuple((0, 60), sync=True)
-    rotate = Tuple((0, 0), sync=True)
+    scale_factor = Float(190).tag(sync=True)
+    center = Tuple((0, 60)).tag(sync=True)
+    rotate = Tuple((0, 0)).tag(sync=True)
     rtype = '(Number, Number)'
     dtype = np.number
-    _view_name = Unicode('Mercator', sync=True)
-    _model_name = Unicode('MercatorModel', sync=True)
+    _view_name = Unicode('Mercator').tag(sync=True)
+    _model_name = Unicode('MercatorModel').tag(sync=True)
 
 
 @register_scale('bqplot.Albers')
@@ -148,7 +146,6 @@ class Albers(GeoScale):
 
     Attributes
     ----------
-
     scale_factor: float (default: 250)
         Specifies the scale value for the projection
     rotate: tuple (default: (96, 0))
@@ -167,15 +164,15 @@ class Albers(GeoScale):
         the associated data type / domain type
     """
 
-    scale_factor = Float(250., sync=True)
-    rotate = Tuple((96, 0), sync=True)
-    center = Tuple((0, 60), sync=True)
-    parallels = Tuple((29.5, 45.5), sync=True)
-    precision = Float(0.1, sync=True)
+    scale_factor = Float(250).tag(sync=True)
+    rotate = Tuple((96, 0)).tag(sync=True)
+    center = Tuple((0, 60)).tag(sync=True)
+    parallels = Tuple((29.5, 45.5)).tag(sync=True)
+    precision = Float(0.1).tag(sync=True)
     rtype = '(Number, Number)'
     dtype = np.number
-    _view_name = Unicode('Albers', sync=True)
-    _model_name = Unicode('AlbersModel', sync=True)
+    _view_name = Unicode('Albers').tag(sync=True)
+    _model_name = Unicode('AlbersModel').tag(sync=True)
 
 
 @register_scale('bqplot.AlbersUSA')
@@ -186,7 +183,6 @@ class AlbersUSA(GeoScale):
 
     Attributes
     ----------
-
     scale_factor: float (default: 1200)
         Specifies the scale value for the projection
     rtype: (Number, Number) (class-level attribute)
@@ -196,11 +192,11 @@ class AlbersUSA(GeoScale):
         the associated data type / domain type
     """
 
-    scale_factor = Float(1200., sync=True)
+    scale_factor = Float(1200).tag(sync=True)
     rtype = '(Number, Number)'
     dtype = np.number
-    _view_name = Unicode('AlbersUSA', sync=True)
-    _model_name = Unicode('AlbersUSAModel', sync=True)
+    _view_name = Unicode('AlbersUSA').tag(sync=True)
+    _model_name = Unicode('AlbersUSAModel').tag(sync=True)
 
 
 @register_scale('bqplot.EquiRectangular')
@@ -212,19 +208,18 @@ class EquiRectangular(GeoScale):
 
     Attributes
     ----------
-
     scale_factor: float (default: 145)
        Specifies the scale value for the projection
     center: list (default: (0, 60))
         Specifies the longitude and latitude where the map is centered.
     """
 
-    scale_factor = Float(145., sync=True)
-    center = Tuple((0, 60), sync=True)
+    scale_factor = Float(145.0).tag(sync=True)
+    center = Tuple((0, 60)).tag(sync=True)
     rtype = '(Number, Number)'
     dtype = np.number
-    _view_name = Unicode('EquiRectangular', sync=True)
-    _model_name = Unicode('EquiRectangularModel', sync=True)
+    _view_name = Unicode('EquiRectangular').tag(sync=True)
+    _model_name = Unicode('EquiRectangularModel').tag(sync=True)
 
 
 @register_scale('bqplot.Orthographic')
@@ -237,7 +232,6 @@ class Orthographic(GeoScale):
 
     Attributes
     ----------
-
     scale_factor: float (default: 145)
        Specifies the scale value for the projection
     center: list (default: (0, 60))
@@ -251,15 +245,15 @@ class Orthographic(GeoScale):
         specified value in pixels.
     """
 
-    scale_factor = Float(145., sync=True)
-    center = Tuple((0, 60), sync=True)
-    rotate = Tuple((0, 0), sync=True)
-    clip_angle = Float(default_value=90., min=0., max=360., sync=True)
-    precision = Float(0.1, sync=True)
+    scale_factor = Float(145.0).tag(sync=True)
+    center = Tuple((0, 60)).tag(sync=True)
+    rotate = Tuple((0, 0)).tag(sync=True)
+    clip_angle = Float(90.0, min=0.0, max=360.0).tag(sync=True)
+    precision = Float(0.1).tag(sync=True)
     rtype = '(Number, Number)'
     dtype = np.number
-    _view_name = Unicode('Orthographic', sync=True)
-    _model_name = Unicode('OrthographicModel', sync=True)
+    _view_name = Unicode('Orthographic').tag(sync=True)
+    _model_name = Unicode('OrthographicModel').tag(sync=True)
 
 
 @register_scale('bqplot.Gnomonic')
@@ -271,7 +265,6 @@ class Gnomonic(GeoScale):
 
     Attributes
     ----------
-
     scale_factor: float (default: 145)
        Specifies the scale value for the projection
     center: list (default: (0, 60))
@@ -283,14 +276,14 @@ class Gnomonic(GeoScale):
         Specifies the clipping circle radius to the specified angle in degrees.
     """
 
-    scale_factor = Float(145., sync=True)
-    center = Tuple((0, 60), sync=True)
-    precision = Float(0.1, sync=True)
-    clip_angle = Float(default_value=89.999, min=0., max=360., sync=True)
+    scale_factor = Float(145.0).tag(sync=True)
+    center = Tuple((0, 60)).tag(sync=True)
+    precision = Float(0.1).tag(sync=True)
+    clip_angle = Float(89.999, min=0.0, max=360.0).tag(sync=True)
     rtype = '(Number, Number)'
     dtype = np.number
-    _view_name = Unicode('Gnomonic', sync=True)
-    _model_name = Unicode('GnomonicModel', sync=True)
+    _view_name = Unicode('Gnomonic').tag(sync=True)
+    _model_name = Unicode('GnomonicModel').tag(sync=True)
 
 
 @register_scale('bqplot.Stereographic')
@@ -303,7 +296,6 @@ class Stereographic(GeoScale):
 
     Attributes
     ----------
-
     scale_factor: float (default: 250)
         Specifies the scale value for the projection
     rotate: tuple (default: (96, 0))
@@ -317,15 +309,15 @@ class Stereographic(GeoScale):
         Specifies the clipping circle radius to the specified angle in degrees.
     """
 
-    scale_factor = Float(145., sync=True)
-    center = Tuple((0, 60), sync=True)
-    precision = Float(0.1, sync=True)
-    rotate = Tuple((96, 0), sync=True)
-    clip_angle = Float(default_value=179.9999, min=0., max=360., sync=True)
+    scale_factor = Float(145.0).tag(sync=True)
+    center = Tuple((0, 60)).tag(sync=True)
+    precision = Float(0.1).tag(sync=True)
+    rotate = Tuple((96, 0)).tag(sync=True)
+    clip_angle = Float(179.9999, min=0.0, max=360.0).tag(sync=True)
     rtype = '(Number, Number)'
     dtype = np.number
-    _view_name = Unicode('Stereographic', sync=True)
-    _model_name = Unicode('StereographicModel', sync=True)
+    _view_name = Unicode('Stereographic').tag(sync=True)
+    _model_name = Unicode('StereographicModel').tag(sync=True)
 
 
 @register_scale('bqplot.LinearScale')
@@ -337,7 +329,6 @@ class LinearScale(Scale):
 
     Attributes
     ----------
-
     min: float or None (default: None)
         if not None, min is the minimal value of the domain
     max: float or None (default: None)
@@ -350,13 +341,13 @@ class LinearScale(Scale):
     """
     rtype = 'Number'
     dtype = np.number
-    min = Float(default_value=None, sync=True, allow_none=True)
-    max = Float(default_value=None, sync=True, allow_none=True)
+    min = Float(None, allow_none=True).tag(sync=True)
+    max = Float(None, allow_none=True).tag(sync=True)
 
-    _view_name = Unicode('LinearScale', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/LinearScale', sync=True)
-    _model_name = Unicode('LinearScaleModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/LinearScaleModel', sync=True)
+    _view_name = Unicode('LinearScale').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/LinearScale').tag(sync=True)
+    _model_name = Unicode('LinearScaleModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/LinearScaleModel').tag(sync=True)
 
 
 @register_scale('bqplot.LogScale')
@@ -368,7 +359,6 @@ class LogScale(Scale):
 
     Attributes
     ----------
-
     min: float or None (default: None)
         if not None, min is the minimal value of the domain
     max: float or None (default: None)
@@ -381,13 +371,13 @@ class LogScale(Scale):
     """
     rtype = 'Number'
     dtype = np.number
-    min = Float(default_value=None, sync=True, allow_none=True)
-    max = Float(default_value=None, sync=True, allow_none=True)
+    min = Float(None, allow_none=True).tag(sync=True)
+    max = Float(None, allow_none=True).tag(sync=True)
 
-    _view_name = Unicode('LogScale', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/LogScale', sync=True)
-    _model_name = Unicode('LogScaleModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/LogScaleModel', sync=True)
+    _view_name = Unicode('LogScale').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/LogScale').tag(sync=True)
+    _model_name = Unicode('LogScaleModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/LogScaleModel').tag(sync=True)
 
 
 @register_scale('bqplot.DateScale')
@@ -399,7 +389,6 @@ class DateScale(Scale):
 
     Attributes
     ----------
-
     min: Date or None (default: None)
         if not None, min is the minimal value of the domain
     max: Date (default: None)
@@ -414,14 +403,14 @@ class DateScale(Scale):
     """
     rtype = 'Number'
     dtype = np.datetime64
-    domain_class = Type(Date, sync=False)
-    min = Date(default_value=None, sync=True, allow_none=True)
-    max = Date(default_value=None, sync=True, allow_none=True)
+    domain_class = Type(Date)
+    min = Date(default_value=None, allow_none=True).tag(sync=True)
+    max = Date(default_value=None, allow_none=True).tag(sync=True)
 
-    _view_name = Unicode('DateScale', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/DateScale', sync=True)
-    _model_name = Unicode('DateScaleModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/DateScaleModel', sync=True)
+    _view_name = Unicode('DateScale').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/DateScale').tag(sync=True)
+    _model_name = Unicode('DateScaleModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/DateScaleModel').tag(sync=True)
 
 
 @register_scale('bqplot.OrdinalScale')
@@ -433,7 +422,6 @@ class OrdinalScale(Scale):
 
     Attributes
     ----------
-
     domain: list (default: [])
         The discrete values mapped by the ordinal scale
     rtype: string (class-level attribute)
@@ -444,12 +432,12 @@ class OrdinalScale(Scale):
     """
     rtype = 'Number'
     dtype = np.str
-    domain = List(sync=True)
+    domain = List().tag(sync=True)
 
-    _view_name = Unicode('OrdinalScale', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/OrdinalScale', sync=True)
-    _model_name = Unicode('OrdinalScaleModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/OrdinalScaleModel', sync=True)
+    _view_name = Unicode('OrdinalScale').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/OrdinalScale').tag(sync=True)
+    _model_name = Unicode('OrdinalScaleModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/OrdinalScaleModel').tag(sync=True)
 
 
 @register_scale('bqplot.ColorScale')
@@ -461,7 +449,6 @@ class ColorScale(Scale):
 
     Attributes
     ----------
-
     scale_type: {'linear'}
         scale type
     colors: list of colors (default: [])
@@ -481,17 +468,17 @@ class ColorScale(Scale):
     """
     rtype = 'Color'
     dtype = np.number
-    scale_type = Enum(['linear'], default_value='linear', sync=True)
-    colors = List(trait=Color(default_value=None, allow_none=True), sync=True)
-    min = Float(default_value=None, sync=True, allow_none=True)
-    max = Float(default_value=None, sync=True, allow_none=True)
-    mid = Float(default_value=None, sync=True, allow_none=True)
-    scheme = Unicode('RdYlGn', sync=True)
+    scale_type = Enum(['linear'], default_value='linear').tag(sync=True)
+    colors = List(trait=Color(default_value=None, allow_none=True)).tag(sync=True)
+    min = Float(None, allow_none=True).tag(sync=True)
+    max = Float(None, allow_none=True).tag(sync=True)
+    mid = Float(None, allow_none=True).tag(sync=True)
+    scheme = Unicode('RdYlGn').tag(sync=True)
 
-    _view_name = Unicode('LinearColorScale', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/LinearColorScale', sync=True)
-    _model_name = Unicode('LinearColorScaleModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/LinearColorScaleModel', sync=True)
+    _view_name = Unicode('LinearColorScale').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/LinearColorScale').tag(sync=True)
+    _model_name = Unicode('LinearColorScaleModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/LinearColorScaleModel').tag(sync=True)
 
 
 @register_scale('bqplot.DateColorScale')
@@ -503,7 +490,6 @@ class DateColorScale(ColorScale):
 
     Attributes
     ----------
-
     min: Date or None (default: None)
         if not None, min is the minimal value of the domain
     max: Date or None (default: None)
@@ -518,14 +504,14 @@ class DateColorScale(ColorScale):
     """
     rtype = 'Color'
     dtype = np.datetime64
-    min = Date(default_value=None, sync=True, allow_none=True)
-    max = Date(default_value=None, sync=True, allow_none=True)
-    mid = Unicode(default_value=None, sync=True, allow_none=True)
+    min = Date(default_value=None, allow_none=True).tag(sync=True)
+    max = Date(default_value=None, allow_none=True).tag(sync=True)
+    mid = Unicode(default_value=None, allow_none=True).tag(sync=True)
 
-    _view_name = Unicode('DateColorScale', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/DateColorScale', sync=True)
-    _model_name = Unicode('DateColorScaleModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/DateColorScaleModel', sync=True)
+    _view_name = Unicode('DateColorScale').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/DateColorScale').tag(sync=True)
+    _model_name = Unicode('DateColorScaleModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/DateColorScaleModel').tag(sync=True)
 
 
 @register_scale('bqplot.OrdinalColorScale')
@@ -537,7 +523,6 @@ class OrdinalColorScale(ColorScale):
 
     Attributes
     ----------
-
     domain: list (default: [])
         The discrete values mapped by the ordinal scales.
     rtype: string (class-level attribute)
@@ -548,9 +533,9 @@ class OrdinalColorScale(ColorScale):
     """
     rtype = 'Color'
     dtype = np.str
-    domain = List(sync=True)
+    domain = List().tag(sync=True)
 
-    _view_name = Unicode('OrdinalColorScale', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/OrdinalColorScale', sync=True)
-    _model_name = Unicode('OrdinalScaleModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/OrdinalScaleModel', sync=True)
+    _view_name = Unicode('OrdinalColorScale').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/OrdinalColorScale').tag(sync=True)
+    _model_name = Unicode('OrdinalScaleModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/OrdinalScaleModel').tag(sync=True)

--- a/bqplot/toolbar.py
+++ b/bqplot/toolbar.py
@@ -61,18 +61,17 @@ class Toolbar(DOMWidget):
 
     Attributes
     ----------
-
     figure: instance of Figure
         The figure to which the toolbar will apply.
     """
 
-    figure = Instance(Figure, sync=True, **widget_serialization)
+    figure = Instance(Figure).tag(sync=True, **widget_serialization)
 
-    _panning = Bool(read_only=True, sync=True)
+    _panning = Bool(read_only=True).tag(sync=True)
     _panzoom = Instance(PanZoom, default_value=None, allow_none=True,
-                        read_only=True, sync=True, **widget_serialization)
+                        read_only=True).tag(sync=True, **widget_serialization)
 
-    _view_name = Unicode('Toolbar', sync=True)
-    _view_module = Unicode('nbextensions/bqplot/Toolbar', sync=True)
-    _model_name = Unicode('ToolbarModel', sync=True)
-    _model_module = Unicode('nbextensions/bqplot/Toolbar', sync=True)
+    _view_name = Unicode('Toolbar').tag(sync=True)
+    _view_module = Unicode('nbextensions/bqplot/Toolbar').tag(sync=True)
+    _model_name = Unicode('ToolbarModel').tag(sync=True)
+    _model_module = Unicode('nbextensions/bqplot/Toolbar').tag(sync=True)


### PR DESCRIPTION
Migration to the new traitlets API: use `.tag` to specify metadata.