### PR TITLE
Remove uses of IPython.display.display

### DIFF
--- a/examples/Advanced Plotting/Advanced Plotting.ipynb
+++ b/examples/Advanced Plotting/Advanced Plotting.ipynb
@@ -10,7 +10,6 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from IPython.display import display\n",
     "from bqplot import *"
    ]
   },
@@ -77,10 +76,8 @@
     "                 labels=['Bar1', 'Bar2', 'Bar3'],\n",
     "                 display_legend=True)\n",
     "\n",
-    "fig = Figure(axes=[ord_ax, y_ax],  marks=[bar_chart, line_chart], legend_location = 'bottom-left')\n",
-    "\n",
     "# the line does not have a Y value set. So only the bars will be displayed\n",
-    "display(fig)"
+    "Figure(axes=[ord_ax, y_ax],  marks=[bar_chart, line_chart], legend_location = 'bottom-left')"
    ]
   },
   {
@@ -112,18 +109,7 @@
     "\n",
     "y_ax_2 = Axis(label='Test Y', scale=y_scale, orientation='vertical', tick_format='0.2f', grid_lines='none')\n",
     "\n",
-    "fig = Figure(axes=[x_ax, y_ax_2], marks=[hist])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "display(fig)"
+    "Figure(axes=[x_ax, y_ax_2], marks=[hist])"
    ]
   },
   {
@@ -174,8 +160,7 @@
     "lax_y = Axis(label='Log Price', scale=lsc, orientation='vertical', tick_format='0.1f', grid_lines='solid')\n",
     "\n",
     "logline = Lines(x=dates_all, y=final_prices, scales={'x': dt_scale, 'y': lsc}, colors=['hotpink', 'orange'])\n",
-    "logfig = Figure(axes=[ax_x, lax_y], marks=[logline], fig_margin = dict(left=100, right=100, top=100, bottom=70))\n",
-    "display(logfig)"
+    "Figure(axes=[ax_x, lax_y], marks=[logline], fig_margin = dict(left=100, right=100, top=100, bottom=70))"
    ]
   },
   {
@@ -210,8 +195,7 @@
     "bar_x = Axis(scale=ord_scale, orientation='horizontal', grid_lines='none', \n",
     "             set_ticks=True)\n",
     "bar_y = Axis(scale=lin_scale, orientation='vertical', grid_lines='none')\n",
-    "fig_2 = Figure(axes=[bar_x, bar_y], marks=[bar_chart, line_chart])\n",
-    "display(fig_2)"
+    "Figure(axes=[bar_x, bar_y], marks=[bar_chart, line_chart])"
    ]
   },
   {
@@ -237,8 +221,7 @@
     "\n",
     "ax_x = Axis(scale=sc_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical', tick_format='.2f')\n",
-    "fig = Figure(marks=[line_1], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[line_1], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -279,8 +262,7 @@
     "\n",
     "ax_x = Axis(scale=sc_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical')\n",
-    "fig = Figure(marks=[line_1, line_2], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[line_1, line_2], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -322,8 +304,7 @@
     "\n",
     "ax_x = Axis(scale=sc_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical')\n",
-    "fig = Figure(marks=[scatt_1, scatt_2], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[scatt_1, scatt_2], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -350,8 +331,7 @@
     "\n",
     "ax_x = Axis(scale=sc_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical')\n",
-    "fig = Figure(marks=[line_1], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[line_1], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -382,8 +362,7 @@
     "bar_x = Axis(scale=ord_scale, orientation='horizontal', set_ticks=True, grid_lines='none')\n",
     "bar_y = Axis(scale=y_scale, orientation='vertical', grid_lines='none')\n",
     "\n",
-    "fig_2 = Figure(axes=[bar_x, bar_y], marks=[bar_chart])\n",
-    "display(fig_2)"
+    "Figure(axes=[bar_x, bar_y], marks=[bar_chart])"
    ]
   },
   {
@@ -412,8 +391,7 @@
     "\n",
     "ax_x = Axis(scale=sc_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical')\n",
-    "fig = Figure(marks=[line_1, line_2], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[line_1, line_2], axes=[ax_x, ax_y])"
    ]
   }
  ],
@@ -433,7 +411,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Advanced Plotting/Animations.ipynb
+++ b/examples/Advanced Plotting/Animations.ipynb
@@ -23,8 +23,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import bqplot as bq\n",
-    "from IPython.display import display"
+    "import bqplot as bq"
    ]
   },
   {
@@ -44,8 +43,7 @@
     "xax = bq.Axis(scale=xs, label='x', grid_lines='solid')\n",
     "yax = bq.Axis(scale=ys, orientation='vertical', tick_format='0.2f', label='y', grid_lines='solid')\n",
     "\n",
-    "fig = bq.Figure(marks=[line], axes=[xax, yax], animation_duration=1000)\n",
-    "display(fig)"
+    "bq.Figure(marks=[line], axes=[xax, yax], animation_duration=1000)"
    ]
   },
   {
@@ -56,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "#update data of the line mark\n",
+    "# update data of the line mark\n",
     "line.y = np.cumsum(np.random.randn(2, 100), axis=1)"
    ]
   },
@@ -82,8 +80,7 @@
     "xax = bq.Axis(scale=xs, label='x', grid_lines='solid')\n",
     "yax = bq.Axis(scale=ys, orientation='vertical', tick_format='0.2f', label='y', grid_lines='solid')\n",
     "\n",
-    "fig = bq.Figure(marks=[scatt], axes=[xax, yax], animation_duration=1000)\n",
-    "display(fig)"
+    "bq.Figure(marks=[scatt], axes=[xax, yax], animation_duration=1000)"
    ]
   },
   {
@@ -191,8 +188,7 @@
     "xax = bq.Axis(scale=xs)\n",
     "yax = bq.Axis(scale=ys, orientation='vertical', tick_format='0.0%', grid_lines='solid')\n",
     "\n",
-    "fig = bq.Figure(marks=[bar], axes=[xax, yax], animation_duration=1000)\n",
-    "display(fig)"
+    "bq.Figure(marks=[bar], axes=[xax, yax], animation_duration=1000)"
    ]
   },
   {
@@ -237,8 +233,7 @@
     "yax1 = bq.Axis(scale=ys1, orientation='vertical', tick_format='0.1f', label='y', grid_lines='solid')\n",
     "yax2 = bq.Axis(scale=ys2, orientation='vertical', side='right', tick_format='0.0%', label='y1', grid_lines='none')\n",
     "\n",
-    "fig = bq.Figure(marks=[bar, line], axes=[xax, yax1, yax2], animation_duration=1000)\n",
-    "display(fig)"
+    "bq.Figure(marks=[bar, line], axes=[xax, yax1, yax2], animation_duration=1000)"
    ]
   },
   {
@@ -249,7 +244,7 @@
    },
    "outputs": [],
    "source": [
-    "#update mark data\n",
+    "# update mark data\n",
     "line.y = np.cumsum(np.random.randn(20))\n",
     "bar.y = np.random.rand(20)"
    ]
