### PR TITLE
scales domain setting bug fix

### DIFF
--- a/bqplot/nbextension/BarsModel.js
+++ b/bqplot/nbextension/BarsModel.js
@@ -122,9 +122,9 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
             });
             if(color_scale && color.length > 0) {
                     if(!this.get("preserve_domain").color) {
-                        color_scale.compute_and_set_domain(color, this.id);
+                        color_scale.compute_and_set_domain(color, this.id + "_color");
                     } else {
-                        color_scale.del_domain([], this.id);
+                        color_scale.del_domain([], this.id + "_color");
                     }
             }
         },
@@ -139,17 +139,17 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
             if(!this.get("preserve_domain").x) {
                 x_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                     return elem.key;
-                }), this.id);
+                }), this.id + "_x");
             }
             else {
-                x_scale.del_domain([], this.id);
+                x_scale.del_domain([], this.id + "_x");
             }
 
             if(!this.get("preserve_domain").y) {
                 if(this.get("type") === "stacked") {
                     y_scale.compute_and_set_domain([d3.min(this.mark_data, function(c) { return c.neg_max; }),
                                                     d3.max(this.mark_data, function(c) { return c.pos_max; }), this.base_value],
-                                                    this.id);
+                                                    this.id + "_y");
                 } else {
                     var min = d3.min(this.mark_data,
                         function(c) {
@@ -162,10 +162,10 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
                             return val.y;
                         });
                     });
-                    y_scale.compute_and_set_domain([min, max, this.base_value], this.id);
+                    y_scale.compute_and_set_domain([min, max, this.base_value], this.id + "_y");
                 }
             } else {
-                y_scale.del_domain([], this.id);
+                y_scale.del_domain([], this.id + "_y");
             }
         },
     });

--- a/bqplot/nbextension/BoxplotModel.js
+++ b/bqplot/nbextension/BoxplotModel.js
@@ -58,9 +58,9 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
             if(!this.get("preserve_domain").x && this.mark_data) {
                 x_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                     return elem[0];
-                }), this.id);
+                }), this.id + "_x");
             } else {
-                x_scale.del_domain([], this.id);
+                x_scale.del_domain([], this.id + "_x");
             }
             if(!this.get("preserve_domain").y && this.mark_data) {
                //The values are sorted, so we are using that to calculate the min/max
@@ -73,10 +73,10 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
                     return values[values.length-1];
                 }));
 
-                y_scale.set_domain([min,max], this.id);
+                y_scale.set_domain([min,max], this.id + "_y");
 
             } else {
-                y_scale.del_domain([], this.id);
+                y_scale.del_domain([], this.id + "_y");
             }
         },
     });

--- a/bqplot/nbextension/GridHeatMapModel.js
+++ b/bqplot/nbextension/GridHeatMapModel.js
@@ -66,23 +66,23 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
             var color_scale = scales.color;
 
             if(!this.get("preserve_domain").row) {
-                y_scale.compute_and_set_domain(this.rows, this.id);
+                y_scale.compute_and_set_domain(this.rows, this.id + "_row");
             } else {
-                y_scale.del_domain([], this.id);
+                y_scale.del_domain([], this.id + "_row");
             }
 
             if(!this.get("preserve_domain").column) {
-                x_scale.compute_and_set_domain(this.columns, this.id);
+                x_scale.compute_and_set_domain(this.columns, this.id + "_column");
             } else {
-                x_scale.del_domain([], this.id);
+                x_scale.del_domain([], this.id + "_column");
             }
             if(color_scale !== null && color_scale !== undefined) {
                 if(!this.get("preserve_domain").color) {
                     color_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                         return elem.color;
-                    }), this.id);
+                    }), this.id + "_color");
                 } else {
-                    color_scale.del_domain([], this.id);
+                    color_scale.del_domain([], this.id + "_color");
                 }
             }
         },

