### PR TITLE
Lighter tick marks

### DIFF
--- a/js/src/bqplot.less
+++ b/js/src/bqplot.less
@@ -157,9 +157,6 @@
         .brushintsel, .intsel {
             fill: #000000;
         }
-        .grid-line {
-            stroke: grey;
-        }
         text.axislabel, tspan.axislabel {
             fill: black;
             font: serif;
@@ -209,10 +206,10 @@
                 stroke: #1A1A1A;
             }
             .tick.short line {
-                stroke: grey;
+                stroke: #B3B3B3;
             }
             .tick text {
-                fill: grey;
+                fill: #B3B3B3;
             }
         }
         .stick, .zeroLine {


### PR DESCRIPTION
<img width="771" alt="screen shot 2016-07-29 at 5 26 10 pm" src="https://cloud.githubusercontent.com/assets/2397974/17253584/a207f12a-55b1-11e6-84bd-ef4916f03780.png">

The color is the same as the one of the rendered markdown and button captions.