### PR TITLE
Add selection for click in Scatter Chart interactions

### DIFF
--- a/examples/Mark Interactions.ipynb
+++ b/examples/Mark Interactions.ipynb
@@ -23,6 +23,77 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Scatter Chart Selections\n",
+    "\n",
+    "Click a point on the `Scatter` plot to select it. Now, run the cell below to check the selection. After you've done this, try holding the `ctrl` (or `command` key on Mac) and clicking another point. Clicking the background will reset the selection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x_sc = LinearScale()\n",
+    "y_sc = LinearScale()\n",
+    "\n",
+    "x_data = np.arange(20)\n",
+    "y_data = np.random.randn(20)\n",
+    "\n",
+    "scatter_chart = Scatter(x=x_data, y=y_data, scales= {'x': x_sc, 'y': y_sc}, default_colors=['dodgerblue'],\n",
+    "                       interactions={'click': 'select'},\n",
+    "                        selected_style={'opacity': 1.0, 'fill': 'DarkOrange', 'stroke': 'Red'},\n",
+    "                       unselected_style={'opacity': 0.5})\n",
+    "\n",
+    "ax_x = Axis(scale=x_sc)\n",
+    "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
+    "\n",
+    "fig = Figure(marks=[scatter_chart], axes=[ax_x, ax_y])\n",
+    "display(fig)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "scatter_chart.selected"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternately, the `selected` attribute can be directly set on the Python side (try running the cell below):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "scatter_chart.selected = [1, 2, 3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Scatter Chart Interactions and Tooltips"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -359,7 +430,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.11"
+  },
+  "widgets": {
+   "state": {},
+   "version": "2.0.0-dev"
   }
  },
  "nbformat": 4,

--- a/js/src/Scatter.js
+++ b/js/src/Scatter.js
@@ -462,8 +462,9 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
             this.update_xy_position(animate);
 
             elements.call(this.drag_listener);
-            elements.on("click", _.bind(function() {
-                this.event_dispatcher("element_clicked");
+            elements.on("click", _.bind(function(d, i) {
+                this.event_dispatcher("element_clicked",
+				      {"data": d, "index": i});
             }, this));
 
             var names = this.model.get_typed_field("names"),
@@ -503,6 +504,10 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
                         this.event_listeners.parent_clicked = this.add_element;
                         this.event_listeners.element_clicked = function() {};
                     }
+		    else if (interactions.click == 'select') {
+       		        this.event_listeners.parent_clicked = this.reset_selection;
+			this.event_listeners.element_clicked = this.scatter_click_handler;
+		    }
                 } else {
                     this.reset_click();
                 }
@@ -538,6 +543,60 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
                 }
             }
         },
+
+        reset_selection: function() {
+            this.model.set("selected", null);
+            this.selected_indices = null;
+            this.touch();
+        },
+
+	scatter_click_handler: function(args) {
+            var data = args.data;
+            var index = args.index;
+            var that = this;
+            var idx = this.model.get("selected");
+            var selected = idx ? utils.deepCopy(idx) : [];
+            // index of bar i. Checking if it is already present in the list.
+            var elem_index = selected.indexOf(index);
+            // Replacement for "Accel" modifier.
+            var accelKey = d3.event.ctrlKey || d3.event.metaKey;
+
+	    if(elem_index > -1 && accelKey) {
+                // if the index is already selected and if accel key is
+                // pressed, remove the element from the list
+                selected.splice(elem_index, 1);
+            } else {
+		if(accelKey) {
+                    //If accel is pressed and the bar is not already selcted
+                    //add the bar to the list of selected bars.
+                    selected.push(index);
+                }
+                // updating the array containing the bar indexes selected
+                // and updating the style
+                else {
+                    //if accel is not pressed, then clear the selected ones
+                    //and set the current element to the selected
+                    selected = [];
+                    selected.push(index);
+                }
+            }
+            this.model.set("selected",
+                           ((selected.length === 0) ? null : selected),
+                           {updated_view: this});
+            this.touch();
+            if(!d3.event) {
+                d3.event = window.event;
+            }
+            var e = d3.event;
+            if(e.cancelBubble !== undefined) { // IE
+                e.cancelBubble = true;
+            }
+            if(e.stopPropagation) {
+                e.stopPropagation();
+            }
+            e.preventDefault();
+	},
+	
 
         draw_legend: function(elem, x_disp, y_disp, inter_x_disp, inter_y_disp) {
             this.legend_el = elem.selectAll(".legend" + this.uuid)


### PR DESCRIPTION
@ssunkara1 @ChakriCherukuri @rmenegaux This is regarding #154.

Should we have the `shift` key functionality for `Scatter` as well? It doesnt seem to make sense to me, since inherently there's no connection between the points index and its x-coordinate, should the shift move in x or y coordinates then?