### PR TITLE
Reinstated save_png method of figure

### DIFF
--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -91,6 +91,11 @@ class Figure(DOMWidget):
         is responsible for making sure that the width and height are greater
         than the sum of the margins.
 
+    Methods
+    -------
+
+    save_png:
+       Saves the figure as a png file
     """
     title = Unicode().tag(sync=True, display_name='Title')
     axes = List(Instance(Axis)).tag(sync=True, **widget_serialization)
@@ -118,6 +123,9 @@ class Figure(DOMWidget):
 
     def _scale_y_default(self):
         return LinearScale(min=0, max=1)
+
+    def save_png(self):
+        self.send({"type": "save_png"})
 
     _view_name = Unicode('Figure').tag(sync=True)
     _model_name = Unicode('FigureModel').tag(sync=True)

--- a/examples/Basic Plotting.ipynb
+++ b/examples/Basic Plotting.ipynb
@@ -57,6 +57,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This image can be saved by calling the `save_png` function of the `Figure` object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "fig.save_png()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Line Chart with dates as x data"
    ]
   },
@@ -199,7 +217,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.11"
+  },
+  "widgets": {
+   "state": {},
+   "version": "2.0.0-dev"
   }
  },
  "nbformat": 4,

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -173,9 +173,17 @@ define(["jupyter-js-widgets", "d3", "underscore"],
                     that.el.parentNode.appendChild(that.tooltip_div.node());
                     that.create_listeners();
                     that.update_layout();
+                    that.model.on("msg:custom", that.handle_custom_messages,
+				  that);
                 });
             });
         },
+
+	handle_custom_messages: function(msg) {
+            if (msg.type === 'save_png') {
+		    this.save_png();
+	    }
+	},
 
         replace_dummy_nodes: function(views) {
             _.each(views, function(view) {


### PR DESCRIPTION
@SylvainCorlay Brought back the save_png function for the `Figure`, @stonebig asked for a stable beta, I think this should probably be included