--- a/bqplot/nbextension/HistModel.js
+++ b/bqplot/nbextension/HistModel.js
@@ -35,9 +35,9 @@ define(["./components/d3/d3", "./MarkModel"], function(d3, MarkModelModule) {
             // Draw, while update_data is generally followed by a Draw.
 
             if(!this.get("preserve_domain").sample) {
-                x_scale.compute_and_set_domain(x_data, this.id);
+                x_scale.compute_and_set_domain(x_data, this.id + "_sample");
             } else {
-                x_scale.del_domain([], this.id);
+                x_scale.del_domain([], this.id + "_sample");
             }
 
             this.min_x = x_scale.domain[0];
@@ -91,7 +91,7 @@ define(["./components/d3/d3", "./MarkModel"], function(d3, MarkModelModule) {
             if(!this.get("preserve_domain").count) {
                 y_scale.set_domain([0, d3.max(this.mark_data, function(d) {
                     return d.y;
-                }) * 1.05], this.id);
+                }) * 1.05], this.id + "_count");
             }
         },
         create_uniform_bins: function(min_val, max_val, num_bins) {

--- a/bqplot/nbextension/LinesModel.js
+++ b/bqplot/nbextension/LinesModel.js
@@ -106,25 +106,25 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
             if(!this.get("preserve_domain").x) {
                 x_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                     return elem.values.map(function(d) { return d.x; });
-                }), this.id);
+                }), this.id + "_x");
             } else {
-                x_scale.del_domain([], this.id);
+                x_scale.del_domain([], this.id + "_x");
             }
 
             if(!this.get("preserve_domain").y) {
                 y_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                     return elem.values.map(function(d) { return d.y; });
-                }), this.id);
+                }), this.id + "_y");
             } else {
-                y_scale.del_domain([], this.id);
+                y_scale.del_domain([], this.id + "_y");
             }
             if(color_scale !== null && color_scale !== undefined) {
                 if(!this.get("preserve_domain").color) {
                     color_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                         return elem.color;
-                    }), this.id);
+                    }), this.id + "_color");
                 } else {
-                    color_scale.del_domain([], this.id);
+                    color_scale.del_domain([], this.id + "_color");
                 }
             }
         },
@@ -184,15 +184,15 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
             var width_scale = scales.width;
 
             if(!this.get("preserve_domain").x) {
-                x_scale.compute_and_set_domain(this.x_data[0].slice(0, this.data_len), this.id);
+                x_scale.compute_and_set_domain(this.x_data[0].slice(0, this.data_len), this.id + "_x" + );
             } else {
-                x_scale.del_domain([], this.id);
+                x_scale.del_domain([], this.id + "_x");
             }
 
             if(!this.get("preserve_domain").y) {
-                y_scale.compute_and_set_domain(this.y_data[0].slice(0, this.data_len), this.id);
+                y_scale.compute_and_set_domain(this.y_data[0].slice(0, this.data_len), this.id + "_y");
             } else {
-                y_scale.del_domain([], this.id);
+                y_scale.del_domain([], this.id + "_y");
             }
 
             if(color_scale !== null && color_scale !== undefined) {
@@ -201,9 +201,9 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
                         return elem.values.map(function(d) {
                             return d.color;
                         });
-                    }), this.id);
+                    }), this.id + "_color");
                 } else {
-                    color_scale.del_domain([], this.id);
+                    color_scale.del_domain([], this.id + "_color");
                 }
             }
             if(width_scale !== null && width_scale !== undefined) {
@@ -212,9 +212,9 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
                         return elem.values.map(function(d) {
                             return d.size;
                         });
-                    }), this.id);
+                    }), this.id + "_width");
                 } else {
-                    width_scale.del_domain([], this.id);
+                    width_scale.del_domain([], this.id + "_width");
                 }
             }
         },

--- a/bqplot/nbextension/LinesModel.js
+++ b/bqplot/nbextension/LinesModel.js
@@ -184,7 +184,7 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
             var width_scale = scales.width;
 
             if(!this.get("preserve_domain").x) {
-                x_scale.compute_and_set_domain(this.x_data[0].slice(0, this.data_len), this.id + "_x" + );
+                x_scale.compute_and_set_domain(this.x_data[0].slice(0, this.data_len), this.id + "_x");
             } else {
                 x_scale.del_domain([], this.id + "_x");
             }

--- a/bqplot/nbextension/MapModel.js
+++ b/bqplot/nbextension/MapModel.js
@@ -41,9 +41,9 @@ define(["nbextensions/widgets/widgets/js/widget", "./MarkModel", "underscore"],
                     color_scale.compute_and_set_domain(
                         Object.keys(color_data).map(function (d) {
                             return color_data[d];
-                        }), this.id);
+                        }), this.id + "_color");
                 } else {
-                    color_scale.del_domain([], this.id);
+                    color_scale.del_domain([], this.id + "_color");
                 }
             }
         },

