### PR TITLE
Default size fixes

### DIFF
--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -125,9 +125,9 @@ class Figure(DOMWidget):
     layout = Instance(Layout, kw={
             'flex': '1',
             'align_self': 'stretch',
-            'min_width': '400px'
+            'min_width': '600px'
         }, allow_none=True).tag(sync=True, **widget_serialization)
-    min_aspect_ratio = Float(16.0 / 9.0).tag(sync=True)
+    min_aspect_ratio = Float(4.0 / 3.0).tag(sync=True)
     max_aspect_ratio = Float(16.0 / 9.0).tag(sync=True)
 
     fig_margin = Dict(dict(top=60, bottom=60, left=60, right=60)).tag(sync=True)

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -47,7 +47,7 @@ var Figure = widgets.DOMWidgetView.extend({
         } else if (height_undefined) {
             suggested_height = suggested_width / min_ratio;
         } else if (width_undefined) {
-            suggested_width = suggested_height * min_ratio;
+            suggested_width = suggested_height * max_ratio;
         }
 
         var ratio = suggested_width / suggested_height;
@@ -80,6 +80,9 @@ var Figure = widgets.DOMWidgetView.extend({
         this.width = impl_dimensions["width"];
         this.height = impl_dimensions["height"];
 
+        this.svg.style("min-width", this.width + "px");
+        this.svg.style("min-height", this.height + "px");
+
         this.id = widgets.uuid();
 
         // Dictionary which contains the mapping for each of the marks id
@@ -101,9 +104,6 @@ var Figure = widgets.DOMWidgetView.extend({
         this.margin = this.model.get("fig_margin");
 
         this.update_plotarea_dimensions();
-        // this.fig is the top <g> element to be impacted by a rescaling / change of margins
-        this.svg.style("min-width", "300px");
-        this.svg.style("min-height", "300px");
 
         this.fig = this.svg.append("g")
             .attr("transform", "translate(" + this.margin.left + "," + this.margin.top + ")");

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -475,8 +475,11 @@ var Figure = widgets.DOMWidgetView.extend({
         var that = this;
 
         var impl_dimensions = this._get_height_width(this.el.clientHeight, this.el.clientWidth);
-        that.width = impl_dimensions["width"];
-        that.height = impl_dimensions["height"];
+        this.width = impl_dimensions["width"];
+        this.height = impl_dimensions["height"];
+
+        this.svg.style("min-width", this.width + "px");
+        this.svg.style("min-height", this.height + "px");
 
         window.requestAnimationFrame(function () {
             // update ranges


### PR DESCRIPTION
* Firstly, the `min_width` attribute is not as innocuous as it seems. Because `min_width` along with `aspect_ratio` is determining the `min_height` which is setting the el.clientHeight since there is no default natural height.

* I do not like setting the properties on the `svg` and on the `div` separately but the `Layout` seems to clear styling that I set even if that styling is not passed to the `Layout`. For e.g., if `min_height` is not set on the `Layout` object, and I set the style manually on the javascript side, it is still cleared by the `Layout`. So, I have to set the style for the svg.