### PR TITLE
Change link to ipython/ipywidgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Help / Documentation
 
 - API reference documentation: [![Read the documentation of the stable version](https://readthedocs.org/projects/pip/badge/?version=stable)](http://bqplot.readthedocs.org/en/stable/) [![Read the documentation of the development version](https://readthedocs.org/projects/pip/badge/?version=latest)](http://bqplot.readthedocs.org/en/latest/)
 
-- Talk to us on our Gitter chat: [![Join the chat at https://gitter.im/bloomberg/bqplot](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bloomberg/bqplot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+- Talk to us on our Gitter chat: [![Join the chat at https://gitter.im/ipython/ipywidgets](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ipython/ipywidgets?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 License
 -------


### PR DESCRIPTION
Given the traffic on the bqplot chat, I would rather consolidate everything on the ipywidgets chat.