### PR TITLE
Add Viridis for Categorical Scales

### DIFF
--- a/js/src/ColorUtils.js
+++ b/js/src/ColorUtils.js
@@ -19,7 +19,7 @@ var colorbrewer = require("./colorbrewer");
 var utils = require("./utils");
 
 var color_schemes = [
-    "Paired", "Set3", "Pastel1", "Set1", "Greys", "Greens", "Reds", "Purples", "Oranges", "Blues", "YlOrRd", "YlOrBr", "YlGnBu", "YlGn", "RdPu",
+    "Paired", "Set3", "Pastel1", "Set1", "Greys", "Greens", "Reds", "Purples", "Viridis", "Oranges", "Blues", "YlOrRd", "YlOrBr", "YlGnBu", "YlGn", "RdPu",
     "PuRd", "PuBuGn", "PuBu", "OrRd", "GnBu", "BuPu", "BuGn", "BrBG", "PiYG", "PRGn", "PuOr", "RdBu", "RdGy", "RdYlBu", "RdYlGn", "Spectral"
 ];
 
@@ -70,7 +70,7 @@ var cycle_colors = function(colors, count) {
 
 var cycle_colors_from_scheme = function(scheme, num_steps) {
     var index = color_schemes.indexOf(scheme);
-    index = (index === -1) ? 29 : index;
+    index = (index === -1) ? 30 : index;
     var color_set = colorbrewer[color_schemes[index]];
 
     if (num_steps === 2) {
@@ -88,7 +88,7 @@ var get_colors = function(scheme, num_colors) {
     var index = color_schemes.indexOf(scheme);
 
     if(index === -1) {
-        index = 29;
+        index = 30;
     }
 
     var colors_object = colorbrewer[color_schemes[index]];
@@ -98,7 +98,7 @@ var get_colors = function(scheme, num_colors) {
     }
     if(index < 4) {
         return this.cycle_colors(colors_object[Math.min(num_colors, 9)], num_colors);
-    } else if(index < 22) {
+    } else if(index < 23) {
         return this.scale_colors(colors_object[Math.min(num_colors, 9)], num_colors);
     } else {
         return this.scale_colors_multi(colors_object[Math.min(num_colors, 9)], num_colors);
@@ -108,12 +108,12 @@ var get_colors = function(scheme, num_colors) {
 var get_linear_scale = function(scheme) {
     var index = color_schemes.indexOf(scheme);
     if(index === -1 && index < 4) {
-        index = 29;
+        index = 30;
     }
 
     var colors = colorbrewer[color_schemes[index]][9];
     var scale = d3.scale.linear();
-    if(index > 22) {
+    if(index > 23) {
         scale.range([colors[0], colors[4], colors[8]]);
     } else {
         scale.range([colors[0], colors[8]]);
@@ -140,7 +140,7 @@ var is_divergent = function(scheme) {
     if(index === -1 && index < 4) {
         index = 2;
     }
-    return (index > 22);
+    return (index > 23);
 };
 
 module.exports = {

--- a/js/src/colorbrewer.js
+++ b/js/src/colorbrewer.js
@@ -1,38 +1,38 @@
 /* Apache-Style Software License for ColorBrewer software and ColorBrewer Color
  * Schemes
- * 
+ *
  * Copyright (c) 2002 Cynthia Brewer, Mark Harrower, and The Pennsylvania State
  * University.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions as source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
- * 
+ *
  * 2. The end-user documentation included with the redistribution, if any, must
  * include the following acknowledgment: "This product includes color
  * specifications and designs developed by Cynthia Brewer
  * (http://colorbrewer.org/)." Alternately, this acknowledgment may appear in the
  * software itself, if and wherever such third-party acknowledgments normally
  * appear.
- * 
+ *
  * 4. The name "ColorBrewer" must not be used to endorse or promote products
  * derived from this software without prior written permission. For written
  * permission, please contact Cynthia Brewer at cbrewer@psu.edu.
- * 
+ *
  * 5. Products derived from this software may not be called "ColorBrewer", nor
  * may "ColorBrewer" appear in their name, without prior written permission of
  * Cynthia Brewer.
@@ -329,6 +329,15 @@ var colorbrewer = {YlGn: {
 6: ["#66c2a5","#fc8d62","#8da0cb","#e78ac3","#a6d854","#ffd92f"],
 7: ["#66c2a5","#fc8d62","#8da0cb","#e78ac3","#a6d854","#ffd92f","#e5c494"],
 8: ["#66c2a5","#fc8d62","#8da0cb","#e78ac3","#a6d854","#ffd92f","#e5c494","#b3b3b3"]
+},Viridis: {
+3: ["#440154","#35b779","#fde725"],
+4: ["#440154","#30698e","#35b779","#fde725"],
+5: ["#440154","#404588","#2a788e","#75d054","#fde725"],
+6: ["#440154","#404588","#2a788e","#22a785","#75d054","#fde725"],
+7: ["#440154","#443b84","#30698e","#21918c","#35b779","#8ed645","#fde725"],
+8: ["#450457","#463480","#365d8d","#27808e","#1fa187","#4ac16d","#9dd93b","#fde725"],
+9: ["#440154","#472a7a","#3e4c8a","#30698e","#25838e","#1f9e89","#35b779","#6ccd5a","#fde725"],
+10: ["#440154","#472e7c","#3b528b","#2c718e","#218f8d","#25ac82","#56c667","#a0da39","#f1e51d","#fde725"],
 },Set3: {
 3: ["#8dd3c7","#ffffb3","#bebada"],
 4: ["#8dd3c7","#ffffb3","#bebada","#fb8072"],


### PR DESCRIPTION
@SylvainCorlay I wanted this PR to be the point where we start discussing how bad our color scales are, and define a roadmap to improve them. 

My suggestions are:
- [ ] Currently, I dont know why, @ssunkara1 , for a linear scale it interpolates linearly between the min, mid, high, rather than interpolating between colors. What was the logic for the 3 colors?
- [ ] We refactor the logic that depends on an arbitrary index to be dictionary like
- [ ] We rely on d3, only interpolating if the user passes colors, that too we should accept n colors
