### PR TITLE
Figure as a tooltip for MarketMap doesn't display

### DIFF
--- a/js/src/MarketMap.js
+++ b/js/src/MarketMap.js
@@ -655,6 +655,7 @@ var MarketMap = figure.Figure.extend({
             tooltip_widget_creation_promise.then(function(view) {
                 that.tooltip_view = view;
                 that.tooltip_div.node().appendChild(view.el);
+                view.trigger("displayed", {"add_to_dom_only": true});
             });
         }
     },


### PR DESCRIPTION
Triggering `displayed` so that the size of the `Figure` is set.