### PR TITLE
Change Map Example notebook

### DIFF
--- a/examples/Map.ipynb
+++ b/examples/Map.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "sc_geo = Mercator()\n",
     "x = Map(scales={'projection': sc_geo})\n",
-    "fig = Figure(marks=[x])\n",
+    "fig = Figure(marks=[x], title='Basic Map Example')\n",
     "display(fig)"
    ]
   },
@@ -53,7 +53,7 @@
    "source": [
     "sc_geo = Orthographic()\n",
     "x = Map(map_data=topo_load('WorldMapData.json'), scales={'projection': sc_geo})\n",
-    "fig = Figure(marks=[x], fig_color='deepskyblue')\n",
+    "fig = Figure(marks=[x], fig_color='deepskyblue', title='Advanced Map Example')\n",
     "display(fig)"
    ]
   },
@@ -72,7 +72,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Chloropleth ##"
+    "## Choropleth ##"
    ]
   },
   {
@@ -92,7 +92,7 @@
     "axis = ColorAxis(scale=sc_c1)\n",
     "\n",
     "x = Map(map_data=topo_load('WorldMapData.json'), **map_styles)\n",
-    "fig = Figure(marks=[x], axes=[axis])\n",
+    "fig = Figure(marks=[x], axes=[axis],title='Choropleth Example')\n",
     "display(fig)"
    ]
   },
@@ -114,7 +114,7 @@
     "sc_geo = AlbersUSA()\n",
     "x = Map(map_data=topo_load('USMapData.json'), \n",
     "            scales={'projection': sc_geo})\n",
-    "fig = Figure(marks=[x])\n",
+    "fig = Figure(marks=[x], title='US States Map Example')\n",
     "display(fig)"
    ]
   },
@@ -136,7 +136,7 @@
     "def_tt = Tooltip(fields=['id', 'name'])\n",
     "map_mark = Map(scales={'projection': Mercator()}, tooltip=def_tt)\n",
     "map_mark.interactions = {'click': 'select', 'hover': 'tooltip'}\n",
-    "fig = Figure(marks=[map_mark])\n",
+    "fig = Figure(marks=[map_mark], title='Interactions Example')\n",
     "display(fig)"
    ]
   }
@@ -160,7 +160,130 @@
    "version": "2.7.11"
   },
   "widgets": {
-   "state": {},
+   "state": {
+    "031105ac82084668b07f1be6cc8a4535": {
+     "views": [
+      {
+       "cell_index": 11
+      }
+     ]
+    },
+    "1569dee521bc40ef9c456edbf467c43d": {
+     "views": []
+    },
+    "16daf8a491ab4a548156e215c11a516e": {
+     "views": [
+      {
+       "cell_index": 9
+      }
+     ]
+    },
+    "18453b91d0f044149bdb81cb0bd286fa": {
+     "views": []
+    },
+    "392b2d7c54f34ad082f3d332703a9894": {
+     "views": []
+    },
+    "3b0be68510a24811bb7b4afa1ac18305": {
+     "views": [
+      {
+       "cell_index": 2
+      }
+     ]
+    },
+    "3ddf84144f2241868d6be20278e329bf": {
+     "views": []
+    },
+    "3e676f6b5a044561ad238d3f5ef2f838": {
+     "views": []
+    },
+    "3fc1d58b3855498bb90f22275880c51c": {
+     "views": []
+    },
+    "4856f1f684ee41e6830364e3320e02d0": {
+     "views": []
+    },
+    "4d5fd16d3cf9476cb6e3efbbbbd65983": {
+     "views": [
+      {
+       "cell_index": 4
+      }
+     ]
+    },
+    "66c8e83b6725450fa773b7fa4663f833": {
+     "views": []
+    },
+    "6fe1293d5c784b428ad21a3a21424a8a": {
+     "views": []
+    },
+    "7c74949c1a534eb4aa0d93f78a72c013": {
+     "views": []
+    },
+    "897cdc3b08b24faaabbbfcacd9ac30f9": {
+     "views": []
+    },
+    "9b8fa99995b245409904d6acfcf9285d": {
+     "views": []
+    },
+    "ae758181b6f948c0b061dbc79edfb8eb": {
+     "views": []
+    },
+    "af17e85871424f0c8afa35e0a6dc1e92": {
+     "views": []
+    },
+    "b1fa31840dae454cbccbb1139a09edc1": {
+     "views": [
+      {
+       "cell_index": 7
+      }
+     ]
+    },
+    "b5c53373df464983a1150dfc862d45ab": {
+     "views": []
+    },
+    "bc70e7980f9d495e9e634735b1161350": {
+     "views": []
+    },
+    "c981a44af8ae4dfb9cced3f56dbd4a1e": {
+     "views": []
+    },
+    "d6bc44fe01024f489aa59d92a1f75635": {
+     "views": []
+    },
+    "dee0787fd64f42c391b4f127863da7aa": {
+     "views": []
+    },
+    "e0f89a13a6f648f185edf525ba796029": {
+     "views": []
+    },
+    "e8f0a97d0dfd44ae8e8aa70a5d1bef87": {
+     "views": []
+    },
+    "ebca5ffcdd994ad99241c97ac0fc5494": {
+     "views": []
+    },
+    "eec040846a664040abf3abe8d27c9ebc": {
+     "views": []
+    },
+    "f12d036491a14ffb9f081917bd37d43f": {
+     "views": []
+    },
+    "f1b2561e981d42c18423a8869c88802e": {
+     "views": []
+    },
+    "f6c5c45aada8413b8893ddce343ac6b9": {
+     "views": []
+    },
+    "f7d51deee53d4880b11095f1cb2c74e9": {
+     "views": []
+    },
+    "f816a50c64ab476a98fd6bbb89c9393d": {
+     "views": []
+    },
+    "fb658eb45fd14e09805e5b3d63f85be2": {
+     "views": []
+    }
+   },
    "version": "2.0.0-dev"
   }
  },

