### PR TITLE
Fixes to 0.5.x

### DIFF
--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -117,10 +117,10 @@ class Figure(DOMWidget):
     animation_duration = Int(0, sync=True, display_name='Animation duration')
 
     def _scale_x_default(self):
-        return LinearScale(min=0, max=1)
+        return LinearScale(min=0, max=1, allow_padding=False)
 
     def _scale_y_default(self):
-        return LinearScale(min=0, max=1)
+        return LinearScale(min=0, max=1, allow_padding=False)
 
     _view_name = Unicode('Figure', sync=True)
     _view_module = Unicode('nbextensions/bqplot/Figure', sync=True)

--- a/bqplot/nbextension/BrushSelector.js
+++ b/bqplot/nbextension/BrushSelector.js
@@ -418,8 +418,8 @@ define(["./components/d3/d3", "./Selector", "./utils", "underscore"], function(d
                 add_remove_classes(d3.select(this), ["active"], ["inactive"]);
                 old_handler.call(this);
                 // Replacement for "Accel" modifier.
-                var accelKey = d3.event.ctrlKey || d3.event.metaKey;
                 d3.select(this).on("mousedown.brush", function() {
+                    var accelKey = d3.event.ctrlKey || d3.event.metaKey;
                     if(d3.event.shiftKey && accelKey && d3.event.altKey) {
                         that.reset();
                     } else if(accelKey) {

--- a/bqplot/nbextension/Mark.js
+++ b/bqplot/nbextension/Mark.js
@@ -223,7 +223,8 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3",
                 var ref_el = d3.select(document.body).select("#notebook").node();
                 var ref_mouse_pos = d3.mouse(ref_el);
 
-                var mouse_pos = d3.mouse(this.parent.el);
+                var parent_node = this.parent.el.parentElement;
+                var mouse_pos = d3.mouse(parent_node);
                 if(mouse_events === undefined || mouse_events === null ||
                    (!(mouse_events))) {
                         this.tooltip_div.style("pointer-events", "none");
@@ -239,16 +240,14 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3",
                     //node
                     var parent_rect = this.parent.el.getBoundingClientRect();
                     var tooltip_div_rect = this.tooltip_div.node().getBoundingClientRect();
-                    var parent_node = this.parent.el.parentElement;
                     this.tooltip_div.style("left", (parent_node.offsetLeft + 5 + parent_rect.width * 0.5 -
-                                                    tooltip_div_rect.width * 0.5) + "px")
+                                                    tooltip_div_rect.width * 0.5 - ref_el.scrollLeft) + "px")
                         .style("top", (parent_node.offsetTop + 5 + parent_rect.height * 0.5 -
-                                                    tooltip_div_rect.height * 0.5) + "px");
+                                                    tooltip_div_rect.height * 0.5 - ref_el.scrollTop) + "px");
                 }
                 else {
-                    var parent_node = this.parent.el.parentElement;
-                    this.tooltip_div.style("left", (mouse_pos[0] + parent_node.offsetLeft + 5) + "px")
-                        .style("top", (mouse_pos[1] + parent_node.offsetTop + 5) + "px");
+                    this.tooltip_div.style("left", (mouse_pos[0] + parent_node.offsetLeft - ref_el.scrollLeft + 5) + "px")
+                        .style("top", (mouse_pos[1] + parent_node.offsetTop - ref_el.scrollTop + 5) + "px");
                 }
             }
         },

--- a/bqplot/nbextension/Mark.js
+++ b/bqplot/nbextension/Mark.js
@@ -239,14 +239,16 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3",
                     //node
                     var parent_rect = this.parent.el.getBoundingClientRect();
                     var tooltip_div_rect = this.tooltip_div.node().getBoundingClientRect();