@@ -271,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Advanced Plotting/Animations.ipynb
+++ b/examples/Advanced Plotting/Animations.ipynb
@@ -23,7 +23,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import bqplot as bq"
+    "from bqplot import *"
    ]
   },
   {
@@ -34,16 +34,16 @@
    },
    "outputs": [],
    "source": [
-    "xs = bq.LinearScale()\n",
-    "ys = bq.LinearScale()\n",
+    "xs = LinearScale()\n",
+    "ys = LinearScale()\n",
     "x = np.arange(100)\n",
     "y = np.cumsum(np.random.randn(2, 100), axis=1) #two random walks\n",
     "\n",
-    "line = bq.Lines(x=x, y=y, scales={'x': xs, 'y': ys}, colors=['red', 'green'])\n",
-    "xax = bq.Axis(scale=xs, label='x', grid_lines='solid')\n",
-    "yax = bq.Axis(scale=ys, orientation='vertical', tick_format='0.2f', label='y', grid_lines='solid')\n",
+    "line = Lines(x=x, y=y, scales={'x': xs, 'y': ys}, colors=['red', 'green'])\n",
+    "xax = Axis(scale=xs, label='x', grid_lines='solid')\n",
+    "yax = Axis(scale=ys, orientation='vertical', tick_format='0.2f', label='y', grid_lines='solid')\n",
     "\n",
-    "bq.Figure(marks=[line], axes=[xax, yax], animation_duration=1000)"
+    "Figure(marks=[line], axes=[xax, yax], animation_duration=1000)"
    ]
   },
   {
@@ -73,14 +73,14 @@
    },
    "outputs": [],
    "source": [
-    "xs = bq.LinearScale()\n",
-    "ys = bq.LinearScale()\n",
+    "xs = LinearScale()\n",
+    "ys = LinearScale()\n",
     "x, y = np.random.rand(2, 20)\n",
-    "scatt = bq.Scatter(x=x, y=y, scales={'x': xs, 'y': ys}, default_colors=['blue'])\n",
-    "xax = bq.Axis(scale=xs, label='x', grid_lines='solid')\n",
-    "yax = bq.Axis(scale=ys, orientation='vertical', tick_format='0.2f', label='y', grid_lines='solid')\n",
+    "scatt = Scatter(x=x, y=y, scales={'x': xs, 'y': ys}, default_colors=['blue'])\n",
+    "xax = Axis(scale=xs, label='x', grid_lines='solid')\n",
+    "yax = Axis(scale=ys, orientation='vertical', tick_format='0.2f', label='y', grid_lines='solid')\n",
     "\n",
-    "bq.Figure(marks=[scatt], axes=[xax, yax], animation_duration=1000)"
+    "Figure(marks=[scatt], axes=[xax, yax], animation_duration=1000)"
    ]
   },
   {
@@ -114,8 +114,8 @@
    "outputs": [],
    "source": [
     "data = np.random.rand(10)\n",
-    "pie = bq.Pie(sizes=data, radius=150, sort=False, labels=list('ABCDEFGHIJ'))\n",
-    "bq.Figure(marks=[pie], animation_duration=1000)"
+    "pie = Pie(sizes=data, radius=150, sort=False, labels=list('ABCDEFGHIJ'))\n",
+    "Figure(marks=[pie], animation_duration=1000)"
    ]
   },
   {
@@ -181,14 +181,14 @@
    },
    "outputs": [],
    "source": [
-    "xs = bq.OrdinalScale()\n",
-    "ys = bq.LinearScale()\n",
+    "xs = OrdinalScale()\n",
+    "ys = LinearScale()\n",
     "\n",
-    "bar = bq.Bars(x=x, y=[y1, y2], scales={'x': xs, 'y': ys}, padding=0.2, type='grouped')\n",
-    "xax = bq.Axis(scale=xs)\n",
-    "yax = bq.Axis(scale=ys, orientation='vertical', tick_format='0.0%', grid_lines='solid')\n",
+    "bar = Bars(x=x, y=[y1, y2], scales={'x': xs, 'y': ys}, padding=0.2, type='grouped')\n",
+    "xax = Axis(scale=xs)\n",
+    "yax = Axis(scale=ys, orientation='vertical', tick_format='0.0%', grid_lines='solid')\n",
     "\n",
-    "bq.Figure(marks=[bar], axes=[xax, yax], animation_duration=1000)"
+    "Figure(marks=[bar], axes=[xax, yax], animation_duration=1000)"
    ]
   },
   {
@@ -218,22 +218,22 @@
    },
    "outputs": [],
    "source": [
-    "xs = bq.LinearScale()\n",
-    "ys1 = bq.LinearScale()\n",
-    "ys2 = bq.LinearScale()\n",
+    "xs = LinearScale()\n",
+    "ys1 = LinearScale()\n",
+    "ys2 = LinearScale()\n",
     "\n",
     "x = np.arange(20)\n",
     "y = np.cumsum(np.random.randn(20))\n",
     "y1 = np.random.rand(20)\n",
     "\n",
-    "line = bq.Lines(x=x, y=y, scales={'x': xs, 'y': ys1}, colors=['magenta'], marker='square')\n",
-    "bar = bq.Bars(x=x, y=y1, scales={'x': xs, 'y': ys2}, colorpadding=0.2, colors=['steelblue'])\n",
+    "line = Lines(x=x, y=y, scales={'x': xs, 'y': ys1}, colors=['magenta'], marker='square')\n",
+    "bar = Bars(x=x, y=y1, scales={'x': xs, 'y': ys2}, colorpadding=0.2, colors=['steelblue'])\n",
     "\n",
-    "xax = bq.Axis(scale=xs, label='x', grid_lines='solid')\n",
-    "yax1 = bq.Axis(scale=ys1, orientation='vertical', tick_format='0.1f', label='y', grid_lines='solid')\n",
-    "yax2 = bq.Axis(scale=ys2, orientation='vertical', side='right', tick_format='0.0%', label='y1', grid_lines='none')\n",
+    "xax = Axis(scale=xs, label='x', grid_lines='solid')\n",
+    "yax1 = Axis(scale=ys1, orientation='vertical', tick_format='0.1f', label='y', grid_lines='solid')\n",
+    "yax2 = Axis(scale=ys2, orientation='vertical', side='right', tick_format='0.0%', label='y1', grid_lines='none')\n",
     "\n",
-    "bq.Figure(marks=[bar, line], axes=[xax, yax1, yax2], animation_duration=1000)"
+    "Figure(marks=[bar, line], axes=[xax, yax1, yax2], animation_duration=1000)"
    ]
   },
   {

--- a/examples/Advanced Plotting/Axis Properties.ipynb
+++ b/examples/Advanced Plotting/Axis Properties.ipynb
@@ -9,7 +9,6 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from IPython.display import display\n",
     "from bqplot import *"
    ]
   },
