### PR TITLE
Add callbacks for all drag behavior in Scatter

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -521,15 +521,30 @@ class Scatter(Mark):
     update_on_move = Bool().tag(sync=True)
 
     def __init__(self, **kwargs):
+        self._drag_start_handlers = CallbackDispatcher()
+        self._drag_handlers = CallbackDispatcher()
         self._drag_end_handlers = CallbackDispatcher()
         super(Scatter, self).__init__(**kwargs)
+
+    def on_drag_start(self, callback, remove=False):
+        self._drag_start_handlers.register_callback(callback, remove=remove)
+
+    def on_drag(self, callback, remove=False):
+        self._drag_handlers.register_callback(callback, remove=remove)
 
     def on_drag_end(self, callback, remove=False):
         self._drag_end_handlers.register_callback(callback, remove=remove)
 
     def _handle_custom_msgs(self, _, content, buffers=None):
-        if content.get('event', '') == 'drag_end':
+        event = content.get('event', '')
+
+        if event == 'drag_start':
+            self._drag_start_handlers(self, content)
+        elif event == 'drag':
+            self._drag_handlers(self, content)
+        elif event == 'drag_end':
             self._drag_end_handlers(self, content)
+
         super(Scatter, self)._handle_custom_msgs(self, content)
 
     _view_name = Unicode('Scatter').tag(sync=True)

--- a/examples/Scatter.ipynb
+++ b/examples/Scatter.ipynb
@@ -13,7 +13,9 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "from IPython.display import display\n",
-    "from bqplot import *"
+    "from bqplot import (Axis, ColorAxis, LinearScale, DateScale, DateColorScale, OrdinalScale, OrdinalColorScale,\n",
+    "                    ColorScale, Scatter, Lines, Figure, Tooltip)\n",
+    "from ipywidgets import Label"
    ]
   },
   {
@@ -292,7 +294,7 @@
    },
    "outputs": [],
    "source": [
-    "factor = np.ceil(len(sec2_levels) * 1.0 / len(ordinal_data))\n",
+    "factor = int(np.ceil(len(sec2_levels) * 1.0 / len(ordinal_data)))\n",
     "ordinal_data = np.tile(ordinal_data, factor)\n",
     "\n",
     "c_ord = OrdinalColorScale(colors=['DodgerBlue', 'SeaGreen', 'Yellow', 'HotPink', 'OrangeRed'])\n",
@@ -346,8 +348,6 @@
    },
    "outputs": [],
    "source": [
-    "from bqplot.interacts import BrushSelector\n",
-    "\n",
     "sc_x = LinearScale()\n",
     "sc_y = LinearScale()\n",
     "sc_y2 = LinearScale()\n",
@@ -562,6 +562,55 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "latex_widget = Label(color='Green', font_size='16px')\n",
+    "\n",
+    "def callback_help(name, value):\n",
+    "    latex_widget.value = str(value)\n",
+    "    \n",
+    "latex_widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "scat.on_drag_start(callback_help)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "scat.on_drag(callback_help)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "scat.on_drag_end(callback_help)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "collapsed": true
    },
    "outputs": [],
