### PR TITLE
Temporary sync fix

### DIFF
--- a/js/src/BaseModel.js
+++ b/js/src/BaseModel.js
@@ -23,6 +23,14 @@ var BaseModel = widgets.WidgetModel.extend({
         _model_module: "bqplot"
     }),
 
+    initialize: function() {
+        BaseModel.__super__.initialize.apply(this, arguments);
+        // Temporary fix to address issue in WidgetModel where
+        // _buffered_state_diff is initially set to the state
+        // on creation.
+        this._buffered_state_diff = {};
+    },
+
     get_typed_field: function(param) {
         // Function that reads in an array of a field that is typed. It
         // performs tpe conversions that you may require and returns you


### PR DESCRIPTION
This addresses issue #330. I believe this also addresses issue #327.

I think, the root issue is that in `WidgetModel` the attribute `_buffered_state_diff` is not set correctly on initialization. So when the first `sync` from `javascript` happens, the `change` handlers of all the attributes are notified. Also, if any of the other attributes changed, they are being overwritten by the old values which came back in the comm message. 

The fix is temporary. I am not sure if I want this to be merged. It is just trying to make sure that what I think as the root issue is actually the issue.