@@ -53,7 +52,7 @@
     "\n",
     "m_fig = dict(left=100, top=50, bottom=50, right=100)\n",
     "fig = Figure(axes=[ax_x, ax_y], marks=[line], fig_margin=m_fig)\n",
-    "display(fig)"
+    "fig"
    ]
   },
   {
@@ -157,8 +156,7 @@
     "line = Lines(x=x_data, y=y_data_2, scales={'x': x_sc, 'y': y_sc}, colors=['hotpink', 'orange'])\n",
     "\n",
     "m_fig = dict(left=100, top=50, bottom=50, right=100)\n",
-    "fig = Figure(axes=[ax_x, ax_y], marks=[line], fig_margin=m_fig)\n",
-    "display(fig)"
+    "Figure(axes=[ax_x, ax_y], marks=[line], fig_margin=m_fig)"
    ]
   },
   {
@@ -211,8 +209,7 @@
     "line = Lines(x=x_data[:20], y=y_data[:20], scales={'x': x_sc, 'y': y_sc}, colors=['hotpink', 'orange'])\n",
     "\n",
     "m_fig = dict(left=50, top=50, bottom=50, right=50)\n",
-    "fig = Figure(axes=[ax_x, ax_y], marks=[line], fig_margin=m_fig)\n",
-    "display(fig)"
+    "Figure(axes=[ax_x, ax_y], marks=[line], fig_margin=m_fig)"
    ]
   },
   {
@@ -293,9 +290,8 @@
     "\n",
     "ax_y2 = Axis(label='Test Y2', scale=sc_y2, orientation='vertical', side='right', \n",
     "             tick_format='0.2f')\n",
-    "fig = Figure(axes=[ax_x, ax_y, ax_y2], marks=[sc1, sc2], legend_location='top-right',\n",
-    "             padding_x=0.025)\n",
-    "display(fig)"
+    "Figure(axes=[ax_x, ax_y, ax_y2], marks=[sc1, sc2], legend_location='top-right',\n",
+    "       padding_x=0.025)"
    ]
   },
   {
@@ -354,7 +350,7 @@
     "ax_c = ColorAxis(scale=col_sc, label='Color')\n",
     "\n",
     "margin=dict(top=80, left=80, right=80, bottom=80)\n",
-    "display(Figure(marks=[scatter], axes=[ax_x, ax_y, ax_c], fig_margin=margin))"
+    "Figure(marks=[scatter], axes=[ax_x, ax_y, ax_c], fig_margin=margin)"
    ]
   },
   {
@@ -417,7 +413,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Advanced Plotting/Plotting Dates.ipynb
+++ b/examples/Advanced Plotting/Plotting Dates.ipynb
@@ -12,7 +12,6 @@
     "import pandas as pd\n",
     "\n",
     "from bqplot import *\n",
-    "from IPython.display import display\n",
     "from datetime import datetime as dt\n",
     "\n",
     "from bqplot.traits import *"
@@ -65,8 +64,7 @@
     "ax_x = Axis(scale=dt_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[line], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[line], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -108,8 +106,7 @@
     "ax_x = Axis(scale=dt_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[line], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[line], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -147,8 +144,7 @@
     "ax_x = Axis(scale=dt_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[line], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[line], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -187,8 +183,7 @@
     "ax_x = Axis(scale=dt_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[line], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[line], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -225,8 +220,7 @@
     "ax_x = Axis(scale=dt_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[line], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[line], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -273,13 +267,13 @@
     "dt_x = DateScale()\n",
     "sc_y = LinearScale()\n",
     "\n",
-    "line = Lines(x=x_data, y=final_y, scales={'x': dt_x, 'y': sc_y}, labels=['spx', 'sp2'], display_legend=True,\n",
-    "             colors=['hotpink', 'orange'])\n",
+    "line = Lines(x=x_data, y=final_y, scales={'x': dt_x, 'y': sc_y}, labels=['spx', 'sp2'], \n",
+    "             display_legend=True, colors=['hotpink', 'orange'])\n",
+    "\n",
     "ax_x = Axis(scale=dt_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[line], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[line], axes=[ax_x, ax_y])"
    ]
   }
  ],
@@ -299,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Basic Plotting/Basic Plotting.ipynb
+++ b/examples/Basic Plotting/Basic Plotting.ipynb
@@ -9,7 +9,6 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from IPython.display import display\n",
     "from bqplot import *"
    ]
   },
@@ -51,7 +50,7 @@
     "\n",
     "line = Lines(x=x_data, y=x_data, scales={'x': x_sc, 'y': y_sc})\n",
     "fig = Figure(axes=[ax_x, ax_y], marks=[line], title='First Example')\n",
-    "display(fig)"
+    "fig"
    ]
   },
   {
@@ -110,7 +109,7 @@
     "\n",
     "fig = Figure(marks=[lc], axes=[x_ax, x_ay], background_style={'fill': 'lightgreen'},\n",
     "            title_style={'font-size': '20px','fill': 'DarkOrange'}, title='Changing Styles')\n",
-    "display(fig)"
+    "fig"
    ]
   },
   {
@@ -146,8 +145,7 @@
     "ax_x = Axis(label='Test X', scale=sc_x)\n",
     "ax_y = Axis(label='Test Y', scale=sc_y, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(axes=[ax_x, ax_y], marks=[scatter])\n",
-    "display(fig)"
+    "Figure(axes=[ax_x, ax_y], marks=[scatter])"
    ]
   },
   {
@@ -171,8 +169,7 @@
     "\n",
     "ax_x = Axis(label='X', scale=scale_x, tick_format='0.2f')\n",
     "ax_y = Axis(label='Y', scale=scale_y, orientation='vertical', grid_lines='solid')\n",
-    "fig = Figure(axes=[ax_x, ax_y], marks=[hist])\n",
-    "display(fig)"
+    "Figure(axes=[ax_x, ax_y], marks=[hist])"
    ]
   },
   {
@@ -198,8 +195,7 @@
     "bar_chart = Bars(x=['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U'],\n",
     "                 y=np.abs(y_data[:20]), scales={'x': sc_x1, 'y': sc_y1})\n",
     "\n",
-    "fig = Figure(axes=[bar_x, bar_y], marks=[bar_chart], padding_x=0)\n",
-    "display(fig)"
+    "Figure(axes=[bar_x, bar_y], marks=[bar_chart], padding_x=0)"
    ]
   }
  ],
@@ -219,7 +215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Interactions/Interaction Layer.ipynb
+++ b/examples/Interactions/Interaction Layer.ipynb
@@ -10,6 +10,7 @@
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
+    "\n",
     "symbol = 'Security 1'\n",
     "symbol2 = 'Security 2'"
    ]