@@ -714,320 +763,7 @@
    "version": "2.7.11"
   },
   "widgets": {
-   "state": {
-    "003d9b5ec9a644c3b8d58f49b6100060": {
-     "views": []
-    },
-    "02c96a8d8eee4bcb91bf11aecea988b6": {
-     "views": [
-      {
-       "cell_index": 30
-      }
-     ]
-    },
-    "03ac7db6113b4747a15c4c748ac00c91": {
-     "views": []
-    },
-    "0abf873c023948ac8629d78c15b4cdc1": {
-     "views": []
-    },
-    "0ce3b0950cd74d4a9a2c22f18b8e35f3": {
-     "views": [
-      {
-       "cell_index": 12
-      }
-     ]
-    },
-    "14936419b1954385bd972bc44e74170d": {
-     "views": []
-    },
-    "192a7dd037b04b3cb915d06f8a5f521b": {
-     "views": []
-    },
-    "19f72420eea44f1a87c1944410b5f5a5": {
-     "views": []
-    },
-    "1bbfa4768b6f41eaa4a5c6b7cd9d7ec2": {
-     "views": []
-    },
-    "1d7ab24d5ff844528135ca3cf137aa00": {
-     "views": []
-    },
-    "203964e614c147298d040ff149a7b96d": {
-     "views": []
-    },
-    "214707ad855346c8bcab880fd1c06464": {
-     "views": []
-    },
-    "257ef13cc53143c68132db3df995381d": {
-     "views": []
-    },
-    "280c18d5457d41e3a5ef31c9d16af660": {
-     "views": []
-    },
-    "298d852af8844a35a308440b30e4f043": {
-     "views": []
-    },
-    "304d90227fc94e7d93e49c76112c565b": {
-     "views": []
-    },
-    "37776ad6ac5743d2b5cd239defcacf0f": {
-     "views": []
-    },
-    "3d1c79ce5e224167a4ca5237a223b3d8": {
-     "views": []
-    },
-    "40d907cd541c46eb97211490bae598fe": {
-     "views": []
-    },
-    "4131698e9ac148ad8043bebc3ac6bbe1": {
-     "views": []
-    },
-    "4426515042b64e24bd7aa9b04fb1d081": {
-     "views": []
-    },
-    "473287e5cbbb45ebaaa409ac129db569": {
-     "views": []
-    },
-    "474d7f4d21b84aef8492f330ebc0ffe3": {
-     "views": []
-    },
-    "4adda665e44940db9ddcd0b452fde753": {
-     "views": []
-    },
-    "4ea9e9487ceb44fe93c901aecf7e053e": {
-     "views": []
-    },
-    "4ed77a0b54274801a7a3074298b6eb52": {
-     "views": []
-    },
-    "4f49ff114e51492ba2087ed5bb56f8cb": {
-     "views": []
-    },
-    "53784c8823f2471e9e69360c923b0684": {
-     "views": []
-    },
-    "54478a12849b43f0a0f116e83e0f2f33": {
-     "views": []
-    },
-    "56fa8a135df84446acf8765b741ce786": {
-     "views": []
-    },
-    "5b001c3b339e440ab01ad387391cf638": {
-     "views": []
-    },
-    "5dad5287fbdd48899b9145786ba8908f": {
-     "views": []
-    },
-    "5e9a00987203443a80f641dbe37dcd3e": {
-     "views": []
-    },
-    "5f2178e179c04da9accc0c58e728e0d6": {
-     "views": []
-    },
-    "6101562ded904be0a485021244416e8e": {
-     "views": []
-    },
-    "63c3810655d74e4c89efdbf28a1156f5": {
-     "views": [
-      {
-       "cell_index": 34
-      }
-     ]
-    },
-    "65775c873e6b43aa8c507e99c24cdd61": {
-     "views": []
-    },
-    "661c55b3d3674e1d855b9c701a1b2f76": {
-     "views": []
-    },
-    "66da3c13b21d478fabef9b9ec128a3f4": {
-     "views": []
-    },
-    "66dd351b498542b3bbd0ba59dbf01be7": {
-     "views": []
-    },
-    "67930e8179ff4e109748900978ac0255": {
-     "views": []
-    },
-    "68b9de19dfc34470b271e625a6a42b0a": {
-     "views": []
-    },
-    "68e32ecada484fa3b0bfde796bd2e43b": {
-     "views": []
-    },
-    "6956b91b316b4c8ea582a0b54de7e6e5": {
-     "views": []
-    },
-    "6c6cc4c656a24a05924c38820c00b463": {
-     "views": []
-    },
-    "6d50a0b2276c409bac89cda38f66d8b5": {
-     "views": []
-    },
-    "70874f5b2f264bb1b68f696967585bae": {
-     "views": []
-    },
-    "725654140aa448d08d4a0a3010959ff8": {
-     "views": []
-    },
-    "7387a9697dd349a4a5d7b1f47fd65d62": {
-     "views": []
-    },
-    "79911c8eb53b4fbdb268510e861a09a7": {
-     "views": []
-    },
-    "7bd5d395669e435fad444c7791505b7f": {
-     "views": []
-    },
-    "7c87ee0b6b514605a2c802c0153eb0b3": {
-     "views": [
-      {
-       "cell_index": 21
-      }
-     ]
-    },
-    "7e425bb3ea7a4adfbdfec9a780dcd3bc": {
-     "views": []
-    },
-    "7f16fcaa35b84ae1b200ad4cf3884f1b": {
-     "views": []
-    },
-    "7f5dde4390444c069069bd05acf7aa23": {
-     "views": []
-    },
-    "804f75af18b742db8b8fe683892e2f28": {
-     "views": []
-    },
-    "82b6e1bf191c40899629b14d8928b1b3": {
-     "views": []
-    },
-    "83a91da2dc65423ea4455f8969689788": {
-     "views": []
-    },
-    "850d9b0b83e441738a5019236e94a8a9": {
-     "views": []
-    },
-    "87f181a1962a4055a77ab0bb44baeb7b": {
-     "views": []
-    },
-    "8c6d882349da4df89542089e9e9ec819": {
-     "views": [
-      {
-       "cell_index": 5
-      }
-     ]
-    },
-    "917912a780cc47819a46f60695aac439": {
-     "views": [
-      {
-       "cell_index": 19
-      }
-     ]
-    },
-    "91f607d1dedd4b69a1b0a69cbdcc9981": {
-     "views": []
-    },
-    "9380fd90364344579894f018a2ae00b9": {
-     "views": []
-    },
-    "9adfac7526c449278b12019d27edb901": {
-     "views": []
-    },
-    "a4b03093b662483bab510c880ec2b746": {
-     "views": []
-    },
-    "a9df60aab1324053a53b5b3e9a061980": {
-     "views": []
-    },
-    "ac015487bdab464892813c15f7a6bf61": {
-     "views": []
-    },
-    "afe46a20e82c4a0d9c7cce075c2de878": {
-     "views": []
-    },
-    "b7275c92db7042529496bb7dc7ad1bce": {
-     "views": []
-    },
-    "b8727666ebce4f21baf9e7280684c626": {
-     "views": []
-    },
-    "bc5d5e6ba7ae41568f8542d94c0ff681": {
-     "views": []
-    },
-    "bd0d658abc3545718d1320051d11e67b": {
-     "views": [
-      {
-       "cell_index": 7
-      }
-     ]
-    },
-    "c1e2e6b8f9504713a562680883248747": {
-     "views": []
-    },
-    "c3edc82a510348398163c34e6fc181a2": {
-     "views": []
-    },
-    "c555234c92f540fcb7f69006466fa807": {
-     "views": []
-    },
-    "c6e6509faa474dc3b91a95395c77b40e": {
-     "views": [
-      {
-       "cell_index": 38
-      }
-     ]
-    },
-    "cbff75079a10455d93847596f001b644": {
-     "views": []
-    },
-    "ce4f7597166f47cab5004515679d378c": {
-     "views": []
-    },
-    "cf087822794541d495fcf67264a68637": {
-     "views": []
-    },
-    "d248ee9aa3c34fb4971e872a949bd08a": {
-     "views": []
-    },
-    "d593a976fc9741d981dce21917df585a": {
-     "views": []
-    },
-    "d9f9f7389b58417aba5116d7cf44dd3c": {
-     "views": []
-    },
-    "dcd22f38d4a54b5589c372f6a41182de": {
-     "views": []
-    },
-    "e48db504eba8496fbf8b279a933e1e9b": {
-     "views": [
-      {
-       "cell_index": 24
-      }
-     ]
-    },
-    "ef87e5c797664488810af848bf913dad": {
-     "views": []
-    },
-    "f12cbaec173e407eaa78aac9ebfcbc41": {
-     "views": []
-    },
-    "f19ad47b40b54f8ba8cc2bd2ad54eeec": {
-     "views": []
-    },
-    "f27eb5f2f96b4c238ca80cc23f70c171": {
-     "views": []
-    },
-    "f700cd86168c4490b80b14fd11888caf": {
-     "views": []
-    },
-    "faea2d78d5fc47a9be6f968933c5227b": {
-     "views": []
-    },
-    "fc2c8781792249eb89929b9cd1d952bc": {
-     "views": []
-    }
-   },
+   "state": {},
    "version": "2.0.0-dev"
   }
  },

