### PR TITLE
remove indexing by label in Lines.js

### DIFF
--- a/js/src/Lines.js
+++ b/js/src/Lines.js
@@ -304,7 +304,7 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
                         opacity: d.opacity};
             });
             this.legend_el = elem.selectAll(".legend" + this.uuid)
-              .data(legend_data, function(d, i) { return d.name; });
+              .data(legend_data);
 
             var that = this,
                 rect_dim = inter_y_disp * 0.8,
@@ -500,7 +500,7 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
         draw: function(animate) {
             this.set_ranges();
             var curves_sel = this.el.selectAll(".curve")
-              .data(this.model.mark_data, function(d, i) { return d.name; });
+              .data(this.model.mark_data);
 
             var new_curves = curves_sel.enter().append("g")
               .attr("class", "curve");


### PR DESCRIPTION
The curves should not be indexed by their labels since we do not impose a one-to-one mapping between them.
This fixes issue #129
It will also make the legend display properly in case there are identical labels. 