@@ -38,12 +39,13 @@
    },
    "outputs": [],
    "source": [
-    "from bqplot import (DateScale, LinearScale, Axis, Lines, Scatter, Bars, Hist, Figure)\n",
-    "from bqplot.interacts import (FastIntervalSelector, IndexSelector, BrushIntervalSelector,\n",
-    "                              BrushSelector, MultiSelector, LassoSelector, PanZoom, HandDraw)\n",
+    "from bqplot import DateScale, LinearScale, Axis, Lines, Scatter, Bars, Hist, Figure\n",
+    "from bqplot.interacts import (\n",
+    "    FastIntervalSelector, IndexSelector, BrushIntervalSelector,\n",
+    "    BrushSelector, MultiSelector, LassoSelector, PanZoom, HandDraw\n",
+    ")\n",
     "from traitlets import link\n",
     "\n",
-    "from IPython.display import display\n",
     "from ipywidgets import Label, ToggleButtons, VBox"
    ]
   },
@@ -128,11 +130,12 @@
     "## on the selector\n",
     "db_fast = Label(color='Black', font_size='24px')\n",
     "db_fast.value = str(intsel_fast.selected)\n",
-    "display(db_fast)\n",
+    "\n",
     "\n",
     "fig_fast_intsel = Figure(marks=[lc, lc_2], axes=[x_ax, x_ay], title=\"Fast Interval Selector Example\",\n",
     "                         interaction=intsel_fast) #This is where we assign the interaction to this particular Figure\n",
-    "display(fig_fast_intsel)"
+    "\n",
+    "VBox([db_fast, fig_fast_intsel])"
    ]
   },
   {
@@ -199,8 +202,7 @@
    "source": [
     "fig_index_sel = Figure(marks=[lc, lc_2], axes=[x_ax, x_ay], title=\"Index Selector Example\",\n",
     "                       interaction=index_sel)\n",
-    "display(db_index)\n",
-    "display(fig_index_sel)"
+    "VBox([db_index, fig_index_sel])"
    ]
   },
   {
@@ -280,8 +282,7 @@
     "fig_date_mark = Figure(marks=[lc2_index], axes=[x_ax1, x_ay2],\n",
     "                       title='Fast Interval Selector Selected Indices Example', interaction=intsel_date)\n",
     "\n",
-    "display(db_date)\n",
-    "display(fig_date_mark)"
+    "VBox([db_date, fig_date_mark])"
    ]
   },
   {
@@ -374,8 +375,7 @@
     "fig_brush_sel = Figure(marks=[lc3_brush], axes=[x_ax_brush, x_ay_brush],\n",
     "                       title=\"Brush Selector Selected Indices Example\", interaction=brushsel_date)\n",
     "\n",
-    "display(db_brush)\n",
-    "display(fig_brush_sel)"
+    "VBox([db_brush, fig_brush_sel])"
    ]
   },
   {
@@ -482,8 +482,7 @@
    },
    "outputs": [],
    "source": [
-    "display(db_scat_brush)\n",
-    "display(fig_scat_brush)"
+    "VBox([db_scat_brush, fig_scat_brush])"
    ]
   },
   {
@@ -577,8 +576,7 @@
    },
    "outputs": [],
    "source": [
-    "display(db_brush_dt)\n",
-    "display(fig_brush_dt)"
+    "VBox([db_brush_dt, fig_brush_dt])"
    ]
   },
   {
@@ -625,13 +623,12 @@
     "\n",
     "db3 = Label(color='Black', font_size='24px')\n",
     "db3.value = str(br_intsel.selected)\n",
-    "display(db3)\n",
     "\n",
     "h_xax = Axis(scale=hist_x, label='Returns', grids='off', set_ticks=True, tick_format='0.2%')\n",
     "h_yax = Axis(scale=hist_y, label='Freq', orientation='vertical', grids='off')\n",
     "\n",
     "fig_hist = Figure(marks=[hist], axes=[h_xax, h_yax], title='Histogram Selection Example', interaction=br_intsel)\n",
-    "display(fig_hist)"
+    "VBox([db3, fig_hist])"
    ]
   },
   {
@@ -672,14 +669,13 @@
     "\n",
     "db4 = Label(color='Black', font_size='24px')\n",
     "db4.value = str(multi_sel.selected)\n",
-    "display(db4)\n",
     "\n",
     "h_xax = Axis(scale=line_x, label='Returns', grids='off', set_ticks=True)\n",
     "h_yax = Axis(scale=hist_y, label='Freq', orientation='vertical', grids='off')\n",
     "\n",
     "fig_multi = Figure(marks=[line], axes=[h_xax, h_yax], title='Multi-Selector Example',\n",
     "                   interaction=multi_sel)\n",
-    "display(fig_multi)"
+    "VBox([db4, fig_multi])"
    ]
   },
   {
@@ -732,14 +728,13 @@
     "\n",
     "db_multi_dt = Label(color='Black', font_size='24px')\n",
     "db_multi_dt.value = str(multi_sel_dt.selected)\n",
-    "display(db_multi_dt)\n",
     "\n",
     "h_xax_dt = Axis(scale=line_dt_x, label='Returns', grids='off')\n",
     "h_yax_dt = Axis(scale=line_dt_y, label='Freq', orientation='vertical', grids='off')\n",
     "\n",
     "fig_multi_dt = Figure(marks=[line_dt], axes=[h_xax_dt, h_yax_dt], title='Multi-Selector with Date Example',\n",
     "                      interaction=multi_sel_dt)\n",
-    "display(fig_multi_dt)"
+    "VBox([db_multi_dt, fig_multi_dt])"
    ]
   },
   {
@@ -777,7 +772,7 @@
     "fig_lasso = Figure(marks=[scatter_lasso, line_lasso, bar_lasso], axes=[xax_lasso, yax_lasso],\n",
     "                   title='Lasso Selector Example', interaction=lasso_sel)\n",
     "lasso_sel.marks = [scatter_lasso, line_lasso]\n",
-    "display(fig_lasso)"
+    "fig_lasso"
    ]
   },
   {
@@ -814,8 +809,7 @@
     "xax = Axis(scale=xs_pz, label='Date', grids='off')\n",
     "yax = Axis(scale=ys_pz, label='Price', orientation='vertical', grids='off')\n",
     "\n",
-    "fig_pz = Figure(marks=[line_pz], axes=[xax, yax], interaction=panzoom)\n",
-    "display(fig_pz)"
+    "Figure(marks=[line_pz], axes=[xax, yax], interaction=panzoom)"
    ]
   },
   {
@@ -841,8 +835,7 @@
     "xax = Axis(scale=xs_hd, label='Date', grids='off')\n",
     "yax = Axis(scale=ys_hd, label='Price', orientation='vertical', grids='off')\n",
     "\n",
-    "fig_hd = Figure(marks=[line_hd], axes=[xax, yax], interaction=handdraw)\n",
-    "display(fig_hd)"
+    "Figure(marks=[line_hd], axes=[xax, yax], interaction=handdraw)"
    ]
   },
   {
@@ -941,10 +934,9 @@
     "                                                       ('FastIntervalSelector', int_sel), ('IndexSelector', index_sel),\n",
     "                                                       ('BrushIntervalSelector', br_intsel), ('MultiSelector', multi_sel),\n",
     "                                                       ('None', None)]))\n",
-    "display(deb)\n",
-    "display(VBox([fig, selection_interacts], align_self=\"stretch\"))\n",
     "\n",
-    "link((selection_interacts, 'value'), (fig, 'interaction'));"
+    "link((selection_interacts, 'value'), (fig, 'interaction'))\n",
+    "VBox([deb, fig, selection_interacts], align_self=\"stretch\")"
    ]
   },
   {
@@ -976,7 +968,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Interactions/Mark Interactions.ipynb
+++ b/examples/Interactions/Mark Interactions.ipynb
@@ -10,7 +10,6 @@
    "source": [
     "from __future__ import print_function\n",
     "from bqplot import *\n",
-    "from IPython.display import display\n",
     "import numpy as np\n",
     "import pandas as pd"
    ]
@@ -53,8 +52,7 @@
     "ax_x = Axis(scale=x_sc)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[scatter_chart], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[scatter_chart], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -133,8 +131,7 @@
     "ax_x = Axis(scale=x_sc)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[scatter_chart, scatter_chart2], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[scatter_chart, scatter_chart2], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -222,8 +219,7 @@
     "ax_x = Axis(scale=x_sc)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[line_chart], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[line_chart], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -269,8 +265,7 @@
     "ax_x = Axis(scale=x_sc)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[bar_chart], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[bar_chart], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -343,8 +338,7 @@
     "ax_x = Axis(scale=x_sc, tick_format='0.2f')\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[hist], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[hist], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -430,11 +424,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
-  },
-  "widgets": {
-   "state": {},
-   "version": "2.0.0-dev"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Introduction.ipynb
+++ b/examples/Introduction.ipynb
@@ -408,6 +408,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The IPython display machinery displays the last returned value of a cell. If you wish to explicitly display a widget, you can call `IPython.display.display`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "display(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Now, that the plot has been generated, we can control every single attribute of it. Let's say we wanted to color the chart based on some other data."
    ]
   },
