### PR TITLE
Styling options for pie labels

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -916,7 +916,7 @@ class Pie(Mark):
         color of the labels
     font_size: string (default: '14px')
         label font size in px, em or ex
-    font_weight: {'bold', 'normal', 'bolder'}
+    font_weight: {'bold', 'normal', 'bolder'} (default: 'normal')
         label font weight
 
     Data Attributes
@@ -962,9 +962,9 @@ class Pie(Mark):
     end_angle = Float(360.0).tag(sync=True)
     display_labels = Bool(True).tag(sync=True)
     label_color = Color(None, allow_none=True).tag(sync=True)
-    font_size = Unicode(default_value='14px').tag(sync=True)
+    font_size = Unicode(default_value='10px').tag(sync=True)
     font_weight = Enum(['bold', 'normal', 'bolder'], 
-                       default_value='bold').tag(sync=True)
+                       default_value='normal').tag(sync=True)
 
     _view_name = Unicode('Pie').tag(sync=True)
     _model_name = Unicode('PieModel').tag(sync=True)

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -779,7 +779,7 @@ class Label(Mark):
     text: string (default: '')
         text to be displayed
     font_size: string (default: '14px')
-        front size in px, em or ex
+        font size in px, em or ex
     font_weight: {'bold', 'normal', 'bolder'}
         font weight of the caption
     align: {'start', 'middle', 'end'}
@@ -910,6 +910,14 @@ class Pie(Mark):
         start angle of the pie (from top), in degrees
     end_angle: Float (default: 360.0)
         end angle of the pie (from top), in degrees
+    display_labels: bool (default: True)
+        display the labels on the pie
+    label_color: Color or None (default: None)
+        color of the labels
+    font_size: string (default: '14px')
+        label font size in px, em or ex
+    font_weight: {'bold', 'normal', 'bolder'}
+        label font weight
 
     Data Attributes
 
@@ -952,6 +960,11 @@ class Pie(Mark):
     inner_radius = Float(0.1, min=0.0, max=float('inf')).tag(sync=True)
     start_angle = Float().tag(sync=True)
     end_angle = Float(360.0).tag(sync=True)
+    display_labels = Bool(True).tag(sync=True)
+    label_color = Color(None, allow_none=True).tag(sync=True)
+    font_size = Unicode(default_value='14px').tag(sync=True)
+    font_weight = Enum(['bold', 'normal', 'bolder'], 
+                       default_value='bold').tag(sync=True)
 
     _view_name = Unicode('Pie').tag(sync=True)
     _model_name = Unicode('PieModel').tag(sync=True)

--- a/examples/Pie.ipynb
+++ b/examples/Pie.ipynb
@@ -8,7 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "from bqplot import *\n",
+    "from bqplot import Pie, Figure\n",
+    "from IPython.display import display\n",
     "import numpy as np"
    ]
   },
