### PR TITLE
Add a data attribute to pyplot's plot functions

### DIFF
--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -798,7 +798,7 @@ def geo(map_data, **kwargs):
     if 'projection' not in scales:
         scales['projection'] = Mercator(**options.get('projection', {}))
     kwargs['scales'] = scales
-    if isinstance(map_data, (str, unicode)):
+    if isinstance(map_data, string_types):
         kwargs['map_data'] = topo_load('map_data/' + map_data + '.json')
     else:
         kwargs['map_data'] = map_data

--- a/examples/Basic Plotting/Pyplot.ipynb
+++ b/examples/Basic Plotting/Pyplot.ipynb
@@ -32,8 +32,17 @@
     "y_data_2 = np.cumsum(np.random.randn(size))\n",
     "y_data_3 = np.cumsum(np.random.randn(size) * 100.)\n",
     "\n",
-    "x = np.linspace(0.0, 10.0, size)\n",
-    "\n",
+    "x = np.linspace(0.0, 10.0, size)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "price_data = pd.DataFrame(np.cumsum(np.random.randn(150, 2).dot([[0.5, 0.8], [0.8, 1.0]]), axis=0) + 100,\n",
     "                          columns=['Security 1', 'Security 2'],\n",
     "                          index=pd.date_range(start='01-01-2007', periods=150))\n",
@@ -41,6 +50,17 @@
     "symbol = 'Security 1'\n",
     "dates_all = price_data.index.values\n",
     "final_prices = price_data[symbol].values.flatten()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "price_data.index.names = ['date']"
    ]
   },
   {
@@ -80,6 +100,19 @@
    "source": [
     "# Setting the title for the current figure\n",
     "plt.title('Brownian Increments')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.plot('Security 1', data=price_data)\n",
+    "plt.show()"
    ]
   },
   {
@@ -136,6 +169,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.scatter('Security 1', 'Security 2', data=price_data)\n",
+    "plt.show()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -152,6 +198,19 @@
    "source": [
     "plt.figure()\n",
     "plt.hist(y_data, colors=['OrangeRed'])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.hist('Security 1', data=price_data, colors=['MediumSeaGreen'])\n",
     "plt.show()"
    ]
   },
@@ -177,6 +236,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.bar('date', 'Security 2', data=price_data.reset_index()[:10])\n",
+    "plt.show()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -194,6 +266,19 @@
     "plt.figure()\n",
     "d = abs(y_data_2[:5])\n",
     "plt.pie(d)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.pie('Security 2', data=price_data[:4])\n",
     "plt.show()"
    ]
   },
@@ -256,7 +341,7 @@
    "outputs": [],
    "source": [
     "plt.figure()\n",
-    "plt.geo(map_data=topo_load('./map_data/WorldMap.json'))\n",
+    "plt.geo(map_data='WorldMap')\n",
     "plt.show()"
    ]
   },
@@ -667,6 +752,193 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
    "version": "2.7.12"
