### PR TITLE
Bug fix with domain reverse

### DIFF
--- a/js/src/ColorScaleModel.js
+++ b/js/src/ColorScaleModel.js
@@ -21,8 +21,15 @@ var ColorScaleModel = linearscalemodel.LinearScaleModel.extend({
 
     initialize: function() {
         ColorScaleModel.__super__.initialize.apply(this, arguments);
+    },
+
+    set_init_state: function() {
         this.type = "color_linear";
         this.divergent = false;
+    },
+
+    set_listeners: function() {
+        ColorScaleModel.__super__.set_listeners.apply(this, arguments);
         this.on("change:mid", this.mid_changed, this);
         this.mid_changed();
     },

--- a/js/src/DateScaleModel.js
+++ b/js/src/DateScaleModel.js
@@ -30,6 +30,9 @@ var DateScaleModel = linearscalemodel.LinearScaleModel.extend({
 
     initialize: function() {
         DateScaleModel.__super__.initialize.apply(this, arguments);
+    },
+
+    set_init_state: function() {
         this.type = "date";
         this.global_min = (new Date()).setTime(0);
         this.global_max = new Date();

--- a/js/src/LinearScaleModel.js
+++ b/js/src/LinearScaleModel.js
@@ -28,13 +28,19 @@ var LinearScaleModel = scalemodel.ScaleModel.extend({
 
     initialize: function() {
         LinearScaleModel.__super__.initialize.apply(this, arguments);
+    },
+
+    set_init_state: function() {
         this.type = "linear";
         this.global_min = Number.NEGATIVE_INFINITY;
         this.global_max = Number.POSITIVE_INFINITY;
-        this.on_some_change(["min", "max"], this.min_max_changed, this);
-        this.min_max_changed();
+    },
+
+    set_listeners: function() {
         this.on("change:reverse", this.reverse_changed, this);
         this.reverse_changed();
+        this.on_some_change(["min", "max"], this.min_max_changed, this);
+        this.min_max_changed();
     },
 
     min_max_changed: function() {
@@ -45,9 +51,15 @@ var LinearScaleModel = scalemodel.ScaleModel.extend({
         this.update_domain();
     },
 
-    reverse_changed: function() {
+    reverse_changed: function(model, value, options) {
+        var prev_reverse = (model === undefined) ? false : model.previous("reverse");
         this.reverse = this.get("reverse");
-        if(this.domain.length > 0) {
+
+        // the domain should be reversed only if the previous value of reverse
+        // is different from the current value. During init, domain should be
+        // reversed only if reverse is set to True.
+        var reverse_domain = (prev_reverse + this.reverse) % 2;
+        if(this.domain.length > 0 && reverse_domain === 1) {
             this.domain.reverse();
             this.trigger("domain_changed", this.domain);
         }

--- a/js/src/LinearScaleModel.js
+++ b/js/src/LinearScaleModel.js
@@ -47,7 +47,7 @@ var LinearScaleModel = scalemodel.ScaleModel.extend({
 
     reverse_changed: function() {
         this.reverse = this.get("reverse");
-        if(this.domain.length > 0 && this.reverse) {
+        if(this.domain.length > 0) {
             this.domain.reverse();
             this.trigger("domain_changed", this.domain);
         }

--- a/js/src/LogScaleModel.js
+++ b/js/src/LogScaleModel.js
@@ -20,14 +20,14 @@ var LogScaleModel = linearscalemodel.LinearScaleModel.extend({
 
     initialize: function() {
         LogScaleModel.__super__.initialize.apply(this, arguments);
+    },
+
+    set_init_state: function() {
         this.type = "log";
         this.global_min = Number.MIN_VALUE;
         this.global_max = Number.POSITIVE_INFINITY;
-        this.on_some_change(["min", "max"], this.min_max_changed, this);
-        this.on("change:reverse", this.reverse_changed, this);
-        this.min_max_changed();
-        this.reverse_changed();
-    }
+    },
+
 });
 
 module.exports = {

--- a/js/src/OrdinalScaleModel.js
+++ b/js/src/OrdinalScaleModel.js
@@ -21,9 +21,15 @@ var OrdinalScaleModel = scalemodel.ScaleModel.extend({
 
     initialize: function() {
         OrdinalScaleModel.__super__.initialize.apply(this, arguments);
+    },
+
+    set_init_state: function() {
         this.type = "ordinal";
         this.min_from_data = true;
         this.max_from_data = true;
+    },
+
+    set_listeners: function() {
         this.on("change:domain", this.domain_changed, this);
         this.domain_changed();
         this.on("change:reverse", this.reverse_changed, this);
@@ -45,8 +51,15 @@ var OrdinalScaleModel = scalemodel.ScaleModel.extend({
         }
     },
 
-    reverse_changed: function() {
-        if(this.domain.length > 0) {
+    reverse_changed: function(model, value, options) {
+        var prev_reverse = (model === undefined) ? false : model.previous("reverse");
+        this.reverse = this.get("reverse");
+
+        // the domain should be reversed only if the previous value of reverse
+        // is different from the current value. During init, domain should be
+        // reversed only if reverse is set to True.
+        var reverse_domain = (prev_reverse + this.reverse) % 2;
+        if(this.domain.length > 0 && reverse_domain === 1) {
             this.domain.reverse();
             this.trigger("domain_changed", this.domain);
         }

--- a/js/src/ScaleModel.js
+++ b/js/src/ScaleModel.js
@@ -30,9 +30,18 @@ var ScaleModel = basemodel.BaseModel.extend({
 
     initialize: function() {
         ScaleModel.__super__.initialize.apply(this, arguments);
-        this.type = "base";
         this.domains = {};
         this.domain = [];
+        this.set_init_state();
+        this.set_listeners();
+    },
+
+    set_init_state: function() {
+        this.type = "base";
+    },
+
+    set_listeners: function() {
+        // Function to be implementd by inherited classes.
     },
 
     set_domain: function(domain, id) {


### PR DESCRIPTION
This is fixing an issue introduced in #237. 

With the previous change, if we update `reverse` from `True` to `False` nothing happens. Since the function was being called whenever `reverse` is changed, I think the logic of the function is fine.

With regards to the issue that @jmabille was facing, I ran into the issue before but I cannot reproduce it now. I think the issue (@jmabille correct me if I am wrong) was that when no data is passed to the `DateScale`, the default domain of the scale is from `[today, epoch date (1970, 1, 1)]`. That issue is slightly different and does not have much to do with the `reverse`. 

I marked the PR as WIP as I want the issue @jmabille faced to be fixed as part of this.