### PR TITLE
pyplot fixes

### DIFF
--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -119,10 +119,14 @@ class HandDraw(Interaction):
     lines = Instance(Lines, allow_none=True, default_value=None).tag(sync=True, **widget_serialization)
     line_index = Int().tag(sync=True)
     # TODO: Handle infinity in a meaningful way (json does not)
-    min_x = (Float(None, allow_none=True).tag(sync=True) |
-             Date(None, allow_none=True).tag(sync=True))
-    max_x = (Float(None, allow_none=True).tag(sync=True) |
-             Date(None, allow_none=True).tag(sync=True))
+    min_x = (
+            Float(None, allow_none=True).tag(sync=True) |
+            Date(None, allow_none=True).tag(sync=True)
+        )
+    max_x = (
+            Float(None, allow_none=True).tag(sync=True) |
+            Date(None, allow_none=True).tag(sync=True)
+        )
 
     _view_name = Unicode('HandDraw').tag(sync=True)
     _model_name = Unicode('HandDrawModel').tag(sync=True)
@@ -156,13 +160,13 @@ class PanZoom(Interaction):
 def panzoom(marks):
     """Helper function for panning and zooming over a set of marks.
 
-    Creates and returns a panzoom interaction with the 'x' and 'y' scales
-    containing the scales of the marks passed.
+    Creates and returns a panzoom interaction with the 'x' and 'y' dimension
+    scales of the specified marks.
     """
     return PanZoom(scales={
-        'x': [mark.scales.get('x') for mark in marks if 'x' in mark.scales],
-        'y': [mark.scales.get('y') for mark in marks if 'y' in mark.scales],
-    })
+            'x': sum([mark._get_dimension_scales('x', preserve_domain=True) for mark in marks], []),
+            'y': sum([mark._get_dimension_scales('y', preserve_domain=True) for mark in marks], [])
+        })
 
 
 class Selector(Interaction):

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -35,8 +35,9 @@ Marks
    Map
 """
 from ipywidgets import Widget, DOMWidget, CallbackDispatcher, Color, widget_serialization
-from traitlets import (Int, Unicode, List, Enum, Dict, Bool, Float, TraitError,
-                       Instance, Tuple)
+from traitlets import (
+        Int, Unicode, List, Enum, Dict, Bool, Float, TraitError, Instance, Tuple
+    )
 
 from .scales import Scale, OrdinalScale
 from .traits import NdArray, Date
@@ -160,10 +161,35 @@ class Mark(Widget):
     _view_module = Unicode('bqplot').tag(sync=True)
     _ipython_display_ = None
 
+    def _get_dimension_scales(self, dimension, preserve_domain=False):
+        """
+        Return the list of scales corresponding to a given dimension.
+
+        The preserve_domain optional argument specifies whether one should
+        filter out the scales for which preserve_domain is set to True.
+        """
+        if preserve_domain:
+            return [
+                self.scales[k] for k in self.scales if (
+                    k in self.scales_metadata
+                    and self.scales_metadata[k].get('dimension') == dimension
+                    and not self.preserve_domain.get(k)
+                )
+            ]
+        else:
+            return [
+                self.scales[k] for k in self.scales if (
+                    k in self.scales_metadata
+                    and self.scales_metadata[k].get('dimension') == dimension
+                )
+            ]
+
     def _scales_validate(self, scales, scales_trait):
-        """validates the dictionary of scales based on the mark's scaled
-        attributes metadata. First checks for missing scale and then for
-        'rtype' compatibility."""
+        """
+        Validates the `scales` based on the mark's scaled attributes metadata.
+
+        First checks for missing scale and then for 'rtype' compatibility.
+        """
         # Validate scales' 'rtype' versus data attribute 'rtype' decoration
         # At this stage it is already validated that all values in self.scales
         # are instances of Scale.

--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -367,7 +367,7 @@ def grids(fig=None, value='solid'):
 
 def hline(level, fig=None, preserve_domain=False, **kwargs):
     """Draws a horizontal line at the given level.
