### PR TITLE
Bug fixes for default values

### DIFF
--- a/bqplot/market_map.py
+++ b/bqplot/market_map.py
@@ -141,7 +141,7 @@ class MarketMap(DOMWidget):
     names = NdArray().tag(sync=True)
     groups = NdArray().tag(sync=True)
     display_text = NdArray().tag(sync=True)
-    ref_data = PandasDataFrame().tag(sync=True)
+    ref_data = PandasDataFrame(allow_none=True).tag(sync=True)
     title = Unicode().tag(sync=True)
 
     tooltip_fields = List().tag(sync=True)

--- a/bqplot/traits.py
+++ b/bqplot/traits.py
@@ -251,7 +251,7 @@ class PandasDataFrame(Instance):
         self.tag(to_json=self._to_json, from_json=self._from_json)
 
     def _from_json(self, value, obj=None):
-        if value is not None or value != []:
+        if value is not None and value != []:
             df = pd.DataFrame(value)
             df = df.set_index(self.index_name)
             df.index.name = None

--- a/examples/Marks/Market Map.ipynb
+++ b/examples/Marks/Market Map.ipynb
@@ -237,7 +237,7 @@
     "ax_y = Axis(scale=sc_y, orientation='vertical', grid_lines='dashed',\n",
     "            label='GDP', label_location='end', label_offset='-1em')\n",
     "\n",
-    "line = Lines(x= gdp_data.index.values, scales={'x': sc_x, 'y': sc_y}, colors=['orange'])\n",
+    "line = Lines(x= gdp_data.index.values, y=[], scales={'x': sc_x, 'y': sc_y}, colors=['orange'])\n",
     "fig_tooltip = Figure(marks=[line], axes=[ax_x, ax_y], min_width=600, min_height=400)"
    ]
   },
@@ -285,21 +285,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [Root]",
    "language": "python",
-   "name": "python2"
+   "name": "Python [Root]"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Scatter.ipynb
+++ b/examples/Marks/Scatter.ipynb
@@ -539,7 +539,7 @@
     "\n",
     "scat = Scatter(x=x_data[:10], y=y_data[:10], scales={'x': sc_x, 'y': sc_y}, default_colors=['orange'],\n",
     "               enable_move=True)\n",
-    "lin = Lines(scales={'x': sc_x, 'y': sc_y}, line_style='dotted', colors=['orange'])\n",
+    "lin = Lines(x=[], y=[], scales={'x': sc_x, 'y': sc_y}, line_style='dotted', colors=['orange'])\n",
     "\n",
     "def update_line(change=None):\n",
     "    with lin.hold_sync():\n",
@@ -745,26 +745,23 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [Root]",
    "language": "python",
-   "name": "python2"
+   "name": "Python [Root]"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
-  },
-  "widgets": {
-   "state": {},
-   "version": "2.0.0-dev"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Previously we were passing `() or `(0,)` as args to the constructor of `NdArray` and `PandaDataFrame` traits which was setting the default value. 

Also includes a bug fix for `_from_json` of `PandasDataFrame` trait.