--- a/bqplot/nbextension/MarkModel.js
+++ b/bqplot/nbextension/MarkModel.js
@@ -51,7 +51,7 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3", "./BaseM
             // disassociates the mark with the scale
             this.dirty = true;
             for (var key in scales) {
-                scales[key].del_domain([], this.id);
+                scales[key].del_domain([], this.id + "_" + key);
             }
             this.dirty = false;
             //TODO: Check if the views are being removed

--- a/bqplot/nbextension/OHLCModel.js
+++ b/bqplot/nbextension/OHLCModel.js
@@ -134,10 +134,10 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
                         return d[0];
                     }));
                     if(max instanceof Date) max = max.getTime();
-                    x_scale.set_domain([min - min_x_dist/2, max + min_x_dist/2], this.id);
+                    x_scale.set_domain([min - min_x_dist/2, max + min_x_dist/2], this.id + "_x");
                 }
             } else {
-                x_scale.del_domain([], this.id);
+                x_scale.del_domain([], this.id + "_x");
             }
 
             // Y Scale
@@ -157,9 +157,9 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
                     return (d[1][top] > d[1][bottom]) ? d[1][top] : d[1][bottom];
                 }));
                 if(max instanceof  Date) max = max.getTime();
-                y_scale.set_domain([min - max_y_height, max + max_y_height], this.id);
+                y_scale.set_domain([min - max_y_height, max + max_y_height], this.id + "_y");
             } else {
-                y_scale.del_domain([], this.id);
+                y_scale.del_domain([], this.id + "_y");
             }
         },
         get_data_dict: function(data, index) {

--- a/bqplot/nbextension/PieModel.js
+++ b/bqplot/nbextension/PieModel.js
@@ -60,9 +60,9 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
             var color_scale = this.get("scales").color;
             if(color_scale) {
                 if(!this.get("preserve_domain").color) {
-                    color_scale.compute_and_set_domain(color, this.id);
+                    color_scale.compute_and_set_domain(color, this.id + "_color");
                 } else {
-                    color_scale.del_domain([], this.id);
+                    color_scale.del_domain([], this.id + "_color");
                 }
             }
         },
@@ -78,16 +78,16 @@ define(["./components/d3/d3", "./MarkModel", "underscore"], function(d3, MarkMod
                 var x = (x_scale.type === "date") ?
                     this.get_date_elem("x") : this.get("x");
                 if(!this.get("preserve_domain").x) {
-                    x_scale.compute_and_set_domain([x], this.id);
+                    x_scale.compute_and_set_domain([x], this.id + "_x");
                 } else {
-                    x_scale.del_domain([], this.id);
+                    x_scale.del_domain([], this.id + "_x");
                 }
             }
             if(y_scale) {
                 if(!this.get("preserve_domain").y) {
-                    y_scale.compute_and_set_domain([this.get("y")], this.id);
+                    y_scale.compute_and_set_domain([this.get("y")], this.id + "_y");
                 } else {
-                    y_scale.del_domain([], this.id);
+                    y_scale.del_domain([], this.id + "_y");
                 }
             }
         },

