### PR TITLE
Hover issue for market map

### DIFF
--- a/bqplot/market_map.py
+++ b/bqplot/market_map.py
@@ -163,8 +163,8 @@ class MarketMap(DOMWidget):
 
     stroke = Color('white').tag(sync=True)
     group_stroke = Color('black').tag(sync=True)
-    selected_stroke = Color('dodgerblue').tag(sync=True)
-    hovered_stroke = Color('orangered').tag(sync=True)
+    selected_stroke = Color('dodgerblue', allow_none=True).tag(sync=True)
+    hovered_stroke = Color('orangered', allow_none=True).tag(sync=True)
     font_style = Dict().tag(sync=True)
     title_style = Dict().tag(sync=True)
 

--- a/js/src/MarketMap.js
+++ b/js/src/MarketMap.js
@@ -576,7 +576,9 @@ var MarketMap = figure.Figure.extend({
                 .attr("y", 0)
                 .attr("width", this.column_width)
                 .attr("height", this.row_height)
-                .style({'stroke': this.hovered_stroke, 'stroke-width': '3px', 'fill': 'none'});
+                .style({'stroke': this.hovered_stroke, 'stroke-width': '3px', 'fill': 'none',
+                        'pointer-events': 'none'
+                    });
             this.show_tooltip(d3.event, data);
         }
     },
@@ -655,6 +657,7 @@ var MarketMap = figure.Figure.extend({
             tooltip_widget_creation_promise.then(function(view) {
                 that.tooltip_view = view;
                 that.tooltip_div.node().appendChild(view.el);
+                view.trigger("displayed", {"add_to_dom_only": true});
             });
         }
     },


### PR DESCRIPTION
There is an issue with hovering over the `MarketMap` when `hovered_stroke` is present. There is a dummy hover event which is triggered because of the addition of the hovered rectangle. Fixing that issue and also making `selected_stroke` and `hovered_stroke` nullable (Don't think this is a word).