### PR TITLE
Make Map default color a Dict

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -36,7 +36,7 @@ Marks
 """
 from ipywidgets import Widget, DOMWidget, CallbackDispatcher, Color, widget_serialization
 from traitlets import (Int, Unicode, List, Enum, Dict, Bool, Float, TraitError,
-                       Instance, Tuple, Union)
+                       Instance, Tuple)
 
 from .scales import Scale, OrdinalScale
 from .traits import NdArray, Date
@@ -975,9 +975,10 @@ class Map(Mark):
 
     Attributes
     ----------
-    colors: Dict (default: {'default_color': 'MediumSeaGreen'})
+    colors: Dict (default: {})
         default colors for items of the map when no color data is passed. The dictionary should be indexed by the
-        id of the element and have the corresponding colors as values.
+        id of the element and have the corresponding colors as values. The key `default_color` controls the items
+        for which no color is specified.
     selected_styles: Dict (default: {'selected_fill': 'Red', 'selected_stroke': None, 'selected_stroke_width': 2.0})
         Dictionary containing the styles for selected subunits
     hovered_styles: Dict (default: {'hovered_fill': 'Orange', 'hovered_stroke': None, 'hovered_stroke_width': 2.0})
@@ -1015,7 +1016,7 @@ class Map(Mark):
     allow_none=True).tag(sync=True)
 
     stroke_color = Color(default_value=None, allow_none=True).tag(sync=True)
-    colors = Dict({'default_color': 'MediumSeaGreen'}).tag(sync=True, display_name='Colors')
+    colors = Dict().tag(sync=True, display_name='Colors')
     scales_metadata = Dict({
         'color': { 'dimension': 'color' },
         'projection': { 'dimension': 'geo' }

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -36,7 +36,7 @@ Marks
 """
 from ipywidgets import Widget, DOMWidget, CallbackDispatcher, Color, widget_serialization
 from traitlets import (Int, Unicode, List, Enum, Dict, Bool, Float, TraitError,
-                       Instance, Tuple)
+                       Instance, Tuple, Union)
 
 from .scales import Scale, OrdinalScale
 from .traits import NdArray, Date
@@ -975,8 +975,9 @@ class Map(Mark):
 
     Attributes
     ----------
-    default_color: Color or None (default: None)
-        default color for items of the map when no color data is passed
+    colors: Dict (default: {'default_color': 'MediumSeaGreen'})
+        default colors for items of the map when no color data is passed. The dictionary should be indexed by the
+        id of the element and have the corresponding colors as values.
     selected_styles: Dict (default: {'selected_fill': 'Red', 'selected_stroke': None, 'selected_stroke_width': 2.0})
         Dictionary containing the styles for selected subunits
     hovered_styles: Dict (default: {'hovered_fill': 'Orange', 'hovered_stroke': None, 'hovered_stroke_width': 2.0})
@@ -1014,7 +1015,7 @@ class Map(Mark):
     allow_none=True).tag(sync=True)
 
     stroke_color = Color(default_value=None, allow_none=True).tag(sync=True)
