### PR TITLE
Disable user select and set default cursor on axis ticks

### DIFF
--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -48,12 +48,6 @@ var Figure = widgets.DOMWidgetView.extend({
         this.figure_padding_y = this.model.get("padding_y");
         this.clip_id = "clip_path_" + this.id;
 
-        this.el.style["user-select"] = "none";
-        this.el.style["ms-user-select"] = "none";
-        this.el.style["moz-user-select"] = "none";
-        this.el.style["khtml-user-select"] = "none";
-        this.el.style["webkit-user-select"] = "none";
-
         this.el.style["flex"] = "1 1 auto";
         this.el.style["align-self"] = "stretch";
         this.el.style["min-width"] = this.width;

--- a/js/src/bqplot.less
+++ b/js/src/bqplot.less
@@ -16,6 +16,12 @@
 .common() {
     svg.bqplot {
         font: 11px sans-serif;
+        user-select: none;
+        -ms-user-select: none;
+        -khtml-user-select: none;
+        -khtml-user-select: none;
+        -webkit-user-select: none;
+
         .axis {
             line {
                 shape-rendering: crispEdges;
@@ -26,6 +32,9 @@
             text.axislabel, tspan.axislabel {
                 text-anchor: end;
                 font: 14px sans-serif;
+            }
+            .tick text {
+                cursor: default;
             }
         }
         .axis.axisbold path {


### PR DESCRIPTION
In the transition to native DOM api calls, the front `-` went missing. Moving this to the css, and adding a rule for the cursor.