### PR TITLE
Add drag_size attribute to objects

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -541,6 +541,7 @@ class Scatter(Mark):
     display_names = Bool(True).tag(sync=True, display_name='Display names')
     fill = Bool(True).tag(sync=True)
     drag_color = Color(None, allow_none=True).tag(sync=True)
+    drag_size = Float(None, allow_none=True).tag(sync=True)
     names_unique = Bool(True).tag(sync=True)
 
     enable_move = Bool().tag(sync=True)
@@ -857,6 +858,7 @@ class Label(Mark):
     rotate_angle = Float().tag(sync=True)
     text = NdArray(squeeze=True).tag(sync=True)
     font_size = Float(16.).tag(sync=True)
+    drag_size = Float(None, allow_none=True).tag(sync=True)
     font_unit = Enum(['px', 'em', 'pt', '%'], default_value='px').tag(sync=True)
     font_weight = Enum(['bold', 'normal', 'bolder'], default_value='bold').tag(sync=True)
     align = Enum(['start', 'middle', 'end'], default_value='start').tag(sync=True)

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -454,6 +454,8 @@ class Scatter(Mark):
         Default marker size in pixel.
         If size data is provided with a scale, default_size stands for the
         maximal marker size (i.e. the maximum value for the 'size' scale range)
+    drag_size: nonnegative float (default: 5.)
+        Ratio of the size of the dragged scatter size to the default scatter size.
     names: numpy.ndarray (default: [])
         Labels for the points of the chart
     display_names: bool (default: True)
@@ -831,6 +833,8 @@ class Label(Mark):
         font size in px, em or ex
     font_weight: {'bold', 'normal', 'bolder'}
         font weight of the caption
+    drag_size: nonnegative float (default: 1.)
+        Ratio of the size of the dragged label font size to the default label font size.
     align: {'start', 'middle', 'end'}
         alignment of the text with respect to the provided location
     enable_move: Bool

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -543,7 +543,7 @@ class Scatter(Mark):
     display_names = Bool(True).tag(sync=True, display_name='Display names')
     fill = Bool(True).tag(sync=True)
     drag_color = Color(None, allow_none=True).tag(sync=True)
-    drag_size = Float(None, allow_none=True).tag(sync=True)
+    drag_size = Float(5.).tag(sync=True)
     names_unique = Bool(True).tag(sync=True)
 
     enable_move = Bool().tag(sync=True)
@@ -862,7 +862,7 @@ class Label(Mark):
     rotate_angle = Float().tag(sync=True)
     text = NdArray(squeeze=True).tag(sync=True)
     font_size = Float(16.).tag(sync=True)
-    drag_size = Float(None, allow_none=True).tag(sync=True)
+    drag_size = Float(1.).tag(sync=True)
     font_unit = Enum(['px', 'em', 'pt', '%'], default_value='px').tag(sync=True)
     font_weight = Enum(['bold', 'normal', 'bolder'], default_value='bold').tag(sync=True)
     align = Enum(['start', 'middle', 'end'], default_value='start').tag(sync=True)