+  },
+  "widgets": {
+   "state": {
+    "00411d225f284872818e91a5cc941726": {
+     "views": [
+      {
+       "cell_index": 25
+      }
+     ]
+    },
+    "05fa3e82c5ef48479cd02142764ebaf2": {
+     "views": [
+      {
+       "cell_index": 56
+      }
+     ]
+    },
+    "4379c45657894831a11df6e60295bbb4": {
+     "views": [
+      {
+       "cell_index": 12
+      }
+     ]
+    },
+    "4423d57250344523a34e30c43efbfb7a": {
+     "views": [
+      {
+       "cell_index": 8
+      }
+     ]
+    },
+    "49446293980249debfea7ad1fbb1f638": {
+     "views": [
+      {
+       "cell_index": 46
+      }
+     ]
+    },
+    "59598accf3034f2abc87e1dc68f85db0": {
+     "views": [
+      {
+       "cell_index": 29
+      }
+     ]
+    },
+    "5a84c1a707734f51b96f275f1cae9eb2": {
+     "views": [
+      {
+       "cell_index": 27
+      }
+     ]
+    },
+    "5d021bdbdbe64ed9974491ff998bd5d3": {
+     "views": [
+      {
+       "cell_index": 38
+      }
+     ]
+    },
+    "5dc27866c14f469fb1db6f23b82a3801": {
+     "views": [
+      {
+       "cell_index": 31
+      }
+     ]
+    },
+    "6907d566f5944f2791e9c66f9720e994": {
+     "views": [
+      {
+       "cell_index": 17
+      }
+     ]
+    },
+    "6fb9bcd57b8c4260b446cec99a0357a6": {
+     "views": [
+      {
+       "cell_index": 22
+      }
+     ]
+    },
+    "732aebce3a55474fbaff049dce0947a9": {
+     "views": [
+      {
+       "cell_index": 16
+      }
+     ]
+    },
+    "7f5f5edddaa64f9a8454651f3a3c2369": {
+     "views": [
+      {
+       "cell_index": 14
+      }
+     ]
+    },
+    "8b9217bc3dd944818c6f8df1d080b5d3": {
+     "views": [
+      {
+       "cell_index": 19
+      }
+     ]
+    },
+    "8f9c060c8e3e4be68c4afd84f5299296": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "91db9a63798b44dda608e5800e8dd862": {
+     "views": [
+      {
+       "cell_index": 63
+      }
+     ]
+    },
+    "a938418bbcbc483cac2eac8f47cb0f81": {
+     "views": [
+      {
+       "cell_index": 45
+      }
+     ]
+    },
+    "aba2a257d57b423180935fcd9a62414d": {
+     "views": [
+      {
+       "cell_index": 42
+      }
+     ]
+    },
+    "b45d862f802642b2b3d32879d23ec673": {
+     "views": [
+      {
+       "cell_index": 40
+      }
+     ]
+    },
+    "baa488a794fd4aa7aa7730cf422933da": {
+     "views": [
+      {
+       "cell_index": 6
+      }
+     ]
+    },
+    "c0dfd261e28a48089f8939da0b19ed5b": {
+     "views": [
+      {
+       "cell_index": 20
+      }
+     ]
+    },
+    "de797336e90e4116aec8a86b61b2438f": {
+     "views": [
+      {
+       "cell_index": 10
+      }
+     ]
+    },
+    "ee3ceb9c13434b24932ac734160c7132": {
+     "views": [
+      {
+       "cell_index": 61
+      }
+     ]
+    },
+    "efd08610852d47a68e55981fcdfe6447": {
+     "views": [
+      {
+       "cell_index": 23
+      }
+     ]
+    },
+    "f4955cd8a583402ca956b759a9d01159": {
+     "views": [
+      {
+       "cell_index": 52
+      }
+     ]
+    },
+    "f9da13635a9e46709c48951d9f8932aa": {
+     "views": [
+      {
+       "cell_index": 36
+      }
+     ]
+    }
+   },
+   "version": "2.0.0-dev"
   }
  },
  "nbformat": 4,

--- a/examples/Basic Plotting/Pyplot.ipynb
+++ b/examples/Basic Plotting/Pyplot.ipynb
@@ -177,7 +177,7 @@
    "outputs": [],
    "source": [
     "plt.figure()\n",
-    "plt.scatter('Security 1', 'Security 2', data=price_data)\n",
+    "plt.scatter('Security 1', 'Security 2', color='date', data=price_data.reset_index())\n",
     "plt.show()"
    ]
   },
@@ -278,7 +278,7 @@
    "outputs": [],
    "source": [
     "plt.figure()\n",
-    "plt.pie('Security 2', data=price_data[:4])\n",
+    "plt.pie('Security 2', color='Security 1', data=price_data[:4])\n",
     "plt.show()"
    ]
   },
@@ -752,193 +752,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
    "version": "2.7.12"
