### PR TITLE
Set a natural width/height of 640x480. Don’t expand by default.

### DIFF
--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -127,7 +127,7 @@ class Figure(DOMWidget):
             'align_self': 'stretch',
             'min_width': '400px'
         }, allow_none=True).tag(sync=True, **widget_serialization)
-    min_aspect_ratio = Float(16.0 / 9.0).tag(sync=True)
+    min_aspect_ratio = Float(1.0).tag(sync=True)
     max_aspect_ratio = Float(16.0 / 9.0).tag(sync=True)
 
     fig_margin = Dict(dict(top=60, bottom=60, left=60, right=60)).tag(sync=True)

--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -122,10 +122,9 @@ class Figure(DOMWidget):
     title_style = Dict(trait=Unicode()).tag(sync=True)
     background_style = Dict().tag(sync=True)
 
+    # min width is based on hardcoded padding values
     layout = Instance(Layout, kw={
-            'flex': '1',
-            'align_self': 'stretch',
-            'min_width': '400px'
+            'min_width': '125px'
         }, allow_none=True).tag(sync=True, **widget_serialization)
     min_aspect_ratio = Float(1.0).tag(sync=True)
     max_aspect_ratio = Float(16.0 / 9.0).tag(sync=True)

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -41,9 +41,9 @@ var Figure = widgets.DOMWidgetView.extend({
         var height_undefined = (suggested_height === undefined || isNaN(suggested_height) || suggested_width <= 0);
 
         if (width_undefined && height_undefined) {
-            // These are defaults if both min_width and min_height are undefined
-            suggested_height = 337.5;
-            suggested_width = 600;
+            // Same as the defaults in bqplot.less
+            suggested_height = 480;
+            suggested_width = 640;
         } else if (height_undefined) {
             suggested_height = suggested_width / min_ratio;
         } else if (width_undefined) {

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -102,8 +102,6 @@ var Figure = widgets.DOMWidgetView.extend({
 
         this.update_plotarea_dimensions();
         // this.fig is the top <g> element to be impacted by a rescaling / change of margins
-        this.svg.style("min-width", "300px");
-        this.svg.style("min-height", "300px");
 
         this.fig = this.svg.append("g")
             .attr("transform", "translate(" + this.margin.left + "," + this.margin.top + ")");

--- a/js/src/FigureModel.js
+++ b/js/src/FigureModel.js
@@ -40,7 +40,7 @@ var FigureModel = basemodel.BaseModel.extend({
             min_width: "",
             min_height: "",
             preserve_aspect: false,
-            min_aspect_ratio: 16 / 9,
+            min_aspect_ratio: 1,
             max_aspect_ratio: 16 / 9,
 
             fig_margin: {

--- a/js/src/bqplot.less
+++ b/js/src/bqplot.less
@@ -15,7 +15,11 @@
 
 .common() {
     .bqplot {
+        box-sizing: border-box;
         display: flex;
+        overflow: hidden;
+        width: 640px;
+        height: 480px;
     }
     .bqplot > svg {
         font: 11px sans-serif;


### PR DESCRIPTION
Thanks @SylvainCorlay for the logic.