-                    this.tooltip_div.style("left", (this.parent.el.offsetLeft + 5 + parent_rect.width * 0.5 -
+                    var parent_node = this.parent.el.parentElement;
+                    this.tooltip_div.style("left", (parent_node.offsetLeft + 5 + parent_rect.width * 0.5 -
                                                     tooltip_div_rect.width * 0.5) + "px")
-                        .style("top", (this.parent.el.offsetTop + 5 + parent_rect.height * 0.5 -
+                        .style("top", (parent_node.offsetTop + 5 + parent_rect.height * 0.5 -
                                                     tooltip_div_rect.height * 0.5) + "px");
                 }
                 else {
-                    this.tooltip_div.style("left", (mouse_pos[0] + this.parent.el.offsetLeft + 5) + "px")
-                        .style("top", (mouse_pos[1] + this.parent.el.offsetTop + 5) + "px");
+                    var parent_node = this.parent.el.parentElement;
+                    this.tooltip_div.style("left", (mouse_pos[0] + parent_node.offsetLeft + 5) + "px")
+                        .style("top", (mouse_pos[1] + parent_node.offsetTop + 5) + "px");
                 }
             }
         },

--- a/bqplot/nbextension/MarketMap.js
+++ b/bqplot/nbextension/MarketMap.js
@@ -562,7 +562,8 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3",
             var ref_el = d3.select(document.body).select("#notebook").node();
             var ref_mouse_pos = d3.mouse(ref_el);
 
-            var mouse_pos = d3.mouse(this.el);
+            var parent_node = this.el.parentElement;
+            var mouse_pos = d3.mouse(parent_node);
             var that = this;
             var tooltip_div = this.tooltip_div;
             tooltip_div.transition()
@@ -570,9 +571,8 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3",
                 .style("display", null);
 
             // the +5s are for breathing room for the tool tip
-            var parent_node = this.el.parentElement;
-            tooltip_div.style("left", (mouse_pos[0] + parent_node.offsetLeft + 5) + "px")
-                .style("top", (mouse_pos[1] + parent_node.offsetTop + 5) + "px");
+            tooltip_div.style("left", (mouse_pos[0] + parent_node.offsetLeft - ref_el.scrollLeft + 5) + "px")
+                .style("top", (mouse_pos[1] + parent_node.offsetTop - ref_el.scrollTop + 5) + "px");
 
             tooltip_div.select("table").remove();
             if(! this.tooltip_view) {

--- a/bqplot/nbextension/MarketMap.js
+++ b/bqplot/nbextension/MarketMap.js
@@ -570,8 +570,9 @@ define(["nbextensions/widgets/widgets/js/widget", "./components/d3/d3",
                 .style("display", null);
 
             // the +5s are for breathing room for the tool tip
-            tooltip_div.style("left", (mouse_pos[0] + this.el.offsetLeft + 5) + "px")
-                .style("top", (mouse_pos[1] + this.el.offsetTop + 5) + "px");
+            var parent_node = this.el.parentElement;
+            tooltip_div.style("left", (mouse_pos[0] + parent_node.offsetLeft + 5) + "px")
+                .style("top", (mouse_pos[1] + parent_node.offsetTop + 5) + "px");
 
             tooltip_div.select("table").remove();
             if(! this.tooltip_view) {

--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -351,31 +351,69 @@ def axes(mark=None, options={}, **kwargs):
     return axes
 
 
-def add_grids(fig=None):
+def grids(fig=None, value='solid'):
+    """Sets the value of the grid_lines for the axis to the passed value.
+    The default value is `solid`.
+
+    Parameters
+    ----------
+    fig: Figure or None(default: None)
+        The figure for which the axes should be edited. If the value is None,
+        the current figure is used.
+    value: {'none', 'solid', 'dashed'}
+        The display of the grid_lines
+    """
+
     if fig is None:
         fig = current_figure()
     for a in fig.axes:
-        a.grid_lines = 'solid'
+        a.grid_lines = value
 
 
-def hline(level=0., fig=None, **kwargs):
+def hline(level=0., fig=None, preserve_domain=True, **kwargs):
+    """Draws a horizontal line at the given level. By default, draws a line at
+    y=0.
+
+    Parameters
+    ----------
+    level: float (default: 0)
+        The level at which to draw the horizontal line
+    fig: Figure or None
+        The figure for which the axes should be edited. If the value is None,
+        the current figure is used.
+    preserve_domain: boolean (default: True)
+        If true, the line does not affect the domain of the 'y' scale.
+    """
     default_colors = kwargs.pop('colors', ['white'])
     default_width = kwargs.pop('stroke_width', 1)
     if fig is None:
         fig = current_figure()
     sc_x = fig.scale_x
     plot([0., 1.], [level, level], scales={'x': sc_x}, preserve_domain={'x': True,
-         'y': True}, axes=False, colors=default_colors,
+         'y': preserve_domain}, axes=False, colors=default_colors,
          stroke_width=default_width, update_context=False)
 
 
-def vline(level=0., fig=None, **kwargs):
+def vline(level=0., fig=None, preserve_domain=True, **kwargs):
+    """Draws a vertical line at the given level. By default, draws a line at
+    x=0.
+
+    Parameters
+    ----------
+    level: float(default: 0)
+        The level at which to draw the vertical line
+    fig: Figure or None
+        The figure for which the axes should be edited. If the value is None,
+        the current figure is used.
+    preserve_domain: boolean (default: True)
+        If true, the line does not affect the domain of the 'x' scale.
+    """
     default_colors = kwargs.pop('colors', ['white'])
     default_width = kwargs.pop('stroke_width', 1)
     if fig is None:
         fig = current_figure()
     sc_y = fig.scale_y
-    plot([level, level], [0., 1.], scales={'y': sc_y}, preserve_domain={'x': True,
+    plot([level, level], [0., 1.], scales={'y': sc_y}, preserve_domain={'x': preserve_domain,
          'y': True}, axes=False, colors=default_colors,
          stroke_width=default_width, update_context=False)
 

--- a/examples/Pyplot.ipynb
+++ b/examples/Pyplot.ipynb
@@ -94,6 +94,37 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Horizontal and Vertical Lines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.hline()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.vline()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Histogram"
    ]
   },
@@ -259,6 +290,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Adding grid lines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.grids()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Editing existing axes properites"
    ]
   },
@@ -271,7 +321,7 @@
    "outputs": [],
    "source": [
     "## adding grid lines and changing the side of the axis in the figure above\n",
-    "plt.axes(options={'x': {'grid_lines': 'solid'}, 'y': {'side': 'right', 'grid_lines': 'dashed'}})"
+    "plt.axes(options={'x': {'label': 'Dates'}, 'y': {'side': 'right'}})"
    ]
   },
   {
@@ -604,6 +654,15 @@
     "# click and drag on chart to make a selection\n",
     "plt.brush_int_selector(call_back, 'brushing')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/Pyplot.ipynb
+++ b/examples/Pyplot.ipynb
@@ -13,14 +13,8 @@
     "from bqplot import topo_load\n",
     "from bqplot.interacts import panzoom\n",
     "from numpy import *\n",
-    "import pandas as pd"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# A simple plot"
+    "import pandas as pd\n",
+    "import datetime as dt"
    ]
   },
   {
@@ -31,192 +25,36 @@
    },
    "outputs": [],
    "source": [
+    "# initializing data to be plotted\n",
     "random.seed(0)\n",
     "size = 100\n",
     "y_data = cumsum(random.randn(size) * 100.0)\n",
     "y_data_2 = cumsum(random.randn(size))\n",
-    "y_data_3 = cumsum(random.randn(size) * 100.)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plt.figure(1)\n",
-    "n = 100\n",
-    "x = linspace(0.0, 10.0, n)\n",
-    "plt.plot(x, y_data, axes_options={'y': {'grid_lines': 'dashed'}})\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "marks = plt.current_figure().marks"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "marks[0].get_state()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Changing context figure"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plt.figure(2)\n",
-    "x = linspace(0.0, 10.0, n)\n",
-    "plt.plot(x,y_data_3)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Re-editing first figure"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plt.figure(1, title='New title')\n",
-    "x = linspace(0.0, 10.0, n)\n",
-    "plt.plot(x,y_data_3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Showing a second view of the first figure"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Deleting all the first figure and all its views. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plt.close(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Using marker strings"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "x = arange(10)\n",
-    "plt.figure(title='Using Marker Strings')\n",
-    "plt.plot(x, 3 * x + 5, 'y-.s') # color=yellow, line_style=dash_dotted, marker=square\n",
-    "plt.plot(x ** 2, 'm:d') # color=magenta, line_style=None, marker=diamond\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# A scatter and a line on the same figure"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plt.clear()\n",
-    "n = 100\n",
-    "plt.figure('Two marks on the same figure')\n",
-    "plt.scatter(y_data_2, y_data_3, color=y_data)\n",
+    "y_data_3 = cumsum(random.randn(size) * 100.)\n",
     "\n",
-    "x = linspace(0.0, 10.0, n)\n",
-    "plt.plot(x,y_data)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plt.figure(title=\"Figure without a toolbar\")\n",
-    "plt.plot(linspace(0.0, 10.0, n), y_data_2, axes_options={'y': {'grid_lines': 'solid'}})\n",
-    "plt.show(display_toolbar=False)"
+    "x = linspace(0.0, 10.0, size)\n",
+    "\n",
+    "price_data = pd.DataFrame(cumsum(random.randn(150, 2).dot([[0.5, 0.8], [0.8, 1.0]]), axis=0) + 100,\n",
+    "                          columns=['Security 1', 'Security 2'],\n",
+    "                          index=pd.date_range(start='01-01-2007', periods=150))\n",
+    "\n",
+    "symbol = 'Security 1'\n",
+    "dates_all = price_data.index.values\n",
+    "final_prices = price_data[symbol].values.flatten()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Histogram"
+    "## Simple Plots"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Line Chart"
    ]
   },
   {
@@ -228,8 +66,7 @@
    "outputs": [],
    "source": [
     "plt.figure()\n",
-    "sample = y_data\n",
-    "plt.hist(sample, colors=['OrangeRed'])\n",
+    "plt.plot(x, y_data)\n",
     "plt.show()"
    ]
   },