--- a/bqplot/nbextension/ScatterModel.js
+++ b/bqplot/nbextension/ScatterModel.js
@@ -109,64 +109,19 @@ define(["./components/d3/d3", "./MarkModel", "underscore"],
             // color scale needs an issue in DateScaleModel to be fixed. It
             // should be moved here as soon as that is fixed.
 
-            var scales = this.get("scales"),
-                x_scale = scales.x,
-                y_scale = scales.y,
-                size_scale = scales.size,
-                opacity_scale = scales.opacity,
-                skew_scale = scales.skew,
-                rotation_scale = scales.rotation;
-
-            if(!this.get("preserve_domain").x) {
-                x_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
-                    return elem.x;
-                }), this.id + "_x");
-            } else {
-                x_scale.del_domain([], this.id + "_x");
-            }
-            if(!this.get("preserve_domain").y) {
-                y_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
-                    return elem.y;
-                }), this.id + "_y");
-            } else {
-                y_scale.del_domain([], this.id + "_y");
-            }
-            if(size_scale) {
-                if(!this.get("preserve_domain").size) {
-                    size_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
-                        return elem.size;
-                    }), this.id + "_size");
-                } else {
-                    size_scale.del_domain([], this.id + "_size");
+           var scales = this.get("scales");
+           for (var key in scales) {
+                if(scales.hasOwnProperty(key) && key != "color") {
+                    var scale = scales[key];
+                    if(!this.get("preserve_domain")[key]) {
+                        scale.compute_and_set_domain(this.mark_data.map(function(elem) {
+                            return elem[key];
+                        }), this.id + key);
+                    } else {
+                        scale.del_domain([], this.id + key);
+                    }
                 }
-            }
-            if(opacity_scale) {
-                if(!this.get("preserve_domain").opacity) {
-                    opacity_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
-                        return elem.opacity;
-                    }), this.id + "_opacity");
-                } else {
-                    opacity_scale.del_domain([], this.id + "_opacity");
-                }
-            }
-            if(skew_scale) {
-                if(!this.get("preserve_domain").skew) {
-                    skew_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
-                        return elem.skew;
-                    }), this.id + "_skew");
-                } else {
-                    skew_scale.del_domain([], this.id + "_skew");
-                }
-            }
-            if(rotation_scale) {
-                if(!this.get("preserve_domain").rotation) {
-                    rotation_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
-                        return elem.rotation;
-                    }), this.id + "_rotation");
-                } else {
-                    rotation_scale.del_domain([], this.id + "_rotation");
-                }
-            }
+           }
 
         },
     });

--- a/bqplot/nbextension/ScatterModel.js
+++ b/bqplot/nbextension/ScatterModel.js
@@ -57,9 +57,9 @@ define(["./components/d3/d3", "./MarkModel", "underscore"],
 
                 if(color_scale) {
                     if(!this.get("preserve_domain").color) {
-                        color_scale.compute_and_set_domain(color, this.id);
+                        color_scale.compute_and_set_domain(color, this.id + "_color");
                     } else {
-                        color_scale.del_domain([], this.id);
+                        color_scale.del_domain([], this.id + "_color");
                     }
                 }
 

--- a/bqplot/nbextension/ScatterModel.js
+++ b/bqplot/nbextension/ScatterModel.js
@@ -120,51 +120,51 @@ define(["./components/d3/d3", "./MarkModel", "underscore"],
             if(!this.get("preserve_domain").x) {
                 x_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                     return elem.x;
-                }), this.id);
+                }), this.id + "_x");
             } else {
-                x_scale.del_domain([], this.id);
+                x_scale.del_domain([], this.id + "_x");
             }
             if(!this.get("preserve_domain").y) {
                 y_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                     return elem.y;
-                }), this.id);
+                }), this.id + "_y");
             } else {
-                y_scale.del_domain([], this.id);
+                y_scale.del_domain([], this.id + "_y");
             }
             if(size_scale) {
                 if(!this.get("preserve_domain").size) {
                     size_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                         return elem.size;
-                    }), this.id);
+                    }), this.id + "_size");
                 } else {
-                    size_scale.del_domain([], this.id);
+                    size_scale.del_domain([], this.id + "_size");
                 }
             }
             if(opacity_scale) {
                 if(!this.get("preserve_domain").opacity) {
                     opacity_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                         return elem.opacity;
-                    }), this.id);
+                    }), this.id + "_opacity");
                 } else {
-                    opacity_scale.del_domain([], this.id);
+                    opacity_scale.del_domain([], this.id + "_opacity");
                 }
             }
             if(skew_scale) {
                 if(!this.get("preserve_domain").skew) {
                     skew_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                         return elem.skew;
-                    }), this.id);
+                    }), this.id + "_skew");
                 } else {
-                    skew_scale.del_domain([], this.id);
+                    skew_scale.del_domain([], this.id + "_skew");
                 }
             }
             if(rotation_scale) {
                 if(!this.get("preserve_domain").rotation) {
                     rotation_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                         return elem.rotation;
-                    }), this.id);
+                    }), this.id + "_rotation");
                 } else {
-                    rotation_scale.del_domain([], this.id);
+                    rotation_scale.del_domain([], this.id + "_rotation");
                 }
             }
 


### PR DESCRIPTION
There was an issue with scales in the same mark being used for different attributes. Suppose the same scale is used for `x` and `y`, then the last attribute to be set gets control of the domain as the key in the dictionary was the mark model id. 

Adding the attribute as a suffix to the key so that it does not over write values set by other attributes.