### PR TITLE
Fixing race condition

### DIFF
--- a/js/src/Mark.js
+++ b/js/src/Mark.js
@@ -85,8 +85,6 @@ var Mark = widgets.WidgetView.extend({
             this.stopListening(this.scales[key]);
         }
 
-        this.scales = {};
-
         var scale_models = this.model.get("scales");
         var that = this;
         var scale_promises = {};


### PR DESCRIPTION
We can't clear `this.scales` in `Mark` view before the promise callback because changes to other traits can happen before the promise is resolved, mark views will throw an error. (We assume `this.scales` is always set)