-    
+
     Parameters
     ----------
     level: float
@@ -383,9 +383,10 @@ def hline(level, fig=None, preserve_domain=False, **kwargs):
     if fig is None:
         fig = current_figure()
     sc_x = fig.scale_x
-    plot([0., 1.], [level, level], scales={'x': sc_x}, preserve_domain={'x': True,
-         'y': preserve_domain}, axes=False, colors=default_colors,
-         stroke_width=default_width, update_context=False)
+    return plot([0., 1.], [level, level], scales={ 'x': sc_x }, preserve_domain={
+        'x': True,
+        'y': preserve_domain
+    }, axes=False, colors=default_colors, stroke_width=default_width, update_context=False)
 
 
 def vline(level, fig=None, preserve_domain=False, **kwargs):
@@ -406,9 +407,10 @@ def vline(level, fig=None, preserve_domain=False, **kwargs):
     if fig is None:
         fig = current_figure()
     sc_y = fig.scale_y
-    plot([level, level], [0., 1.], scales={'y': sc_y}, preserve_domain={'x': preserve_domain,
-         'y': True}, axes=False, colors=default_colors,
-         stroke_width=default_width, update_context=False)
+    return plot([level, level], [0., 1.], scales={ 'y': sc_y }, preserve_domain={
+        'x': preserve_domain,
+        'y': True
+    }, axes=False, colors=default_colors, stroke_width=default_width, update_context=False)
 
 
 def _draw_mark(mark_type, options={}, axes_options={}, **kwargs):
@@ -443,7 +445,7 @@ def _draw_mark(mark_type, options={}, axes_options={}, **kwargs):
         elif name in scales:
             if update_context:
                 _context['scales'][dimension] = scales[name]
-        # Scale has to be fetched from the conext or created as it has not
+        # Scale has to be fetched from the context or created as it has not
         # been passed.
         elif dimension not in _context['scales']:
             # Creating a scale for the dimension if a matching scale is not
@@ -453,10 +455,12 @@ def _draw_mark(mark_type, options={}, axes_options={}, **kwargs):
             dtype = traitlet.validate(None, kwargs[name]).dtype
             # Fetching the first matching scale for the rtype and dtype of the
             # scaled attributes of the mark.
-            compat_scale_types = [Scale.scale_types[key]
-                                  for key in Scale.scale_types
-                                  if Scale.scale_types[key].rtype == rtype and
-                                  issubdtype(dtype, Scale.scale_types[key].dtype)]
+            compat_scale_types = [
+                    Scale.scale_types[key]
+                    for key in Scale.scale_types
+                    if Scale.scale_types[key].rtype == rtype and
+                    issubdtype(dtype, Scale.scale_types[key].dtype)
+                ]
             sorted_scales = sorted(compat_scale_types, key=lambda x: x.precedence)
             scales[name] = sorted_scales[-1](**options.get(name, {}))
             # Adding the scale to the conext scales

--- a/js/src/Toolbar.js
+++ b/js/src/Toolbar.js
@@ -121,13 +121,14 @@ define([
                 return Promise.all(figure.get("marks")).then(function(marks) {
                     var x_scales = [], y_scales = [];
                     for (var i=0; i<marks.length; ++i) {
+                        var preserve_domain = marks[i].get("preserve_domain");
                         var scales = marks[i].get("scales");
                         _.each(scales, function(v, k) {
                             var dimension = marks[i].get("scales_metadata")[k]["dimension"];
-                            if (dimension === "x") {
+                            if (dimension === "x" && !preserve_domain[k]) {
                                  x_scales.push(scales[k]);
                             }
-                            if (dimension === "y") {
+                            if (dimension === "y" && !preserve_domain[k]) {
                                  y_scales.push(scales[k]);
                             }
                         });


### PR DESCRIPTION
 - the `panzoom` python helper function uses scales corresponding to a given dimension.
 - toolbar widget does the same thing.
 - we filter with the `preserve_domain` attribute.
 - `vline` and `hline` now return the mark like other drawing routines in pyplot.

This fixes #220 .