@@ -17,6 +18,15 @@
    "metadata": {},
    "source": [
     "## Basic Pie Chart"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generating the simplest possible pie chart and plotting it in a `Figure`.\n",
+    "\n",
+    "The area and angle of each slice will be proportional to the data passed to `sizes`"
    ]
   },
   {
@@ -29,7 +39,53 @@
    "source": [
     "data = range(1, 6)\n",
     "pie = Pie(sizes=data)\n",
-    "Figure(marks=[pie], animation_duration=1000)"
+    "fig = Figure(marks=[pie], animation_duration=1000)\n",
+    "# Add `animation_duration` (in milliseconds) to have smooth transitions\n",
+    "display(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As with all bqplot Marks, pie data can be dynamically modified"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Nslices = 5\n",
+    "pie.sizes = np.random.rand(Nslices)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sort the pie slices by ascending size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pie.sort = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Setting different styles for selected slices"
    ]
   },
   {
@@ -49,38 +105,57 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "pie.selected = None\n",
-    "size = 4\n",
-    "normal = np.random.randn(size)\n",
-    "pie.sizes = np.abs(normal)\n",
-    "pie.labels = ['{:.2f}'.format(d) for d in pie.sizes]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "pie.sort = True"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "pie.label_color = 'black'\n",
-    "pie.font_size = '1.7em'"
+    "pie.selected = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For more on piechart interactions, see the [Mark Interactions notebook](Mark Interactions.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adding labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pie.labels = ['{:.2f}'.format(d) for d in pie.sizes]\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Modify label styling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pie.label_color = 'white'\n",
+    "pie.font_size = '20px'\n",
+    "pie.font_weight = 'normal'"
    ]
   },
   {
@@ -98,8 +173,16 @@
    },
    "outputs": [],
    "source": [
-    "pie = Pie(sizes=np.abs(normal1), inner_radius=0.05)\n",
-    "Figure(marks=[pie], animation_duration=1000)"
+    "pie1 = Pie(sizes=np.random.rand(6), inner_radius=0.05)\n",
+    "fig1 = Figure(marks=[pie1], animation_duration=1000)\n",
+    "display(fig1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Change pie dimensions"
    ]
   },
   {
@@ -110,8 +193,9 @@
    },
    "outputs": [],
    "source": [
-    "pie.radius = 250\n",
-    "pie.inner_radius = 80"
+    "# As of now, the radius sizes are absolute, in pixels\n",
+    "pie1.radius = 250\n",
+    "pie1.inner_radius = 80"
    ]
   },
   {
@@ -122,10 +206,19 @@
    },
    "outputs": [],
    "source": [
-    "pie.start_angle = -90\n",
-    "pie.end_angle = 90\n",
-    "pie.y = 0.1\n",
-    "pie.radius = 320"
+    "# Angles are in radians, 0 being the top vertical\n",
+    "pie1.start_angle = -90\n",
+    "pie1.end_angle = 90"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Moving the pie around\n",
+    "`x` and `y` attributes control the position of the pie in the figure.\n",
+    "If no scales are passed for `x` and `y`, they are taken in absolute \n",
+    "figure coordinates, between 0 and 1."
    ]
   },
   {
@@ -136,9 +229,31 @@
    },
    "outputs": [],
    "source": [
-    "pie.stroke = 'black'\n",
-    "pie.opacities = [0.4]\n",
-    "pie.colors=['gold', 'magenta']"
+    "pie1.y = 0.9\n",
+    "pie1.x = 0.4\n",
+    "pie1.radius = 320"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Changing slice styles\n",
+    "Pie slice colors cycle through the `colors` and `opacities` attribute, as the `Lines` Mark."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pie1.stroke = 'brown'\n",
+    "pie1.colors = ['orange', 'darkviolet']\n",
+    "pie1.opacities = [.1, 1]\n",
+    "display(fig1)"
    ]
   },
   {
@@ -149,17 +264,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "sc = ColorScale(scheme='Reds')\n",
-    "ax = ColorAxis(scale=sc)\n",
-    "pie = Pie(sizes=np.abs(normal1),scales={'color': sc}, color=normal2)\n",
-    "Figure(marks=[pie], axes=[ax])"
+    "The `Pie` allows for its colors to be determined by data, that is passed to the `color` attribute. \n",
+    "A `ColorScale` with the desired color scheme must also be passed."
    ]
   },
   {
@@ -170,48 +279,65 @@
    },
    "outputs": [],
    "source": [
-    "import datetime as dt\n",
-    "from bqplot.traits import convert_to_date\n",
-    "ref_date = dt.datetime(2010, 1, 1)\n",
-    "num_items = (10 * i for i in range(10))\n",
+    "from bqplot import ColorScale, ColorAxis\n",
     "\n",
-    "x_data = [ref_date + dt.timedelta(x) for x in num_items]\n",
-    "y_data = normal2\n",
+    "Nslices = 7\n",
+    "size_data = np.random.rand(Nslices)\n",
+    "color_data = np.random.randn(Nslices)\n",
+    "\n",
+    "sc = ColorScale(scheme='Reds')\n",
+    "# The ColorAxis gives a visual representation of its ColorScale\n",
+    "ax = ColorAxis(scale=sc)\n",
+    "\n",
+    "pie2 = Pie(sizes=size_data, scales={'color': sc}, color=color_data)\n",
+    "Figure(marks=[pie2], axes=[ax])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Positioning the Pie using custom scales"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pies can be positioned, via the `x` and `y` attributes, \n",
+    "using either absolute figure scales or custom 'x' or 'y' scales"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "from bqplot.traits import convert_to_date\n",
+    "from bqplot import DateScale, LinearScale, Axis\n",
+    "\n",
+    "avg_precipitation_days = [(d/30., 1-d/30.) for d in [2, 3, 4, 6, 12, 17, 23, 22, 15, 4, 1, 1]]\n",
+    "temperatures = [9, 12, 16, 20, 22, 23, 22, 22, 22, 20, 15, 11]\n",
+    "\n",
+    "dates = [datetime(2010, k, 1) for k in range(1, 13)]\n",
     "\n",
     "sc_x = DateScale()\n",
     "sc_y = LinearScale()\n",
-    "ax_x = Axis(scale=sc_x)\n",
-    "ax_y = Axis(scale=sc_y, orientation='vertical')\n",
+    "ax_x = Axis(scale=sc_x, label='month', tick_format='%B')\n",
+    "ax_y = Axis(scale=sc_y, orientation='vertical', label='average temperature')\n",
     "\n",
-    "pies=[]\n",
-    "for i in range(10):\n",
-    "    pie_data = np.abs(normal3[2 * i:2 * (i + 1)])\n",
-    "    pies.append(Pie(sizes=pie_data, x=x_data[i], y=y_data[i], radius=50.,\n",
-    "                    scales={\"x\": sc_x, \"y\": sc_y},\n",
-    "                    colors = ['red', 'blue']))\n",
-    "    \n",
-    "line = Lines(x=convert_to_date(x_data), y=y_data, scales={\"x\": sc_x, \"y\": sc_y})"
+    "pies = [Pie(sizes=precipit, x=date, y=temp, \n",
+    "            scales={\"x\": sc_x, \"y\": sc_y}, radius=30., stroke='navy',\n",
+    "            colors=['navy', 'navy'], opacities=[1, .1]) \n",
+    "        for precipit, date, temp in zip(avg_precipitation_days, dates, temperatures)]\n",
+    "\n",
+    "Figure(title='Kathmandu precipitation', marks=pies, axes=[ax_x, ax_y],\n",
+    "       padding_x=.05, padding_y=.1)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Figure(marks=[line] + pies, axes=[ax_x, ax_y])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -230,9 +356,13 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.11"
+  },
+  "widgets": {
+   "state": {},
+   "version": "2.0.0-dev"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/Pie.ipynb
+++ b/examples/Pie.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "data = range(1, 6)\n",
-    "pie = Pie(sizes=data, select_slices=True, opacities=[0.2])\n",
+    "pie = Pie(sizes=data, opacities=[0.2])\n",
     "Figure(marks=[pie], animation_duration=1000)"
    ]
   },

