### PR TITLE
Add interpolation options for steps-before and steps-after

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -348,8 +348,8 @@ class Lines(Mark):
     curves_subset = List().tag(sync=True)
     line_style = Enum(['solid', 'dashed', 'dotted', 'dash_dotted'],
                       default_value='solid').tag(sync=True, display_name='Line style')
-    interpolation = Enum(['linear', 'basis', 'cardinal', 'monotone'], default_value='linear').tag(sync=True,
-                         display_name='Interpolation')
+    interpolation = Enum(['linear', 'basis', 'cardinal', 'monotone', 'steps-before', 'steps-after'],
+                         default_value='linear').tag(sync=True, display_name='Interpolation')
     close_path = Bool().tag(sync=True, display_name='Close path')
     fill = Enum(['none', 'bottom', 'top', 'inside'], default_value='none').tag(sync=True, display_name='Fill')
     marker = Enum(['circle', 'cross', 'diamond', 'square', 'triangle-down',

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -348,7 +348,7 @@ class Lines(Mark):
     curves_subset = List().tag(sync=True)
     line_style = Enum(['solid', 'dashed', 'dotted', 'dash_dotted'],
                       default_value='solid').tag(sync=True, display_name='Line style')
-    interpolation = Enum(['linear', 'basis', 'cardinal', 'monotone', 'steps-before', 'steps-after'],
+    interpolation = Enum(['linear', 'basis', 'cardinal', 'monotone', 'step-before', 'step-after'],
                          default_value='linear').tag(sync=True, display_name='Interpolation')
     close_path = Bool().tag(sync=True, display_name='Close path')
     fill = Enum(['none', 'bottom', 'top', 'inside'], default_value='none').tag(sync=True, display_name='Fill')

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -348,7 +348,8 @@ class Lines(Mark):
     curves_subset = List().tag(sync=True)
     line_style = Enum(['solid', 'dashed', 'dotted', 'dash_dotted'],
                       default_value='solid').tag(sync=True, display_name='Line style')
-    interpolation = Enum(['linear', 'basis', 'cardinal', 'monotone', 'step-before', 'step-after'],
+    interpolation = Enum(['linear', 'basis', 'basis-open', 'basis-closed', 'bundle',
+                          'cardinal', 'cardinal-open', 'cardinal-closed', 'monotone', 'step-before', 'step-after'],
                          default_value='linear').tag(sync=True, display_name='Interpolation')
     close_path = Bool().tag(sync=True, display_name='Close path')
     fill = Enum(['none', 'bottom', 'top', 'inside'], default_value='none').tag(sync=True, display_name='Fill')


### PR DESCRIPTION
The interpolation options that provide step graphs are already provided by d3, but just not exposed in bqplot.