### PR TITLE
Stabilized Scale

### DIFF
--- a/bqplot/scales.py
+++ b/bqplot/scales.py
@@ -353,9 +353,12 @@ class LinearScale(Scale):
         mid_range and min_range.
     mid_range: float (default: 0.8)
         Proportion of the range that is spanned initially.
+        Used only if stabilized is True.
     min_range: float (default: 0.6)
         Minimum proportion of the range that should be spanned by the data.
         If the data span falls beneath that level, the scale is reset.
+        min_range must be <= mid_range.
+        Used only if stabilized is True.
     """
     rtype = 'Number'
     dtype = np.number

--- a/bqplot/scales.py
+++ b/bqplot/scales.py
@@ -346,12 +346,25 @@ class LinearScale(Scale):
         two or more scales have the same rtype and dtype.
         default_value is 2 because for the same range and domain types,
         LinearScale should take precedence.
+    stabilized: bool (default: False)
+        if set to False, the domain of the scale is tied to the data range
+        if set to True, the domain of the scale is udpated only when
+        the data range is beyond certain thresholds, given by the attributes
+        mid_range and min_range.
+    mid_range: float (default: 0.8)
+        Proportion of the range that is spanned initially.
+    min_range: float (default: 0.6)
+        Minimum proportion of the range that should be spanned by the data.
+        If the data span falls beneath that level, the scale is reset.
     """
     rtype = 'Number'
     dtype = np.number
     precedence = 2
     min = Float(None, allow_none=True).tag(sync=True)
     max = Float(None, allow_none=True).tag(sync=True)
+    stabilized = Bool(False).tag(sync=True)
+    min_range = Float(0.6, min=0.0, max=1.0).tag(sync=True)
+    mid_range = Float(0.8, min=0.1, max=1.0).tag(sync=True)
 
     _view_name = Unicode('LinearScale').tag(sync=True)
     _model_name = Unicode('LinearScaleModel').tag(sync=True)