-    default_color = Color(default_value=None, allow_none=True).tag(sync=True)
+    colors = Dict({'default_color': 'MediumSeaGreen'}).tag(sync=True, display_name='Colors')
     scales_metadata = Dict({
         'color': { 'dimension': 'color' },
         'projection': { 'dimension': 'geo' }

--- a/examples/Map.ipynb
+++ b/examples/Map.ipynb
@@ -51,8 +51,9 @@
    },
    "outputs": [],
    "source": [
-    "sc_geo = Orthographic()\n",
-    "x = Map(map_data=topo_load('WorldMapData.json'), scales={'projection': sc_geo})\n",
+    "sc_geo = Orthographic(scale_factor=375, center=[0, 25], rotate=(-50, 0))\n",
+    "x = Map(map_data=topo_load('WorldMapData.json'), scales={'projection': sc_geo}, \n",
+    "        colors={682: 'Green', 356: 'Red', 643: '#0000ff', 'default_color': 'DarkOrange'})\n",
     "fig = Figure(marks=[x], fig_color='deepskyblue', title='Advanced Map Example')\n",
     "display(fig)"
    ]
@@ -86,8 +87,8 @@
     "sc_geo = Mercator()\n",
     "sc_c1 = ColorScale(scheme='YlOrRd')\n",
     "\n",
-    "map_styles = {'color': {643: 105., 4: 21., 398: 23., 156: 42., 124:78., 76: 98.}, \n",
-    "              'scales': {'projection': sc_geo, 'color': sc_c1}}\n",
+    "map_styles = {'color': {643: 105., 4: 21., 398: 23., 156: 42., 124:78., 76: 98.},\n",
+    "              'scales': {'projection': sc_geo, 'color': sc_c1}, 'colors': {'default_color': 'Grey'}}\n",
     "\n",
     "axis = ColorAxis(scale=sc_c1)\n",
     "\n",
@@ -160,130 +161,7 @@
    "version": "2.7.11"
   },
   "widgets": {
-   "state": {
-    "031105ac82084668b07f1be6cc8a4535": {
-     "views": [
-      {
-       "cell_index": 11
-      }
-     ]
-    },
-    "1569dee521bc40ef9c456edbf467c43d": {
-     "views": []
-    },
-    "16daf8a491ab4a548156e215c11a516e": {
-     "views": [
-      {
-       "cell_index": 9
-      }
-     ]
-    },
-    "18453b91d0f044149bdb81cb0bd286fa": {
-     "views": []
-    },
-    "392b2d7c54f34ad082f3d332703a9894": {
-     "views": []
-    },
-    "3b0be68510a24811bb7b4afa1ac18305": {
-     "views": [
-      {
-       "cell_index": 2
-      }
-     ]
-    },
-    "3ddf84144f2241868d6be20278e329bf": {
-     "views": []
-    },
-    "3e676f6b5a044561ad238d3f5ef2f838": {
-     "views": []
-    },
-    "3fc1d58b3855498bb90f22275880c51c": {
-     "views": []
-    },
-    "4856f1f684ee41e6830364e3320e02d0": {
-     "views": []
-    },
-    "4d5fd16d3cf9476cb6e3efbbbbd65983": {
-     "views": [
-      {
-       "cell_index": 4
-      }
-     ]
-    },
-    "66c8e83b6725450fa773b7fa4663f833": {
-     "views": []
-    },
-    "6fe1293d5c784b428ad21a3a21424a8a": {
-     "views": []
-    },
-    "7c74949c1a534eb4aa0d93f78a72c013": {
-     "views": []
-    },
-    "897cdc3b08b24faaabbbfcacd9ac30f9": {
-     "views": []
-    },
-    "9b8fa99995b245409904d6acfcf9285d": {
-     "views": []
-    },
-    "ae758181b6f948c0b061dbc79edfb8eb": {
-     "views": []
-    },
-    "af17e85871424f0c8afa35e0a6dc1e92": {
-     "views": []
-    },
-    "b1fa31840dae454cbccbb1139a09edc1": {
-     "views": [
-      {
-       "cell_index": 7
-      }
-     ]
-    },
-    "b5c53373df464983a1150dfc862d45ab": {
-     "views": []
-    },
-    "bc70e7980f9d495e9e634735b1161350": {
-     "views": []
-    },
-    "c981a44af8ae4dfb9cced3f56dbd4a1e": {
-     "views": []
-    },
-    "d6bc44fe01024f489aa59d92a1f75635": {
-     "views": []
-    },
-    "dee0787fd64f42c391b4f127863da7aa": {
-     "views": []
-    },
-    "e0f89a13a6f648f185edf525ba796029": {
-     "views": []
-    },
-    "e8f0a97d0dfd44ae8e8aa70a5d1bef87": {
-     "views": []
-    },
-    "ebca5ffcdd994ad99241c97ac0fc5494": {
-     "views": []
-    },
-    "eec040846a664040abf3abe8d27c9ebc": {
-     "views": []
-    },
-    "f12d036491a14ffb9f081917bd37d43f": {
-     "views": []
-    },
-    "f1b2561e981d42c18423a8869c88802e": {
-     "views": []
-    },
-    "f6c5c45aada8413b8893ddce343ac6b9": {
-     "views": []
-    },
-    "f7d51deee53d4880b11095f1cb2c74e9": {
-     "views": []
-    },
-    "f816a50c64ab476a98fd6bbb89c9393d": {
-     "views": []
-    },
-    "fb658eb45fd14e09805e5b3d63f85be2": {
-     "views": []
-    }
-   },
+   "state": {},
    "version": "2.0.0-dev"
   }
  },

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -231,7 +231,7 @@ define(["d3", "topojson", "./Figure", "jupyter-js-widgets", "./Mark", "underscor
             this.listenTo(this.model, "data_updated", this.draw, this);
             this.listenTo(this.model, "change:color", this.update_style, this);
             this.listenTo(this.model, "change:stroke_color", this.change_stroke_color, this);
-            this.listenTo(this.model, "change:default_color", this.change_map_color, this);
+            this.listenTo(this.model, "change:colors", this.change_map_color, this);
             this.listenTo(this.model, "change:selected", this.change_selected, this);
             this.listenTo(this.model, "change:selected_styles", function() {
                 that.change_selected_fill();
@@ -378,7 +378,7 @@ define(["d3", "topojson", "./Figure", "jupyter-js-widgets", "./Mark", "underscor
             });
             this.fill_g.selectAll("path").classed("selected", false)
                 .style("fill", function(d, i) {
-                    return that.fill_g_colorfill(d,i);
+                    return that.fill_g_colorfill(d, i);
                 });
         },
 
@@ -388,11 +388,14 @@ define(["d3", "topojson", "./Figure", "jupyter-js-widgets", "./Mark", "underscor
         },
 
         change_map_color: function(){
+		var that = this;
             if (!this.is_object_empty(this.model.get("color"))){
                 return;
             }
             this.fill_g.selectAll("path")
-                .style("fill", this.model.get("default_color"));
+                .style("fill", function(d, i) {
+			return that.fill_g_colorfill(d, i)
+		});
         },
 
         update_style: function() {
@@ -425,18 +428,20 @@ define(["d3", "topojson", "./Figure", "jupyter-js-widgets", "./Mark", "underscor
         },
 
         fill_g_colorfill: function(d, j) {
-            var color_scale = this.scales.color;
-            var selection = this.model.get("selected");
-            var color_data = this.model.get("color");
-            if (selection.indexOf(d.id) > -1) {
-                return this.model.get("selected_styles").selected_fill;
-            } else if (this.is_object_empty(color_data)) {
-                return this.model.get("default_color");
-            } else if (color_data[d.id] === undefined ||
+	    var color_scale = this.scales.color;
+	    var selection = this.model.get("selected");
+	    var color_data = this.model.get("color");
+	    var colors = this.model.get("colors");
+
+	    if (selection.indexOf(d.id) > -1) {
+		    return this.model.get("selected_styles").selected_fill;
+	    } else if (this.is_object_empty(color_data)) {
+		   return colors[d.id] || colors["default_color"];
+	    } else if (color_data[d.id] === undefined ||
                        color_data[d.id] === null ||
                        color_data[d.id] === "nan" ||
                        color_scale === undefined) {
-                return "Grey";
+                return colors["default_color"]; 
             } else {
                 return color_scale.scale(color_data[d.id]);
             }


### PR DESCRIPTION
@SylvainCorlay @ssunkara1 @jasongrout Regarding #40. This is a major API change.

Map now takes a `Dict` for its `colors` attribute, so the `id` can be passed to it. It looks for a key `default_value` in the dict for the default value.

```python
sc_geo = Mercator()
x = Map(map_data=topo_load('WorldMapData.json'), scales={'projection': sc_geo}, 
        colors={682: 'Green', 356: 'Red', 643: '#0000ff',
                'default_color': 'DarkOrange'})
fig = Figure(marks=[x], fig_color='deepskyblue', title='Advanced Map Example')
display(fig)
```

replaces

```python
sc_geo = Mercator()
x = Map(map_data=topo_load('WorldMapData.json'), scales={'projection': sc_geo}, 
      default_color='Green')
fig = Figure(marks=[x], fig_color='deepskyblue', title='Advanced Map Example')
display(fig)
```