### PR TITLE
fix typo in notebook: "removing"

### DIFF
--- a/examples/Scatter.ipynb
+++ b/examples/Scatter.ipynb
@@ -679,7 +679,7 @@
    },
    "outputs": [],
    "source": [
-    "## remvoing field names from the tooltip\n",
+    "## removing field names from the tooltip\n",
     "def_tt.show_names = False"
    ]
   },


### PR DESCRIPTION
Thanks to Sally Wilsak for pointing this out.