@@ -535,21 +564,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Bars.ipynb
+++ b/examples/Marks/Bars.ipynb
@@ -9,7 +9,6 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from IPython.display import display\n",
     "from bqplot import *"
    ]
   },
@@ -52,8 +51,7 @@
     "ax_x = Axis(scale=x_ord)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[bar], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[bar], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -78,8 +76,7 @@
     "ax_x = Axis(scale=x_ord)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[bar], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[bar], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -128,8 +125,7 @@
     "ax_x = Axis(scale=x_ord)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[bar], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[bar], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -168,8 +164,7 @@
     "ax_x = Axis(scale=x_ord)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[bar], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[bar], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -217,8 +212,7 @@
     "ax_x = Axis(scale=x_ord)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[bar], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[bar], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -239,8 +233,7 @@
     "ax_x = Axis(scale=x_ord)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[bar], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[bar], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -272,8 +265,8 @@
     "ax_c = ColorAxis(scale=col_sc, tick_format='0.2f')\n",
     "\n",
     "margin = dict(top=50, bottom=80, left=50, right=50)\n",
-    "fig = Figure(marks=[bar], axes=[ax_x, ax_y, ax_c], fig_margin=margin)\n",
-    "display(fig)"
+    "\n",
+    "Figure(marks=[bar], axes=[ax_x, ax_y, ax_c], fig_margin=margin)"
    ]
   },
   {
@@ -307,8 +300,7 @@
     "ax_c = ColorAxis(scale=col_sc, tick_format='0.2f')\n",
     "\n",
     "margin = dict(top=50, bottom=80, left=50, right=50)\n",
-    "fig = Figure(marks=[bar], axes=[ax_x, ax_y, ax_c], fig_margin=margin)\n",
-    "display(fig)"
+    "Figure(marks=[bar], axes=[ax_x, ax_y, ax_c], fig_margin=margin)"
    ]
   },
   {
@@ -335,18 +327,8 @@
     "ax_c = ColorAxis(scale=col_sc, tick_format='0.2f')\n",
     "\n",
     "margin = dict(top=50, bottom=80, left=50, right=50)\n",
-    "fig = Figure(marks=[bar], axes=[ax_x, ax_y, ax_c], fig_margin=margin)\n",
-    "display(fig)"
+    "Figure(marks=[bar], axes=[ax_x, ax_y, ax_c], fig_margin=margin)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -365,7 +347,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Boxplot.ipynb
+++ b/examples/Marks/Boxplot.ipynb
@@ -10,8 +10,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import bqplot as bq\n",
-    "from IPython.display import display"
+    "import bqplot as bq"
    ]
   },
   {
@@ -95,7 +94,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Candles.ipynb
+++ b/examples/Marks/Candles.ipynb
@@ -9,7 +9,6 @@
    },
    "outputs": [],
    "source": [
-    "from IPython.display import display\n",
     "from bqplot import *\n",
     "import numpy as np"
    ]
@@ -83,8 +82,7 @@
     "            stroke='blue', display_legend=True, labels=['IBM US Equity'])\n",
     "ohlc2 = OHLC(x=dates2, y=prices2, marker='bar', scales={'x': dt_scale, 'y': sc}, colors=['dodgerblue', 'orange'],\n",
     "            stroke='orange', display_legend=True, labels=['AAPL US Equity'], format='ohlc')\n",
