### PR TITLE
Yet again tackling resizing, this time letting flex box do the hard work

### DIFF
--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -102,6 +102,8 @@ var Figure = widgets.DOMWidgetView.extend({
 
         this.update_plotarea_dimensions();
         // this.fig is the top <g> element to be impacted by a rescaling / change of margins
+        this.svg.style("min-width", "300px");
+        this.svg.style("min-height", "300px");
 
         this.fig = this.svg.append("g")
             .attr("transform", "translate(" + this.margin.left + "," + this.margin.top + ")");

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -102,10 +102,6 @@ var Figure = widgets.DOMWidgetView.extend({
 
         this.update_plotarea_dimensions();
         // this.fig is the top <g> element to be impacted by a rescaling / change of margins
-        this.svg.attr("viewBox", "0 0 " + this.width +
-                                    " " + this.height);
-        this.svg.style("min-width", "" + this.width + "px");
-        this.svg.style("min-height", "" + this.height + "px");
 
         this.fig = this.svg.append("g")
             .attr("transform", "translate(" + this.margin.left + "," + this.margin.top + ")");
@@ -473,9 +469,6 @@ var Figure = widgets.DOMWidgetView.extend({
     },
 
     relayout: function() {
-        this.svg.attr("viewBox", "0 0 1 1");
-        this.svg.style("min-width", '');
-        this.svg.style("min-height", '');
 
         var that = this;
 
@@ -483,10 +476,6 @@ var Figure = widgets.DOMWidgetView.extend({
         that.width = impl_dimensions["width"];
         that.height = impl_dimensions["height"];
 
-        that.svg.attr("viewBox", "0 0 " + that.width +
-                                    " " + that.height);
-        that.svg.style("min-width", "" + that.width + "px");
-        that.svg.style("min-height", "" + that.height + "px");
         window.requestAnimationFrame(function () {
             // update ranges
             that.margin = that.model.get("fig_margin");

--- a/js/src/bqplot.less
+++ b/js/src/bqplot.less
@@ -14,6 +14,9 @@
  */
 
 .common() {
+    .bqplot {
+        display: flex;
+    }
     .bqplot > svg {
         font: 11px sans-serif;
         user-select: none;
@@ -21,7 +24,7 @@
         -khtml-user-select: none;
         -khtml-user-select: none;
         -webkit-user-select: none;
-
+        flex-grow: 1;
         .axis {
             line {
                 shape-rendering: crispEdges;


### PR DESCRIPTION
This time, we had issues with the intrinsic aspect ratio from the view box messing up the calculated width and height. Setting the view box to ‘0 0 1 1’ and then measuring the width/height meant that it would try to expand to a 1:1 aspect ratio and then calculate the hard minimum sizes and set them, often leading to plots that would overflow their containing box.

Thanks to @ssunkara1 for working on this commit as well.
