### PR TITLE
fixing setup.py for windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,9 @@ class NPM(Command):
 
     def has_npm(self):
         try:
-            check_call(['npm', '--version'], shell=True)
+            ## shell=True needs to be passed for windows to look at non .exe files.
+            shell = (sys.platform == 'win32')
+            check_call(['npm', '--version'], shell=shell)
             return True
         except:
             return False
@@ -141,7 +143,9 @@ class NPM(Command):
 
         if self.should_run_npm_install():
             log.info("Installing build dependencies with npm.  This may take a while...")
-            check_call(['npm', 'install'], cwd=node_root, stdout=sys.stdout, stderr=sys.stderr, shell=True)
+            ## shell=True needs to be passed for windows to look at non .exe files.
+            shell = (sys.platform == 'win32')
+            check_call(['npm', 'install'], cwd=node_root, stdout=sys.stdout, stderr=sys.stderr, shell=shell)
             os.utime(self.node_modules, None)
 
         for t in self.targets:

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ class NPM(Command):
 
     def has_npm(self):
         try:
-            check_call(['npm', '--version'])
+            check_call(['npm', '--version'], shell=True)
             return True
         except:
             return False
@@ -141,7 +141,7 @@ class NPM(Command):
 
         if self.should_run_npm_install():
             log.info("Installing build dependencies with npm.  This may take a while...")
-            check_call(['npm', 'install'], cwd=node_root, stdout=sys.stdout, stderr=sys.stderr)
+            check_call(['npm', 'install'], cwd=node_root, stdout=sys.stdout, stderr=sys.stderr, shell=True)
             os.utime(self.node_modules, None)
 
         for t in self.targets:


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/6981114/17058314/ce2583fe-4fed-11e6-8e1e-ca95407f6d26.png)

the `check_call` command works only for .exe files. .cmd files are not found by that unless the additional argument is passed and npm is not a .exe file. 

I checked that this works on windows and Ubuntu. Have not checked it on a mac.