-    "fig = Figure(axes=[ax_x, ax_y], marks=[ohlc, ohlc2])\n",
-    "display(fig)"
+    "Figure(axes=[ax_x, ax_y], marks=[ohlc, ohlc2])"
    ]
   },
   {
@@ -117,8 +115,7 @@
     "ohlc3 = OHLC(x=np.arange(len(dates2)) + 1, y=np.array(prices2) / 60,\n",
     "             marker='bar', scales={'x': sc_x, 'y': sc_y}, colors=['dodgerblue','orange'])\n",
     "\n",
-    "fig = Figure(axes=[ax_x, ax_y], marks=[ohlc3])\n",
-    "display(fig)"
+    "Figure(axes=[ax_x, ax_y], marks=[ohlc3])"
    ]
   },
   {
@@ -156,8 +153,7 @@
     "ohlc3 = OHLC(x=dates2, y=np.array(prices2) / 60, marker='candle', \n",
     "             scales={'x': sc_x, 'y': sc_y}, colors=['dodgerblue','orange'])\n",
     "\n",
-    "fig = Figure(axes=[ax_x, ax_y], marks=[ohlc3])\n",
-    "display(fig)"
+    "Figure(axes=[ax_x, ax_y], marks=[ohlc3])"
    ]
   },
   {
@@ -188,7 +184,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/FlexLine.ipynb
+++ b/examples/Marks/FlexLine.ipynb
@@ -9,8 +9,7 @@
    },
    "outputs": [],
    "source": [
-    "from bqplot import *\n",
-    "from IPython.display import display"
+    "from bqplot import *"
    ]
   },
   {
@@ -63,8 +62,7 @@
     "fl = FlexLine(x=dates, y=spx, color=vix,\n",
     "              scales={'x': lin_x, 'color': col_line, 'y': lin_y})\n",
     "\n",
-    "fig = Figure(marks=[fl], axes=[ax_x, ax_y, ax_col], fig_margin=fig_margin)\n",
-    "display(fig)"
+    "Figure(marks=[fl], axes=[ax_x, ax_y, ax_col], fig_margin=fig_margin)"
    ]
   },
   {
@@ -95,8 +93,7 @@
     "               scales={'x': lin_x, 'width': width_line, 'y': lin_y},\n",
     "               stroke_width=5)\n",
     "\n",
-    "fig2 = Figure(marks=[fl2], axes=[ax_x, ax_y])\n",
-    "display(fig2)"
+    "Figure(marks=[fl2], axes=[ax_x, ax_y])"
    ]
   }
  ],
@@ -116,7 +113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/GridHeatMap.ipynb
+++ b/examples/Marks/GridHeatMap.ipynb
@@ -10,8 +10,7 @@
    "source": [
     "from __future__ import print_function\n",
     "import numpy as np\n",
-    "from bqplot import *\n",
-    "from IPython.display import display"
+    "from bqplot import *"
    ]
   },
   {
@@ -51,8 +50,7 @@
     "col_sc = ColorScale()\n",
     "grid_map = GridHeatMap(color=data, scales={'color': col_sc})\n",
     "\n",
-    "fig = Figure(marks=[grid_map], padding_y=0.0)\n",
-    "display(fig)"
+    "Figure(marks=[grid_map], padding_y=0.0)"
    ]
   },
   {
@@ -75,8 +73,7 @@
     "grid_map = GridHeatMap(color=data, scales={'column': x_sc, 'row': y_sc, 'color': col_sc})\n",
     "ax_x, ax_y = Axis(scale=x_sc), Axis(scale=y_sc, orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[grid_map], axes=[ax_x, ax_y], padding_y=0.0)\n",
-    "display(fig)"
+    "Figure(marks=[grid_map], axes=[ax_x, ax_y], padding_y=0.0)"
    ]
   },
   {
@@ -107,8 +104,7 @@
     "\n",
     "grid_map = GridHeatMap(row=row_data, column=column_data, color=data,\n",
     "                       scales={'row': y_sc, 'column': x_sc, 'color': col_sc})\n",
-    "fig = Figure(marks=[grid_map], padding_y=0.0, axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[grid_map], padding_y=0.0, axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -156,8 +152,7 @@
     "\n",
     "grid_map = GridHeatMap(row=row_data, column=column_data, color=data,\n",
     "                       scales={'row': y_sc, 'column': x_sc, 'color': col_sc})\n",
-    "fig = Figure(marks=[grid_map], padding_y=0.0, axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[grid_map], padding_y=0.0, axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -186,8 +181,7 @@
     "\n",
     "grid_map = GridHeatMap(row=row_data, column=column_data, color=data,\n",
     "                       scales={'row': y_sc, 'column': x_sc, 'color': col_sc})\n",
-    "fig = Figure(marks=[grid_map], padding_y=0.0, axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[grid_map], padding_y=0.0, axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -215,8 +209,7 @@
     "grid_map = GridHeatMap(row=row_data, column=column_data, color=data,\n",
     "                      scales={'row': y_sc, 'column': x_sc, 'color': col_sc},\n",
     "                      row_align='end')\n",
-    "fig = Figure(marks=[grid_map], padding_y=0.0, axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[grid_map], padding_y=0.0, axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -243,8 +236,7 @@
     "\n",
     "grid_map = GridHeatMap(row=row_data, column=column_data, color=data, \n",
     "                       scales={'row': y_sc, 'column': x_sc, 'color': col_sc}, row_align='end')\n",
-    "fig = Figure(marks=[grid_map], padding_y=0.0, axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[grid_map], padding_y=0.0, axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -265,8 +257,7 @@
     "col_sc = ColorScale()\n",
     "\n",
     "grid_map = GridHeatMap(color=data, scales={'color': col_sc}, opacity=0.3, stroke='white')\n",
-    "fig = Figure(marks=[grid_map], padding_y=0.0)\n",
-    "display(fig)"
+    "Figure(marks=[grid_map], padding_y=0.0)"
    ]
   },
   {
@@ -297,8 +288,7 @@
     "grid_map = GridHeatMap(color=data, scales={'color': col_sc}, interactions={'click':'select'},\n",
     "                      selected_style={'opacity': '1.0'}, unselected_style={'opacity': 0.4})\n",
     "\n",
-    "fig = Figure(marks=[grid_map], padding_y=0.0)\n",
-    "display(fig)"
+    "Figure(marks=[grid_map], padding_y=0.0)"
    ]
   },
   {
@@ -337,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Hist.ipynb
+++ b/examples/Marks/Hist.ipynb
@@ -9,8 +9,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from bqplot import *\n",
-    "from IPython.display import display"
+    "from bqplot import *"
    ]
   },
   {
@@ -47,8 +46,7 @@
     "ax_x = Axis(scale=x_sc, tick_format='0.2f')\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[hist], axes=[ax_x, ax_y], padding_y=0)\n",
-    "display(fig)"
+    "Figure(marks=[hist], axes=[ax_x, ax_y], padding_y=0)"
    ]
   },
   {
@@ -98,8 +96,7 @@
     "ax_x = Axis(scale=x_sc, tick_format='0.2f')\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[hist], axes=[ax_x, ax_y], padding_y=0)\n",
-    "display(fig)"
+    "Figure(marks=[hist], axes=[ax_x, ax_y], padding_y=0)"
    ]
   },
   {
@@ -149,8 +146,7 @@
     "ax_x = Axis(scale=x_sc, tick_format='0.2f')\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[hist], axes=[ax_x, ax_y], padding_y=0)\n",
-    "display(fig)"
+    "Figure(marks=[hist], axes=[ax_x, ax_y], padding_y=0)"
    ]
   },
   {
@@ -194,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Label.ipynb
+++ b/examples/Marks/Label.ipynb
@@ -9,7 +9,6 @@
    "outputs": [],
    "source": [
     "from bqplot import *\n",
-    "from IPython.display import display\n",
     "import numpy as np\n",
     "import pandas as pd"
    ]
@@ -55,8 +54,7 @@
     "ax_x = Axis(scale=x_sc, label='X')\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f', label='Y')\n",
     "\n",
-    "fig = Figure(marks=[test_label, test_line], axes=[ax_x, ax_y], title='Basic Label Example')\n",
-    "display(fig)"
+    "Figure(marks=[test_label, test_line], axes=[ax_x, ax_y], title='Basic Label Example')"
    ]
   },
   {
@@ -102,8 +100,7 @@
     "ax_x = Axis(scale=x_sc)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[test_line, test_label], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[test_line, test_label], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -142,8 +139,7 @@
     "ax_x = Axis(scale=dt_sc)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[lines, label], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[lines, label], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -175,7 +171,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Lines.ipynb
+++ b/examples/Marks/Lines.ipynb
@@ -89,7 +89,6 @@
    "source": [
     "import numpy as np #For numerical programming and multi-dimensional arrays\n",
     "from pandas import date_range #For date-rate generation\n",
-    "from IPython.display import display #The display function allows us to display bqplot figures or general GUIs\n",
     "from bqplot import * #We import the relevant modules from bqplot"
    ]
   },
