### PR TITLE
Clearing hovered style

### DIFF
--- a/js/src/Mark.js
+++ b/js/src/Mark.js
@@ -213,10 +213,14 @@ var Mark = widgets.WidgetView.extend({
         this.set_style_on_elements(new_style, indices);
     },
 
-    apply_styles: function() {
+    apply_styles: function(style_arr) {
+        if(style_arr === undefined || style_arr == null) {
+            style_arr = [this.selected_style, this.unselected_style];
+        }
         var all_indices = _.range(this.model.mark_data.length);
-        this.clear_style(this.selected_style);
-        this.clear_style(this.unselected_style);
+        for(var i = 0; i < style_arr.length; i++) {
+            this.clear_style(style_arr[i]);
+        }
 
         this.set_default_style(all_indices);
 

--- a/js/src/MarkModel.js
+++ b/js/src/MarkModel.js
@@ -35,7 +35,7 @@ var MarkModel = basemodel.BaseModel.extend({
             visible: true,
             selected_style: {},
             unselected_style: {},
-            selected: [],
+            selected: null,
             enable_hover: true,
             tooltip: null,
             tooltip_style: { opacity: 0.9 },

--- a/js/src/ScatterBase.js
+++ b/js/src/ScatterBase.js
@@ -579,12 +579,16 @@ var ScatterBase = mark.Mark.extend({
     },
 
     update_hovered: function(model, value) {
-        this.hovered_index = [value];
+        this.hovered_index = value === null ? value : [value];
         this.apply_styles();
     },
 
-    apply_styles: function() {
-        ScatterBase.__super__.apply_styles.apply(this);
+    apply_styles: function(style_arr) {
+        if(style_arr === undefined || style_arr == null) {
+            style_arr = [this.selected_style, this.unselected_style,
+                         this.hovered_style, this.unhovered_style];
+        }
+        ScatterBase.__super__.apply_styles.apply(this, [style_arr]);
 
         var all_indices = _.range(this.model.mark_data.length);
 


### PR DESCRIPTION
A couple of points here.
1. We have to clear the `hovered_style` and `unhovered_style` as well because if they set styles which are not overridden by the `set_default_style` they will remain on the elements.
2. When `hovered_index` is set to `null`, we do not want it to be set to a list which puts off the calculation of the `unhovered_indices`.