### PR TITLE
Change README.md to remove bq. imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,25 +94,26 @@ plt.show()
 ```python
 import numpy as np
 from IPython.display import display
-import bqplot as bq
+from bqplot import (OrdinalScale, LinearScale, Bars,
+                    Lines, Axis, Figure)
 
 size = 20
 np.random.seed(0)
 
 x_data = np.arange(size)
 
-x_ord = bq.OrdinalScale()
-y_sc = bq.LinearScale()
+x_ord = OrdinalScale()
+y_sc = LinearScale()
 
-bar = bq.Bars(x=x_data, y=np.random.randn(2, size), scales={'x': x_ord, 'y': y_sc},
+bar = Bars(x=x_data, y=np.random.randn(2, size), scales={'x': x_ord, 'y': y_sc},
               type='stacked')
-line = bq.Lines(x=x_data, y=np.random.randn(size), scales={'x': x_ord, 'y': y_sc},
+line = Lines(x=x_data, y=np.random.randn(size), scales={'x': x_ord, 'y': y_sc},
                 stroke_width=3, colors=['red'], display_legend=True, labels=['Line chart'])
 
-ax_x = bq.Axis(scale=x_ord)
-ax_y = bq.Axis(scale=y_sc, orientation='vertical', tick_format='0.2f', grid_lines='solid')
+ax_x = Axis(scale=x_ord)
+ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f', grid_lines='solid')
 
-fig = bq.Figure(marks=[bar, line], axes=[ax_x, ax_y])
+fig = Figure(marks=[bar, line], axes=[ax_x, ax_y], title='API Example')
 display(fig)
 ```
 


### PR DESCRIPTION
@SylvainCorlay @rmenegaux This change is because none of the examples or talks ever use bq. This is pretty much the only place. I guess it needs to be changed.

I also added a title.