@@ -237,7 +74,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bar chart"
+    "### Scatter Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(title='Scatter Plot with colors')\n",
+    "plt.scatter(y_data_2, y_data_3, color=y_data)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Histogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.hist(y_data, colors=['OrangeRed'])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Bar Chart"
    ]
   },
   {
@@ -249,9 +126,8 @@
    "outputs": [],
    "source": [
     "plt.figure()\n",
-    "y = y_data_3\n",
-    "x=['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U']\n",
-    "plt.bar(x, y)\n",
+    "bar_x=['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U']\n",
+    "plt.bar(bar_x, y_data_3)\n",
     "plt.show()"
    ]
   },
@@ -259,25 +135,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Editing existing axes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plt.axes(options={'x': {'grid_lines': 'solid'}, 'y': {'side': 'right', 'grid_lines': 'dashed'}})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Pie chart"
+    "### Pie Chart"
    ]
   },
   {
@@ -295,96 +153,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "y_data_2"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Dealing with dates"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "price_data = pd.DataFrame(cumsum(random.randn(150, 2).dot([[0.5, 0.8], [0.8, 1.0]]), axis=0) + 100,\n",
-    "                          columns=['Security 1', 'Security 2'],\n",
-    "                          index=pd.date_range(start='01-01-2007', periods=150))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "symbol = 'Security 1'\n",
-    "dates_all = price_data.index.values\n",
-    "final_prices = price_data[symbol].values.flatten()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plt.figure()\n",
-    "plt.plot(dates_all, final_prices)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    "# Partially changing the scales "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plt.figure()\n",
-    "n = 100\n",
-    "x = linspace(0.0, 10.0, n)\n",
-    "y = y_data_3\n",
-    "plt.plot(x,y, axes_options={'y': {'side': 'right'}})\n",
-    "plt.scales(key=3, scales={'x': plt.Keep})\n",
-    "plt.plot(x, y ** 2)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    "# OHLC"
+    "### OHLC"
    ]
   },
   {
@@ -436,17 +208,8 @@
     "       [ 179.605 ,  179.65  ,  177.66  ,  177.9   ],\n",
     "       [ 178.05  ,  178.45  ,  176.16  ,  176.85  ],\n",
     "       [ 175.98  ,  178.53  ,  175.89  ,  176.4   ],\n",
-    "       [ 177.17  ,  177.86  ,  176.36  ,  177.36  ]])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
+    "       [ 177.17  ,  177.86  ,  176.36  ,  177.36  ]])\n",
+    "\n",
     "plt.figure()\n",
     "plt.ohlc(dates, prices)\n",
     "plt.show()"
@@ -456,35 +219,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Label"
+    "### Map"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "from bqplot import LinearScale\n",
-    "plt.figure()\n",
-    "plt.label('Some Red Label', x=0.5, y=0.5, font_size='50px', color='red')\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Map"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -497,7 +239,312 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Interactions in Pyplot"
+    "### Plotting Dates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.plot(dates_all, final_prices)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Editing existing axes properites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "## adding grid lines and changing the side of the axis in the figure above\n",
+    "plt.axes(options={'x': {'grid_lines': 'solid'}, 'y': {'side': 'right', 'grid_lines': 'dashed'}})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Advanced Usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multiple Marks on the same Figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.plot(x, y_data_3, colors=['orange'])\n",
+    "plt.scatter(x, y_data, stroke='black')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using marker strings in Line Chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "mark_x = arange(10)\n",
+    "plt.figure(title='Using Marker Strings')\n",
+    "plt.plot(mark_x, 3 * mark_x + 5, 'y-.s') # color=yellow, line_style=dash_dotted, marker=square\n",
+    "plt.plot(mark_x ** 2, 'm:d') # color=magenta, line_style=None, marker=diamond\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Partially changing the scales"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.plot(x, y_data)\n",
+    "\n",
+    "## preserving the x scale and changing the y scale\n",
+    "plt.scales(scales={'x': plt.Keep})\n",
+    "plt.plot(x, y_data_2, colors=['lightgreen'], axes_options={'y': {'side': 'right', 'color': 'lightgreen'}})\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adding a label to the chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "line = plt.plot(dates_all, final_prices)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "## adds the label to the figure created above\n",
+    "plt.label('Pie Day', x=dt.date(2007, 3, 14), y=final_prices.mean(), scales=line.scales,\n",
+    "          color='orange')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Changing context figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(1)\n",
+    "plt.plot(x,y_data_3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(2)\n",
+    "plt.plot(x[:20],y_data_3[:20])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Re-editing first figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "## adds the new line to the first figure\n",
+    "plt.figure(1, title='New title')\n",
+    "plt.plot(x,y_data, colors=['orange'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Viewing the properties of the figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "marks = plt.current_figure().marks\n",
+    "marks[0].get_state()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Showing a second view of the first figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Clearing the figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "### Clearing the figure above\n",
+    "plt.clear()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deleting a figure and all its views. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.show(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.close(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interactions in Pyplot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def call_back(name, value):\n",
+    "    print(value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Brush Selector"
    ]
   },
   {
@@ -510,37 +557,17 @@
    "source": [
     "plt.figure()\n",
     "plt.scatter(y_data_2, y_data_3, default_colors=['orange'], stroke='black')\n",
+    "\n",
+    "## click and drag on the figure to see the selector\n",
+    "plt.brush_selector(call_back)\n",
     "plt.show(display_toolbar=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "def call_back(name, value):\n",
-    "    print(value)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Adding a Brush Selector"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plt.brush_selector(call_back)"
+    "### Fast Interval Selector"
    ]
   },
   {
@@ -554,6 +581,8 @@
     "plt.figure()\n",
     "n= 100\n",
     "plt.plot(arange(n), y_data_3)\n",
+    "## click on the figure to activate the selector\n",
+    "plt.int_selector(call_back)\n",
     "plt.show(display_toolbar=False)"
    ]
   },
@@ -561,7 +590,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Interval Selector"
+    "### Brush Interval Selector with call back on brushing"
    ]
   },
   {
@@ -572,24 +601,7 @@
    },
    "outputs": [],
    "source": [
-    "plt.int_selector(call_back)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Brush Interval Selector with call back on brushing"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
+    "# click and drag on chart to make a selection\n",
     "plt.brush_int_selector(call_back, 'brushing')"
    ]
   }
@@ -610,7 +622,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. Fixed tooltip positioning in 0.5.x.
2. Added functions for grids, hline and vline.
3. Fixed bug with clear in pyplot.
4. Modified pyplot example.

Note: This is intended only 0.5.x. Points 3 and 4 are already fixed in 0.6.x. For 1 and 2, a separate PR has to created.