### PR TITLE
line labels move with the line

### DIFF
--- a/js/src/Lines.js
+++ b/js/src/Lines.js
@@ -103,6 +103,7 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
                 var animate = true;
                 this.draw(animate);
             }, this);
+            this.listenTo(this.model, "labels_updated", this.update_labels, this);
             this.listenTo(this.model, "change:stroke_width", this.update_stroke_width, this);
             this.listenTo(this.model, "change:labels_visibility", this.update_legend_labels, this);
             this.listenTo(this.model, "change:curves_subset", this.update_curves_subset, this);
@@ -133,6 +134,13 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
                 this.el.selectAll(".curve_label")
                   .attr("display", "none");
             }
+        },
+
+        update_labels: function() {
+            var curves_sel = this.el.selectAll(".curve")
+              .data(this.model.mark_data)
+              .select(".curve_label")
+              .text(function(d) { return d.name; });
         },
 
         get_line_style: function() {
@@ -297,7 +305,7 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
         },
 
         draw_legend: function(elem, x_disp, y_disp, inter_x_disp, inter_y_disp) {
-            var curve_labels = this.model.update_labels();
+            var curve_labels = this.model.get_labels();
             var legend_data = this.model.mark_data.map(function(d) {
                 return {index: d.index, name: d.name, color: d.color,
                         opacity: d.opacity};
@@ -471,7 +479,7 @@ define(["d3", "./Mark", "./utils", "./Markers", "underscore"],
               .transition().duration(animation_duration)
               .attr("d", function(d) { return that.area(d.values); });
 
-            curves_sel.select("text")
+            curves_sel.select(".curve_label")
               .transition().duration(animation_duration)
               .attr("transform", function(d) {
                   var last_xy = d.values[d.values.length - 1];

--- a/js/src/LinesModel.js
+++ b/js/src/LinesModel.js
@@ -48,6 +48,7 @@ define(["d3", "./MarkModel", "underscore"], function(d3, MarkModel, _) {
         initialize: function() {
             LinesModel.__super__.initialize.apply(this);
             this.on_some_change(["x", "y", "color"], this.update_data, this);
+            this.on("change:labels", this.update_labels, this);
             // FIXME: replace this with on("change:preserve_domain"). It is not done here because
             // on_some_change depends on the GLOBAL backbone on("change") handler which
             // is called AFTER the specific handlers on("change:foobar") and we make that
@@ -75,7 +76,7 @@ define(["d3", "./MarkModel", "underscore"], function(d3, MarkModel, _) {
                     this.x_data : [this.x_data];
                 this.y_data = this.y_data[0] instanceof Array ?
                     this.y_data : [this.y_data];
-                curve_labels = this.update_labels();
+                curve_labels = this.get_labels();
 
                 if (this.x_data.length == 1 && this.y_data.length > 1) {
                     // same x for all y
@@ -111,6 +112,15 @@ define(["d3", "./MarkModel", "underscore"], function(d3, MarkModel, _) {
         },
 
         update_labels: function() {
+            // update the names in mark_data
+            var labels = this.get_labels();
+            this.mark_data.forEach(function(element, i) {
+                element.name = labels[i];
+            });
+            this.trigger("labels_updated");
+        },
+
+        get_labels: function() {
             // Function to set the labels appropriately.
             // Setting the labels to the value sent and filling in the
             // remaining values.
@@ -214,7 +224,7 @@ define(["d3", "./MarkModel", "underscore"], function(d3, MarkModel, _) {
                     this.x_data : [this.x_data];
                 this.y_data = this.y_data[0] instanceof Array ?
                     this.y_data : [this.y_data];
-                curve_labels = this.update_labels();
+                curve_labels = this.get_labels();
                 var color_data = this.get_typed_field("color");
                 var width_data = this.get_typed_field("width");
                 this.data_len = Math.min(this.x_data[0].length, this.y_data[0].length);


### PR DESCRIPTION
This does two things:
- Separates the creation of the labels and their positioning. The label positions update correctly now, including with panning and zooming.
- Adds a listener to a change in the `labels` trait, that correctly updates the inline labels.
Also updates the d3 bound data of the elements, to keep the names consistent.