@@ -142,8 +141,7 @@
     "ax_x = Axis(scale=sc_x, label='Index')\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical', label='y-values of Security 1')\n",
     "\n",
-    "fig = Figure(marks=[line], axes=[ax_x, ax_y], title='Security 1')\n",
-    "display(fig) "
+    "Figure(marks=[line], axes=[ax_x, ax_y], title='Security 1')"
    ]
   },
   {
@@ -286,8 +284,7 @@
     "ax_x = Axis(scale=dt_x, label='Date')\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical', label='Security 1')\n",
     "\n",
-    "fig = Figure(marks=[time_series], axes=[ax_x, ax_y], title='A Time Series Plot')\n",
-    "display(fig) "
+    "Figure(marks=[time_series], axes=[ax_x, ax_y], title='A Time Series Plot')"
    ]
   },
   {
@@ -371,8 +368,7 @@
     "ax_x = Axis(scale=x_dt, label='Date')\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', label='Security 1')\n",
     "\n",
-    "fig = Figure(marks=[line], axes=[ax_x, ax_y], legend_location='top-left')\n",
-    "display(fig) "
+    "Figure(marks=[line], axes=[ax_x, ax_y], legend_location='top-left')"
    ]
   },
   {
@@ -469,8 +465,7 @@
     "ax_x = Axis(scale=x_dt, label='Date')\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', label='Security 1')\n",
     "\n",
-    "fig = Figure(marks=[line], axes=[ax_x, ax_y], legend_location='top-left')\n",
-    "display(fig) "
+    "Figure(marks=[line], axes=[ax_x, ax_y], legend_location='top-left')"
    ]
   },
   {
@@ -525,8 +520,7 @@
     "              scales={'x': sc_x, 'y': sc_y},\n",
     "              display_legend=True)\n",
     "\n",
-    "fig = Figure(marks=[patch], animation_duration=1000)\n",
-    "display(fig) "
+    "Figure(marks=[patch], animation_duration=1000)"
    ]
   },
   {
@@ -602,11 +596,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
-  },
-  "widgets": {
-   "state": {},
-   "version": "2.0.0-dev"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Map.ipynb
+++ b/examples/Marks/Map.ipynb
@@ -8,9 +8,10 @@
    },
    "outputs": [],
    "source": [
-    "from IPython.display import display\n",
-    "from bqplot import (Figure, Map, Mercator, Orthographic, ColorScale, ColorAxis,\n",
-    "                    AlbersUSA, topo_load, Tooltip)"
+    "from bqplot import (\n",
+    "    Figure, Map, Mercator, Orthographic, ColorScale, ColorAxis,\n",
+    "    AlbersUSA, topo_load, Tooltip\n",
+    ")"
    ]
   },
   {
@@ -30,8 +31,7 @@
    "source": [
     "sc_geo = Mercator()\n",
     "map_mark = Map(scales={'projection': sc_geo})\n",
-    "fig = Figure(marks=[map_mark], title='Basic Map Example')\n",
-    "display(fig)"
+    "Figure(marks=[map_mark], title='Basic Map Example')"
    ]
   },
   {
@@ -54,8 +54,7 @@
     "sc_geo = Orthographic(scale_factor=375, center=[0, 25], rotate=(-50, 0))\n",
     "map_mark = Map(map_data=topo_load('map_data/WorldMapData.json'), scales={'projection': sc_geo}, \n",
     "        colors={682: 'Green', 356: 'Red', 643: '#0000ff', 'default_color': 'DarkOrange'})\n",
-    "fig = Figure(marks=[map_mark], fig_color='deepskyblue', title='Advanced Map Example')\n",
-    "display(fig)"
+    "Figure(marks=[map_mark], fig_color='deepskyblue', title='Advanced Map Example')"
    ]
   },
   {
@@ -93,8 +92,7 @@
     "axis = ColorAxis(scale=sc_c1)\n",
     "\n",
     "chloro_map = Map(map_data=topo_load('map_data/WorldMapData.json'), **map_styles)\n",
-    "fig = Figure(marks=[chloro_map], axes=[axis],title='Choropleth Example')\n",
-    "display(fig)"
+    "Figure(marks=[chloro_map], axes=[axis],title='Choropleth Example')"
    ]
   },
   {
@@ -115,8 +113,7 @@
     "sc_geo = AlbersUSA()\n",
     "states_map = Map(map_data=topo_load('map_data/USMapData.json'), \n",
     "            scales={'projection': sc_geo})\n",
-    "fig = Figure(marks=[states_map], title='US States Map Example')\n",
-    "display(fig)"
+    "Figure(marks=[states_map], title='US States Map Example')"
    ]
   },
   {
@@ -137,8 +134,7 @@
     "sc_geo = Mercator(scale_factor=450)\n",
     "euro_map = Map(map_data=topo_load('map_data/EuropeMapData.json'), \n",
     "            scales={'projection': sc_geo})\n",
-    "fig = Figure(marks=[euro_map], title='Europe States Map Example')\n",
-    "display(fig)"
+    "Figure(marks=[euro_map], title='Europe States Map Example')"
    ]
   },
   {
@@ -159,8 +155,7 @@
     "def_tt = Tooltip(fields=['id', 'name'])\n",
     "map_mark = Map(scales={'projection': Mercator()}, tooltip=def_tt)\n",
     "map_mark.interactions = {'click': 'select', 'hover': 'tooltip'}\n",
-    "fig = Figure(marks=[map_mark], title='Interactions Example')\n",
-    "display(fig)"
+    "Figure(marks=[map_mark], title='Interactions Example')"
    ]
   }
  ],
@@ -180,7 +175,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Market Map.ipynb
+++ b/examples/Marks/Market Map.ipynb
@@ -9,9 +9,8 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from IPython.display import display\n",
     "from bqplot import ColorScale, ColorAxis, DateScale, LinearScale, Axis, Lines, Figure\n",
