### PR TITLE
Update Light Theme

### DIFF
--- a/js/src/Axis.js
+++ b/js/src/Axis.js
@@ -489,8 +489,7 @@ define(["jupyter-js-widgets", "d3", "./utils", "underscore"],
                 .selectAll(".tick line")
                 .attr(is_x ? "y1" : "x1",
                       (this.offset_scale && grid_type !== "none")? tickOffset : null)
-                .style("stroke-dasharray", grid_type === "dashed" ? ("5, 5") : null)
-                .style("opacity", grid_type === "none" ? 1.0 : 0.2);
+                .style("stroke-dasharray", grid_type === "dashed" ? ("5, 5") : null);
 
             if (this.model.get("grid_color")) {
                 this.g_axisline

--- a/js/src/bqplot.less
+++ b/js/src/bqplot.less
@@ -125,8 +125,21 @@
     .common();
     svg.bqplot {
         .axis {
-            rect, path, line {
+            path, line {
                 stroke: #EEEEEE;
+            }
+            rect {
+                stroke: white;
+                opacity: 1.0;
+            }
+            .tick line {
+            	stroke: white;
+            	stroke-width: 1.4;
+                opacity: 1.0;
+            }
+            .tick text {
+                fill: #7f7f7f;
+                font: 12px sans-serif;
             }
         }
         .stick, .zeroLine {
@@ -147,11 +160,17 @@
         .grid-line {
             stroke: grey;
         }
-        text.axislabel, tspan.axislabel, text.mainheading {
+        text.axislabel, tspan.axislabel {
+            fill: #7f7f7f;
+            font: serif;
+        }
+        text.mainheading {
             fill: black;
+            font: serif;
+            font-size: large;
         }
         .plotarea_background {
-            fill: #FBFBFB;
+            fill: #EEEEEE;
         }
     }
     .mark_tooltip {

--- a/js/src/bqplot.less
+++ b/js/src/bqplot.less
@@ -151,7 +151,7 @@
             fill: black;
         }
         .plotarea_background {
-            fill: #F7F7F7;
+            fill: #FBFBFB;
         }
     }
     .mark_tooltip {

--- a/js/src/bqplot.less
+++ b/js/src/bqplot.less
@@ -126,7 +126,7 @@
     svg.bqplot {
         .axis {
             rect, path, line {
-                stroke: black;
+                stroke: #EEEEEE;
             }
         }
         .stick, .zeroLine {


### PR DESCRIPTION
@bloomberg/bqplot-developers I updated the `theme-light` `Figure` background  because the grey is a bit too contrasting to something closer to white.

What other changes can we think of? Maybe crisper axes?