### PR TITLE
Minor bug fix in Market Map font styles

### DIFF
--- a/js/src/MarketMap.js
+++ b/js/src/MarketMap.js
@@ -502,7 +502,7 @@ var MarketMap = figure.Figure.extend({
     },
 
     update_font_style: function(model, value) {
-        d3.selectAll(".market_map_text")
+        this.svg.selectAll(".market_map_text")
             .style(value);
     },
 


### PR DESCRIPTION
Right now, if there are more than 1 MarketMaps in the same notebook, changing the `font_style` for any one of the MarketMaps, changes the style for all of the MarketMaps.