--- a/examples/Pie.ipynb
+++ b/examples/Pie.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "data = range(1, 6)\n",
-    "pie = Pie(sizes=data, opacities=[0.2])\n",
+    "pie = Pie(sizes=data)\n",
     "Figure(marks=[pie], animation_duration=1000)"
    ]
   },
@@ -41,17 +41,7 @@
    "outputs": [],
    "source": [
     "pie.selected_style = {\"opacity\": \"1\", \"stroke\": \"white\", \"stroke-width\": \"2\"}\n",
-    "pie.unselected_style = {\"opacity\": \"0.2\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
+    "pie.unselected_style = {\"opacity\": \"0.2\"}\n",
     "pie.selected = [3]"
    ]
   },
@@ -63,11 +53,11 @@
    },
    "outputs": [],
    "source": [
-    "size = 10\n",
-    "normal1 = np.random.randn(size)\n",
-    "normal2 = np.random.randn(size)\n",
-    "normal3 = np.random.randn(2 * size)\n",
-    "pie.sizes = np.abs(normal1)"
+    "pie.selected = None\n",
+    "size = 4\n",
+    "normal = np.random.randn(size)\n",
+    "pie.sizes = np.abs(normal)\n",
+    "pie.labels = ['{:.2f}'.format(d) for d in pie.sizes]"
    ]
   },
   {
@@ -85,11 +75,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "pie.labels = ['{:.2f}'.format(d) for d in pie.sizes]"
+    "pie.label_color = 'black'\n",
+    "pie.font_size = '1.7em'"
    ]
   },
   {
@@ -146,7 +137,7 @@
    "outputs": [],
    "source": [
     "pie.stroke = 'black'\n",
-    "pie.opacities = [0.9]\n",
+    "pie.opacities = [0.4]\n",
     "pie.colors=['gold', 'magenta']"
    ]
   },

--- a/js/src/Pie.js
+++ b/js/src/Pie.js
@@ -229,7 +229,8 @@ define(["d3", "./Mark", "./utils", "underscore"],
                         .attr("class", "pie_text")
                         .attr("dy", ".35em")
                         .attr("pointer-events", "none")
-                        .style("text-anchor", "middle");
+                        .style("text-anchor", "middle")
+                        .style("stroke", "none");
                 });
 
             var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
@@ -273,7 +274,7 @@ define(["d3", "./Mark", "./utils", "underscore"],
               });
         },
         update_labels: function() {
-            var labels = this.el.select(".pielayout").selectAll(".slice").select("text")
+            var labels = this.el.select(".pielayout").selectAll(".pie_text")
                 .text(function(d) { return d.data.label; })
                 .style("visibility", this.model.get("display_labels") ? "visible" : "hidden")
                 .style("font-weight", this.model.get("font_weight"))

--- a/js/src/Pie.js
+++ b/js/src/Pie.js
@@ -97,6 +97,8 @@ define(["d3", "./Mark", "./utils", "underscore"],
             }, this);
             this.model.on_some_change(["stroke", "opacities"], this.update_stroke_and_opacities, this);
             this.model.on_some_change(["x", "y"], this.position_center, this);
+            this.model.on_some_change(["display_labels", "label_color", "font_size", "font_weight"],
+                                      this.update_labels, this);
             this.model.on_some_change(["start_angle", "end_angle", "sort"], function() {
                 var animate = true;
                 this.draw(animate);
@@ -271,8 +273,16 @@ define(["d3", "./Mark", "./utils", "underscore"],
               });
         },
         update_labels: function() {
-            this.el.select(".pielayout").selectAll(".slice").select("text")
-              .text(function(d) { return d.data.label; });
+            var labels = this.el.select(".pielayout").selectAll(".slice").select("text")
+                .text(function(d) { return d.data.label; })
+                .style("visibility", this.model.get("display_labels") ? "visible" : "hidden")
+                .style("font-weight", this.model.get("font_weight"))
+                .style("font-size", this.model.get("font_size"));
+
+            var color = this.model.get("label_color");
+            if(color !== undefined) {
+                labels.style("fill", color);
+            }
         },
         clear_style: function(style_dict, indices) {
             // Function to clear the style of a dict on some or all the elements of the


### PR DESCRIPTION
Added the following options:
- `display_labels`: whether to make the labels visible or not
- `label_color`
- `font_size`
- `font_weight`

Fixes issue #99, helps with #130 