-    "from ipywidgets import Label\n",
+    "from ipywidgets import Label, VBox\n",
     "from bqplot.market_map import MarketMap\n",
     "import os"
    ]
@@ -58,7 +57,7 @@
     "                       # Axis and scale for color data\n",
     "                       tooltip_fields=['Name'])  \n",
     "\n",
-    "display(market_map)"
+    "market_map"
    ]
   },
   {
@@ -152,8 +151,7 @@
     "    deb_output.value = str(data['new'])\n",
     "        \n",
     "market_map.observe(selected_index_changed, 'selected')\n",
-    "display(deb_output)\n",
-    "display(market_map)"
+    "VBox([deb_output, market_map])"
    ]
   },
   {
@@ -267,7 +265,7 @@
     "\n",
     "# Custom msg sent when a particular cell is hovered on\n",
     "market_map.on_hover(hover_handler)\n",
-    "display(market_map)"
+    "market_map"
    ]
   },
   {
@@ -285,21 +283,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [Root]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "Python [Root]"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Pie.ipynb
+++ b/examples/Marks/Pie.ipynb
@@ -9,7 +9,6 @@
    "outputs": [],
    "source": [
     "from bqplot import Pie, Figure\n",
-    "from IPython.display import display\n",
     "import numpy as np"
    ]
   },
@@ -39,9 +38,9 @@
    "source": [
     "data = range(1, 6)\n",
     "pie = Pie(sizes=data)\n",
+    "# Set `animation_duration` (in milliseconds) to have smooth transitions\n",
     "fig = Figure(marks=[pie], animation_duration=1000)\n",
-    "# Add `animation_duration` (in milliseconds) to have smooth transitions\n",
-    "display(fig)"
+    "fig"
    ]
   },
   {
@@ -175,7 +174,7 @@
    "source": [
     "pie1 = Pie(sizes=np.random.rand(6), inner_radius=0.05)\n",
     "fig1 = Figure(marks=[pie1], animation_duration=1000)\n",
-    "display(fig1)"
+    "fig1"
    ]
   },
   {
@@ -253,7 +252,7 @@
     "pie1.stroke = 'brown'\n",
     "pie1.colors = ['orange', 'darkviolet']\n",
     "pie1.opacities = [.1, 1]\n",
-    "display(fig1)"
+    "fig1"
    ]
   },
   {
@@ -356,11 +355,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
-  },
-  "widgets": {
-   "state": {},
-   "version": "2.0.0-dev"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Scatter.ipynb
+++ b/examples/Marks/Scatter.ipynb
@@ -12,9 +12,10 @@
     "from __future__ import print_function\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from IPython.display import display\n",
-    "from bqplot import (Axis, ColorAxis, LinearScale, DateScale, DateColorScale, OrdinalScale, OrdinalColorScale,\n",
-    "                    ColorScale, Scatter, Lines, Figure, Tooltip)\n",
+    "from bqplot import (\n",
+    "    Axis, ColorAxis, LinearScale, DateScale, DateColorScale, OrdinalScale,\n",
+    "    OrdinalColorScale, ColorScale, Scatter, Lines, Figure, Tooltip\n",
+    ")\n",
     "from ipywidgets import Label"
    ]
   },
@@ -85,8 +86,7 @@
     "ax_x = Axis(scale=sc_x, label='Date')\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical', tick_format='0.2f', label='Security 2')\n",
     "\n",
-    "fig = Figure(marks=[scatt], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[scatt], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -113,8 +113,7 @@
     "ax_x = Axis(scale=sc_x)\n",
     "ax_y = Axis(scale=sc_y, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[scatt], axes=[ax_x, ax_y], padding_x=0.025)\n",
-    "display(fig)"
+    "Figure(marks=[scatt], axes=[ax_x, ax_y], padding_x=0.025)"
    ]
   },
   {
@@ -175,8 +174,9 @@
     "ax_c = ColorAxis(scale=sc_c1, tick_format='0.2%', label='Returns', orientation='vertical', side='right')\n",
     "\n",
     "m_chart = dict(top=50, bottom=70, left=50, right=100)\n",
-    "fig = Figure(axes=[ax_x, ax_c, ax_y], marks=[scatter], fig_margin=m_chart, title='Scatter of Security 2 vs Dates')\n",
-    "display(fig)"
+    "\n",
+    "Figure(axes=[ax_x, ax_c, ax_y], marks=[scatter], fig_margin=m_chart,\n",
+    "       title='Scatter of Security 2 vs Dates')"
    ]
   },
   {
@@ -272,8 +272,7 @@
     "ax_c = ColorAxis(scale=sc_c1, label='Date', num_ticks=10)\n",
     "\n",
     "m_chart = dict(top=50, bottom=80, left=50, right=50)\n",
-    "fig = Figure(axes=[ax_x, ax_c, ax_y], marks=[scatter], fig_margin=m_chart)\n",
-    "display(fig)"
+    "Figure(axes=[ax_x, ax_c, ax_y], marks=[scatter], fig_margin=m_chart)"
    ]
   },
   {
@@ -314,8 +313,7 @@
     "ax_c = ColorAxis(scale=c_ord, label='Class', side='right', orientation='vertical')\n",
     "\n",
     "m_chart = dict(top=50, bottom=70, left=100, right=100)\n",
-    "fig2 = Figure(axes=[ax_x, ax_y, ax_c], marks=[scatter2], fig_margin=m_chart)\n",
-    "display(fig2)"
+    "Figure(axes=[ax_x, ax_y, ax_c], marks=[scatter2], fig_margin=m_chart)"
    ]
   },
   {
@@ -363,8 +361,7 @@
     "ax_y = Axis(label='Security 1', scale=sc_y, orientation='vertical', side='left')\n",
     "ax_x = Axis(label='Security 2', scale=sc_x)\n",
     "\n",
-    "fig2 = Figure(axes=[ax_x, ax_y], marks=[scatter2])\n",
-    "display(fig2)"
+    "Figure(axes=[ax_x, ax_y], marks=[scatter2])"
    ]
   },
   {
@@ -554,8 +551,7 @@
     "ax_x = Axis(scale=sc_x)\n",
     "ax_y = Axis(scale=sc_y, tick_format='0.2f', orientation='vertical')\n",
     "\n",
-    "fig = Figure(marks=[scat, lin], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[scat, lin], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -715,8 +711,7 @@
     "ax_x = Axis(scale=x_sc)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
-    "fig = Figure(marks=[scatter_chart], axes=[ax_x, ax_y])\n",
-    "display(fig)"
+    "Figure(marks=[scatter_chart], axes=[ax_x, ax_y])"
    ]
   },
   {
@@ -747,21 +742,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [Root]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "Python [Root]"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This removes all the uses of `IPython.display.display` and only uses the displaying of the last computed value as it was suggested by Fernando.