### PR TITLE
GridHeatmap minor issues fix

### DIFF
--- a/js/src/GridHeatMap.js
+++ b/js/src/GridHeatMap.js
@@ -273,6 +273,9 @@ var GridHeatMap = mark.Mark.extend({
     },
 
     _filter_cells_by_cell_num: function(cell_numbers) {
+        if (cell_numbers === null || cell_numbers === undefined) {
+            return [];
+        }
         return this.display_cells.filter(function(el) {
            return (cell_numbers.indexOf(el._cell_num) !== -1);});
     },
@@ -302,7 +305,6 @@ var GridHeatMap = mark.Mark.extend({
         var selected_cell_nums = this._cell_nums_from_indices(this.selected_indices);
         var unsel_cell_nums = (selected_cell_nums === null) ? []
                                 : _.difference(_.range(num_rows*num_cols), selected_cell_nums);
-        var anchor_num = this._cell_nums_from_indices([this.anchor_cell_index]);
 
         this.selected_elements = this._filter_cells_by_cell_num(selected_cell_nums);
         this.set_style_on_elements(this.selected_style, this.selected_indices, this.selected_elements);
@@ -310,8 +312,11 @@ var GridHeatMap = mark.Mark.extend({
         this.unselected_elements = this._filter_cells_by_cell_num(unsel_cell_nums);
         this.set_style_on_elements(this.unselected_style, [], this.unselected_elements);
 
-        this.anchor_element = this._filter_cells_by_cell_num(anchor_num);
-        this.set_style_on_elements(this.anchor_style, [], this.anchor_element);
+        if(this.anchor_cell_index !== null && this.anchor_cell_index !== undefined) {
+            var anchor_num = this._cell_nums_from_indices([this.anchor_cell_index]);
+            this.anchor_element = this._filter_cells_by_cell_num(anchor_num);
+            this.set_style_on_elements(this.anchor_style, [], this.anchor_element);
+        }
     },
 
     style_updated: function(new_style, indices, elements) {

--- a/js/src/GridHeatMap.js
+++ b/js/src/GridHeatMap.js
@@ -298,6 +298,7 @@ var GridHeatMap = mark.Mark.extend({
 
         this.clear_style(this.selected_style);
         this.clear_style(this.unselected_style);
+        this.clear_style(this.anchor_style);
 
         this.set_default_style([], this.display_cells);
         var that = this;
@@ -331,7 +332,9 @@ var GridHeatMap = mark.Mark.extend({
         this.selected_indices = null;
         this.clear_style(this.selected_style);
         this.clear_style(this.unselected_style);
-        this.set_default_style();
+        this.clear_style(this.anchor_style);
+
+        this.set_default_style([], this.display_cells);
     },
 
     relayout: function() {


### PR DESCRIPTION
When `selected` attribute was being set to `None` from the Python side, there was a JS error because of a missing null check. Also, clearing out the `anchor_style` and applying default style on the cells when selection is reset.