--- a/js/src/Label.js
+++ b/js/src/Label.js
@@ -309,7 +309,7 @@ var Label = mark.Mark.extend({
         // of the dragged point, for the length of the drag event
         var x_scale = this.x_scale, y_scale = this.y_scale;
         var font_size = this.model.get("font_size") + this.model.get("font_unit");
-        var dragged_size = (this.model.get("drag_size")) ? this.model.get("drag_size") + this.model.get("font_unit") : font_size;
+        var dragged_size = (this.model.get("drag_size")) ? (this.model.get("drag_size") * this.model.get("font_size")) + this.model.get("font_unit") : font_size;
         d[0] = x_scale.scale(d.x) + x_scale.offset;
         d[1] = y_scale.scale(d.y) + y_scale.offset;
 
@@ -365,7 +365,7 @@ var Label = mark.Mark.extend({
           .select("text")
           .classed("drag_label", false)
           .transition()
-          .attr("font-size", this.get_element_size(d));
+          .style("font-size", this.get_element_size(d));
 
         this.update_array(d, i);
         this.send({

--- a/js/src/Label.js
+++ b/js/src/Label.js
@@ -309,6 +309,7 @@ var Label = mark.Mark.extend({
         // of the dragged point, for the length of the drag event
         var x_scale = this.x_scale, y_scale = this.y_scale;
         var font_size = this.model.get("font_size") + this.model.get("font_unit");
+        var dragged_size = (this.model.get("drag_size")) ? this.model.get("drag_size") + this.model.get("font_unit") : font_size;
         d[0] = x_scale.scale(d.x) + x_scale.offset;
         d[1] = y_scale.scale(d.y) + y_scale.offset;
 
@@ -316,7 +317,7 @@ var Label = mark.Mark.extend({
           .select("text")
           .classed("drag_label", true)
           .transition()
-          .attr("font-size", (1.15 * font_size));
+          .style("font-size", (dragged_size));
 
         this.send({
             event: "drag_start",

--- a/js/src/Label.js
+++ b/js/src/Label.js
@@ -205,8 +205,8 @@ var Label = mark.Mark.extend({
             .text(function(d) {
                 return d.text;
             });
-            
-        this.set_drag_behavior();    
+
+        this.set_drag_behavior();
         this.update_style();
         this.update_default_opacities(true);
         this.update_position();
@@ -299,8 +299,8 @@ var Label = mark.Mark.extend({
         if (this.model.get("enable_move")) {
             labels.call(this.drag_listener);
         }
-        else { 
-            labels.on(".drag", null); 
+        else {
+            labels.on(".drag", null);
         }
     },
 
@@ -308,8 +308,7 @@ var Label = mark.Mark.extend({
         // d[0] and d[1] will contain the previous position (in pixels)
         // of the dragged point, for the length of the drag event
         var x_scale = this.x_scale, y_scale = this.y_scale;
-        var font_size = this.model.get("font_size") + this.model.get("font_unit");
-        var dragged_size = (this.model.get("drag_size")) ? (this.model.get("drag_size") * this.model.get("font_size")) + this.model.get("font_unit") : font_size;
+        var dragged_size = (this.model.get("drag_size") * this.model.get("font_size")) + this.model.get("font_unit");
         d[0] = x_scale.scale(d.x) + x_scale.offset;
         d[1] = y_scale.scale(d.y) + y_scale.offset;
 
@@ -344,7 +343,7 @@ var Label = mark.Mark.extend({
             event: "drag",
             origin: {x: d.x, y: d.y},
             point: {
-                x: x_scale.invert(d[0]), 
+                x: x_scale.invert(d[0]),
                 y: y_scale.invert(d[1])
             },
             index: i
@@ -371,7 +370,7 @@ var Label = mark.Mark.extend({
         this.send({
             event: "drag_end",
             point: {
-                x: x_scale.invert(d[0]), 
+                x: x_scale.invert(d[0]),
                 y: y_scale.invert(d[1])
             },
             index: i

--- a/js/src/LabelModel.js
+++ b/js/src/LabelModel.js
@@ -44,7 +44,7 @@ var LabelModel = markmodel.MarkModel.extend({
         text: [],
         font_size: 16.0,
         font_unit: "px",
-        drag_size: null,
+        drag_size: 1.0,
         font_weight: "bold",
         align: "start",
         enable_move: false,

--- a/js/src/LabelModel.js
+++ b/js/src/LabelModel.js
@@ -44,6 +44,7 @@ var LabelModel = markmodel.MarkModel.extend({
         text: [],
         font_size: 16.0,
         font_unit: "px",
+        drag_size: null,
         font_weight: "bold",
         align: "start",
         enable_move: false,

--- a/js/src/Scatter.js
+++ b/js/src/Scatter.js
@@ -944,7 +944,8 @@ var Scatter = mark.Mark.extend({
         var x_scale = this.scales.x, y_scale = this.scales.y;
         d[0] = x_scale.scale(d.x) + x_scale.offset;
         d[1] = y_scale.scale(d.y) + y_scale.offset;
-        var dragged_size = (this.model.get("drag_size")) ? this.model.get("drag_size") : 5 * this.model.get("default_size");
+        var drag_ratio = (this.model.get("drag_size")) ? this.model.get("drag_size") : 5;
+        var dragged_size = drag_ratio * this.model.get("default_size");
 
         d3.select(dragged_node)
           .select("path")

--- a/js/src/Scatter.js
+++ b/js/src/Scatter.js
@@ -485,7 +485,7 @@ var Scatter = mark.Mark.extend({
 	    elements.on("mouseout", _.bind(function() {
 		    this.reset_hover();
             this.apply_styles();
-	    }, this));	
+	    }, this));
         var names = this.model.get_typed_field("names"),
             text_loc = Math.sqrt(this.model.get("default_size")) / 2.0,
             show_names = (this.model.get("display_names") && names.length !== 0);
@@ -511,7 +511,7 @@ var Scatter = mark.Mark.extend({
             //set all the event listeners to blank functions
             this.reset_interactions();
         } else {
-            if(interactions.click !== undefined && 
+            if(interactions.click !== undefined &&
                interactions.click !== null) {
                 if(interactions.click === "tooltip") {
                     this.event_listeners.element_clicked = function() {
@@ -575,7 +575,7 @@ var Scatter = mark.Mark.extend({
                        index, {updated_view: this});
 	    this.touch();
     },
-	
+
     reset_selection: function() {
         this.model.set("selected", null);
         this.selected_indices = null;
@@ -944,8 +944,7 @@ var Scatter = mark.Mark.extend({
         var x_scale = this.scales.x, y_scale = this.scales.y;
         d[0] = x_scale.scale(d.x) + x_scale.offset;
         d[1] = y_scale.scale(d.y) + y_scale.offset;
-        var drag_ratio = (this.model.get("drag_size")) ? this.model.get("drag_size") : 5;
-        var dragged_size = drag_ratio * this.model.get("default_size");
+        var dragged_size = this.model.get("drag_size") * this.model.get("default_size");
 
         d3.select(dragged_node)
           .select("path")
@@ -985,7 +984,7 @@ var Scatter = mark.Mark.extend({
             event: "drag",
             origin: {x: d.x, y: d.y},
 	        point: {
-                x: x_scale.invert(d[0]), 
+                x: x_scale.invert(d[0]),
                 y: y_scale.invert(d[1])
             },
             index: i

--- a/js/src/Scatter.js
+++ b/js/src/Scatter.js
@@ -944,12 +944,13 @@ var Scatter = mark.Mark.extend({
         var x_scale = this.scales.x, y_scale = this.scales.y;
         d[0] = x_scale.scale(d.x) + x_scale.offset;
         d[1] = y_scale.scale(d.y) + y_scale.offset;
+        var dragged_size = (this.model.get("drag_size")) ? this.model.get("drag_size") : 5 * this.model.get("default_size");
 
         d3.select(dragged_node)
           .select("path")
           .classed("drag_scatter", true)
           .transition()
-          .attr("d", this.dot.size(5 * this.model.get("default_size")));
+          .attr("d", this.dot.size(dragged_size));
 
         var drag_color = this.model.get("drag_color");
         if (drag_color) {

--- a/js/src/ScatterModel.js
+++ b/js/src/ScatterModel.js
@@ -48,6 +48,7 @@ var ScatterModel = markmodel.MarkModel.extend({
         display_names: true,
         fill: true,
         drag_color: null,
+        drag_size: null,
         names_unique: true,
         enable_move: false,
         enable_delete: false,

--- a/js/src/ScatterModel.js
+++ b/js/src/ScatterModel.js
@@ -48,7 +48,7 @@ var ScatterModel = markmodel.MarkModel.extend({
         display_names: true,
         fill: true,
         drag_color: null,
-        drag_size: null,
+        drag_size: 5.0,
         names_unique: true,
         enable_move: false,
         enable_delete: false,


### PR DESCRIPTION
@ssunkara1 @SylvainCorlay Useful for different kinds of `Scatter`/`Label`

@rmenegaux There seems to be an issue with the `Label` drag, related to the `align` attribute.

- [x] #TODO: Move `align` and `offset` to respect the new `Label`