--- a/examples/Map.ipynb
+++ b/examples/Map.ipynb
@@ -9,7 +9,8 @@
    "outputs": [],
    "source": [
     "from IPython.display import display\n",
-    "from bqplot import *"
+    "from bqplot import (Figure, Map, Mercator, Orthographic, ColorScale, ColorAxis,\n",
+    "                    AlbersUSA, topo_load, Tooltip)"
    ]
   },
   {
@@ -28,7 +29,7 @@
    "outputs": [],
    "source": [
     "sc_geo = Mercator()\n",
-    "x = Map(map_data=topo_load('WorldMapData.json'), scales={'projection': sc_geo})\n",
+    "x = Map(scales={'projection': sc_geo})\n",
     "fig = Figure(marks=[x])\n",
     "display(fig)"
    ]
@@ -46,7 +47,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -85,7 +86,7 @@
     "sc_geo = Mercator()\n",
     "sc_c1 = ColorScale(scheme='YlOrRd')\n",
     "\n",
-    "map_styles = {'color': {643: 200., 4: 21., 398: 23., 156: 42., 124:78., 76: 98.}, \n",
+    "map_styles = {'color': {643: 105., 4: 21., 398: 23., 156: 42., 124:78., 76: 98.}, \n",
     "              'scales': {'projection': sc_geo, 'color': sc_c1}}\n",
     "\n",
     "axis = ColorAxis(scale=sc_c1)\n",
@@ -133,21 +134,11 @@
    "outputs": [],
    "source": [
     "def_tt = Tooltip(fields=['id', 'name'])\n",
-    "map_mark = Map(map_data=topo_load('WorldMapData.json'), \n",
-    "               scales={'projection': Mercator()}, tooltip=def_tt)\n",
+    "map_mark = Map(scales={'projection': Mercator()}, tooltip=def_tt)\n",
     "map_mark.interactions = {'click': 'select', 'hover': 'tooltip'}\n",
     "fig = Figure(marks=[map_mark])\n",
     "display(fig)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -166,7 +157,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "version": "2.7.11"
+  },
+  "widgets": {
+   "state": {},
+   "version": "2.0.0-dev"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
@SylvainCorlay `topo_load` already has the WorldMap as its default. It isn't needed anymore. I removed it and renormalized the chloropleth a bit better.

Changed the `import *` syntax as well