-  },
-  "widgets": {
-   "state": {
-    "00411d225f284872818e91a5cc941726": {
-     "views": [
-      {
-       "cell_index": 25
-      }
-     ]
-    },
-    "05fa3e82c5ef48479cd02142764ebaf2": {
-     "views": [
-      {
-       "cell_index": 56
-      }
-     ]
-    },
-    "4379c45657894831a11df6e60295bbb4": {
-     "views": [
-      {
-       "cell_index": 12
-      }
-     ]
-    },
-    "4423d57250344523a34e30c43efbfb7a": {
-     "views": [
-      {
-       "cell_index": 8
-      }
-     ]
-    },
-    "49446293980249debfea7ad1fbb1f638": {
-     "views": [
-      {
-       "cell_index": 46
-      }
-     ]
-    },
-    "59598accf3034f2abc87e1dc68f85db0": {
-     "views": [
-      {
-       "cell_index": 29
-      }
-     ]
-    },
-    "5a84c1a707734f51b96f275f1cae9eb2": {
-     "views": [
-      {
-       "cell_index": 27
-      }
-     ]
-    },
-    "5d021bdbdbe64ed9974491ff998bd5d3": {
-     "views": [
-      {
-       "cell_index": 38
-      }
-     ]
-    },
-    "5dc27866c14f469fb1db6f23b82a3801": {
-     "views": [
-      {
-       "cell_index": 31
-      }
-     ]
-    },
-    "6907d566f5944f2791e9c66f9720e994": {
-     "views": [
-      {
-       "cell_index": 17
-      }
-     ]
-    },
-    "6fb9bcd57b8c4260b446cec99a0357a6": {
-     "views": [
-      {
-       "cell_index": 22
-      }
-     ]
-    },
-    "732aebce3a55474fbaff049dce0947a9": {
-     "views": [
-      {
-       "cell_index": 16
-      }
-     ]
-    },
-    "7f5f5edddaa64f9a8454651f3a3c2369": {
-     "views": [
-      {
-       "cell_index": 14
-      }
-     ]
-    },
-    "8b9217bc3dd944818c6f8df1d080b5d3": {
-     "views": [
-      {
-       "cell_index": 19
-      }
-     ]
-    },
-    "8f9c060c8e3e4be68c4afd84f5299296": {
-     "views": [
-      {
-       "cell_index": 13
-      }
-     ]
-    },
-    "91db9a63798b44dda608e5800e8dd862": {
-     "views": [
-      {
-       "cell_index": 63
-      }
-     ]
-    },
-    "a938418bbcbc483cac2eac8f47cb0f81": {
-     "views": [
-      {
-       "cell_index": 45
-      }
-     ]
-    },
-    "aba2a257d57b423180935fcd9a62414d": {
-     "views": [
-      {
-       "cell_index": 42
-      }
-     ]
-    },
-    "b45d862f802642b2b3d32879d23ec673": {
-     "views": [
-      {
-       "cell_index": 40
-      }
-     ]
-    },
-    "baa488a794fd4aa7aa7730cf422933da": {
-     "views": [
-      {
-       "cell_index": 6
-      }
-     ]
-    },
-    "c0dfd261e28a48089f8939da0b19ed5b": {
-     "views": [
-      {
-       "cell_index": 20
-      }
-     ]
-    },
-    "de797336e90e4116aec8a86b61b2438f": {
-     "views": [
-      {
-       "cell_index": 10
-      }
-     ]
-    },
-    "ee3ceb9c13434b24932ac734160c7132": {
-     "views": [
-      {
-       "cell_index": 61
-      }
-     ]
-    },
-    "efd08610852d47a68e55981fcdfe6447": {
-     "views": [
-      {
-       "cell_index": 23
-      }
-     ]
-    },
-    "f4955cd8a583402ca956b759a9d01159": {
-     "views": [
-      {
-       "cell_index": 52
-      }
-     ]
-    },
-    "f9da13635a9e46709c48951d9f8932aa": {
-     "views": [
-      {
-       "cell_index": 36
-      }
-     ]
-    }
-   },
-   "version": "2.0.0-dev"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
@madridnick @ssunkara1 Added support for a data argument ala matplotlib.

Currently it works only for the args (not the kwargs) of the plotting functions and follows matplotlib in that it assumes whatever names you pass it is supported by the _get_item of your data.

```
plt.figure()
plt.plot('Security 1', 'Security 2', data=price_data)
plt.show()
```