### PR TITLE
Tooltip figure bug fix

### DIFF
--- a/examples/Interactions/Mark Interactions.ipynb
+++ b/examples/Interactions/Mark Interactions.ipynb
@@ -11,7 +11,8 @@
     "from __future__ import print_function\n",
     "from bqplot import *\n",
     "import numpy as np\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from ipywidgets import Layout"
    ]
   },
   {
@@ -173,7 +174,7 @@
     "lc = Lines(x=x_data, y=y_data, scales={'x': x_sc, 'y':y_sc})\n",
     "ax_x = Axis(scale=x_sc)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
-    "tooltip_fig = Figure(marks=[lc], axes=[ax_x, ax_y], min_height=400, min_width=400)\n",
+    "tooltip_fig = Figure(marks=[lc], axes=[ax_x, ax_y], layout=Layout(min_width='600px'))\n",
     "\n",
     "scatter_chart.tooltip = tooltip_fig"
    ]
@@ -409,22 +410,23 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [conda root]",
    "language": "python",
-   "name": "python2"
+   "name": "conda-root-py"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.5"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Market Map.ipynb
+++ b/examples/Marks/Market Map.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "import pandas as pd\n",
     "from bqplot import ColorScale, ColorAxis, DateScale, LinearScale, Axis, Lines, Figure\n",
-    "from ipywidgets import Label, VBox\n",
+    "from ipywidgets import Label, VBox, Layout\n",
     "from bqplot.market_map import MarketMap\n",
     "import os"
    ]
@@ -236,7 +236,7 @@
     "            label='GDP', label_location='end', label_offset='-1em')\n",
     "\n",
     "line = Lines(x= gdp_data.index.values, y=[], scales={'x': sc_x, 'y': sc_y}, colors=['orange'])\n",
-    "fig_tooltip = Figure(marks=[line], axes=[ax_x, ax_y], min_width=600, min_height=400)"
+    "fig_tooltip = Figure(marks=[line], axes=[ax_x, ax_y], layout=Layout(min_width='600px'))"
    ]
   },
   {
@@ -283,21 +283,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [conda root]",
    "language": "python",
-   "name": "python2"
+   "name": "conda-root-py"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.5"
   }
  },
  "nbformat": 4,

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -96,17 +96,14 @@ var Figure = widgets.DOMWidgetView.extend({
         this.figure_padding_x = this.model.get("padding_x");
         this.figure_padding_y = this.model.get("padding_y");
         this.clip_id = "clip_path_" + this.id;
-
-        this.el.style["flex"] = "1 1 auto";
-        this.el.style["align-self"] = "stretch";
-        this.el.style["min-width"] = this.width;
-        this.el.style["min-height"] = this.height;
-
         this.margin = this.model.get("fig_margin");
 
         this.svg = d3.select(this.el);
         this.update_plotarea_dimensions();
         // this.fig is the top <g> element to be impacted by a rescaling / change of margins
+        this.svg.attr("viewBox", "0 0 " + this.width +
+                                    " " + this.height);
+
         this.fig = this.svg.append("g")
             .attr("transform", "translate(" + this.margin.left + "," + this.margin.top + ")");
         this.tooltip_div = d3.select(document.createElement("div"))

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -201,10 +201,14 @@ var Figure = widgets.DOMWidgetView.extend({
                 this.set_interaction(value);
             }, that);
 
-            that.displayed.then(function() {
+            that.displayed.then(function(args) {
                 that.el.parentNode.appendChild(that.tooltip_div.node());
                 that.create_listeners();
-                that.relayout();
+                if(args === undefined || args.add_to_dom_only !== true) {
+                    //do not relayout if it is only being added to the DOM
+                    //and not displayed.
+                    that.relayout();
+                }
                 that.model.on("msg:custom", that.handle_custom_messages,
 			  that);
             });

--- a/js/src/Mark.js
+++ b/js/src/Mark.js
@@ -314,6 +314,7 @@ var Mark = widgets.WidgetView.extend({
                 //remove previous tooltip
                 that.tooltip_view = view;
                 that.tooltip_div.node().appendChild(view.el);
+                view.trigger("displayed", {"add_to_dom_only": true});
                 // we do not trigger displayed as the tooltip is not currently
                 // visible.
             });

--- a/js/src/Mark.js
+++ b/js/src/Mark.js
@@ -315,8 +315,6 @@ var Mark = widgets.WidgetView.extend({
                 that.tooltip_view = view;
                 that.tooltip_div.node().appendChild(view.el);
                 view.trigger("displayed", {"add_to_dom_only": true});
-                // we do not trigger displayed as the tooltip is not currently
-                // visible.
             });
         } else {
             if(that.tooltip_view) {

--- a/js/src/Mark.js
+++ b/js/src/Mark.js
@@ -314,7 +314,8 @@ var Mark = widgets.WidgetView.extend({
                 //remove previous tooltip
                 that.tooltip_view = view;
                 that.tooltip_div.node().appendChild(view.el);
-                view.trigger("displayed");
+                // we do not trigger displayed as the tooltip is not currently
+                // visible.
             });
         } else {
             if(that.tooltip_view) {


### PR DESCRIPTION
If we trigger `displayed` on the `view` before the `widget` in the `tooltip` is displayed, the `width` and `height` are set to negative values as the `el.clientHeight` and `el.clientWidth` are 0. 

This PR fixes it by not triggering `displayed` when `tooltip` is not necessarily displayed.