--- a/js/src/LinearScaleModel.js
+++ b/js/src/LinearScaleModel.js
@@ -23,7 +23,9 @@ var LinearScaleModel = scalemodel.ScaleModel.extend({
         _model_name: "LinearScaleModel",
          _view_name: "LinearScale",
         min: null,
-        max: null
+        max: null,
+        min_range: 0.6,
+        mid_range: 0.8
     }),
 
     initialize: function() {
@@ -41,6 +43,7 @@ var LinearScaleModel = scalemodel.ScaleModel.extend({
         this.reverse_changed();
         this.on_some_change(["min", "max"], this.min_max_changed, this);
         this.min_max_changed();
+        this.on_some_change(["min_range", "mid_range", "stabilized"], this.update_domain, this);
     },
 
     min_max_changed: function() {
@@ -75,10 +78,28 @@ var LinearScaleModel = scalemodel.ScaleModel.extend({
             this.max : d3.max(_.map(this.domains, function(d) {
                 return d.length > 1 ? d[1] : that.global_min;
             }));
-        var prev_domain = this.domain;
-        var min_index = (this.reverse) ? 1 : 0;
-        if(min !== prev_domain[min_index] || max !== prev_domain[1 - min_index]) {
-            this.domain = (this.reverse) ? [max, min] : [min, max];
+        var mid = (min+max)/2,
+            new_width = (max-min)/2 / this.get("mid_range");
+            prev_domain = this.domain,
+            min_index = (this.reverse) ? 1 : 0,
+            prev_min = prev_domain[min_index],
+            prev_max = prev_domain[1 - min_index],
+            prev_mid = (prev_max+prev_min)/2,
+            min_width = (prev_max-prev_min)/2 * this.get("min_range");
+
+        var stabilized = this.get("stabilized");
+
+        // If the scale is stabilized, only update if the new min/max is without
+        // a certain range, else update as soon as the new min/max is different.
+        var update_domain = stabilized ?
+            (!(min >= prev_min) || !(min <= prev_mid-min_width) ||
+             !(max <= prev_max) || !(max >= prev_mid+min_width)) :
+            (min !== prev_min || max !== prev_max);
+        
+        if (update_domain) {
+            var new_min = stabilized ? mid - new_width : min,
+                new_max = stabilized ? mid + new_width : max;
+            this.domain = (this.reverse) ? [new_max, new_min] : [new_min, new_max];
             this.trigger("domain_changed", this.domain);
         }
     },

--- a/js/src/LinearScaleModel.js
+++ b/js/src/LinearScaleModel.js
@@ -78,14 +78,14 @@ var LinearScaleModel = scalemodel.ScaleModel.extend({
             this.max : d3.max(_.map(this.domains, function(d) {
                 return d.length > 1 ? d[1] : that.global_min;
             }));
-        var mid = (min+max)/2,
-            new_width = (max-min)/2 / this.get("mid_range");
+        var mid = (min + max) * 0.5,
+            new_width = (max - min) * 0.5 / this.get("mid_range");
             prev_domain = this.domain,
             min_index = (this.reverse) ? 1 : 0,
             prev_min = prev_domain[min_index],
             prev_max = prev_domain[1 - min_index],
-            prev_mid = (prev_max+prev_min)/2,
-            min_width = (prev_max-prev_min)/2 * this.get("min_range");
+            prev_mid = (prev_max + prev_min) * 0.5,
+            min_width = (prev_max - prev_min) * 0.5 * this.get("min_range");
 
         var stabilized = this.get("stabilized");
 
@@ -95,7 +95,7 @@ var LinearScaleModel = scalemodel.ScaleModel.extend({
             (!(min >= prev_min) || !(min <= prev_mid-min_width) ||
              !(max <= prev_max) || !(max >= prev_mid+min_width)) :
             (min !== prev_min || max !== prev_max);
-        
+
         if (update_domain) {
             var new_min = stabilized ? mid - new_width : min,
                 new_max = stabilized ? mid + new_width : max;

--- a/js/src/MarkModel.js
+++ b/js/src/MarkModel.js
@@ -67,7 +67,7 @@ var MarkModel = basemodel.BaseModel.extend({
 
     update_domains: function() {
         // update_domains is typically overloaded in each mark to update
-        // the domains related to it's scales
+        // the domains related to its scales
     },
 
     update_scales: function() {


### PR DESCRIPTION
As of now, unless a `min` and `max` is set, the domain of the scale is tied to the range of the data. This is what we want for static views, but in some cases we want to visualize the change in data-range. The `StabilizedScale` selectively updates its domain, changing it only when the range of the data becomes too small or too big (user-defined thresholds). 

How it works
---------------

- Initially, on the first draw and on each reset, the data spans a proportion `mid_range` (80% by default) of the total space.
- This domain is kept on change of the data, unless the new data range is more than 100%, or less than `min_range` (60% by default) of the current domain. In that case, the scale domain is reset. 

If either `min_range` or `mid_range` is changed from the back-end, the domain is reset.

Example
----------
```python
import numpy as np
import bqplot.pyplot as plt
from bqplot.scales import StabilizedScale
from ipywidgets import FloatSlider
from IPython.display import display

x = np.linspace(-4, 4, 50)
plt.figure(title='Stabilized y-scale', animation_duration=100)
line = plt.plot(x, np.cos(x), scales={'y': StabilizedScale()})

def update(change):
    line.y = change['new'] * np.cos(x)
    
i = FloatSlider(min=1.0)
i.observe(update, names='value', type='change')
plt.show()
display(i)
```

To be discussed
------------------
- Whether this should be just a boolean trait `stabilized` of the linear scale, or of any scale for that matter. The problem boils down to choosing the best default to avoid complicating the API. 
If `True`, all initial draws would have a 10% padding, which is excessive in my view.
I would personally either go for a `stabilized=False` default, or keep it as is.
- We don't impose `min_range` < `mid_range`