--- a/js/src/Scatter.js
+++ b/js/src/Scatter.js
@@ -33,7 +33,7 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
 
             var that = this;
             this.drag_listener = d3.behavior.drag()
-              .on("dragstart", function(d) { return that.drag_start(d, this); })
+              .on("dragstart", function(d, i) { return that.drag_start(d, i, this); })
               .on("drag", function(d, i) { return that.on_drag(d, i, this); })
               .on("dragend", function(d, i) { return that.drag_ended(d, i, this); });
 
@@ -805,7 +805,7 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
             this.touch();
         },
 
-        drag_start: function(d, dragged_node) {
+        drag_start: function(d, i, dragged_node) {
             if (!this.model.get("enable_move")) {
                 return;
             }
@@ -826,6 +826,11 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
                   .style("fill", drag_color)
                   .style("stroke", drag_color);
             }
+            this.send({
+                event: "drag_start",
+                point: {x : d.x, y: d.y},
+                index: i
+            });
         },
 
         on_drag: function(d, i, dragged_node) {
@@ -855,6 +860,12 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
               .attr("transform", function() {
                   return "translate(" + d[0] + "," + d[1] + ")";
               });
+            this.send({
+                event: "drag",
+                origin: {x: d.x, y: d.y},
+		point: {x: x_scale.invert(d3.event.x), y: y_scale.invert(d3.event.y)},
+                index: i
+            });
             if(this.model.get("update_on_move")) {
                 // saving on move if flag is set
                 this.update_array(d, i);
@@ -908,7 +919,7 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
             this.update_array(d, i);
             this.send({
                 event: "drag_end",
-                point: { x : d.x, y: d.y},
+                point: {x : d.x, y: d.y},
                 index: i
             });
         },


### PR DESCRIPTION
This pull request adds two more callbacks to Scatter, namely the `on_drag_start` which is called when a point triggers a d3 `dragstart` event and `on_drag` which is called while a point is being dragged.

Unfortunately, it seems, for `dragstart` and `dragend` the current position of the `Scatter` point cannot be known. If they can, a similar template for `drag` can be followed.

@ssunkara1 @SylvainCorlay 