### PR TITLE
Union-level metadata

### DIFF
--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -122,11 +122,11 @@ class HandDraw(Interaction):
     min_x = (
             Float(None, allow_none=True).tag(sync=True) |
             Date(None, allow_none=True).tag(sync=True)
-        )
+        ).tag(sync=True)
     max_x = (
             Float(None, allow_none=True).tag(sync=True) |
             Date(None, allow_none=True).tag(sync=True)
-        )
+        ).tag(sync=True)
 
     _view_name = Unicode('HandDraw').tag(sync=True)
     _model_name = Unicode('HandDrawModel').tag(sync=True)

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -1039,8 +1039,8 @@ class Pie(Mark):
                           atype='bqplot.ColorAxis', min_dim=1, max_dim=1)
 
     # Other attributes
-    x = Float(0.5).tag(sync=True) | Date().tag(sync=True) | Unicode().tag(sync=True)
-    y = Float(0.5).tag(sync=True) | Date().tag(sync=True) | Unicode().tag(sync=True)
+    x = (Float(0.5).tag(sync=True) | Date().tag(sync=True) | Unicode().tag(sync=True)).tag(sync=True)
+    y = (Float(0.5).tag(sync=True) | Date().tag(sync=True) | Unicode().tag(sync=True)).tag(sync=True)
 
     scales_metadata = Dict({'color': {'dimension': 'color'}}).tag(sync=True)
     sort = Bool().tag(sync=True)


### PR DESCRIPTION
The bug fix on the Union metadata in traitlets upstream requires this change. When traitlets 4.3 is released, I will remove the individual `sync=True` on the components of the Union.