### PR TITLE
Adding rotation to scatter scales metadata

### DIFF
--- a/js/src/ScatterBaseModel.js
+++ b/js/src/ScatterBaseModel.js
@@ -36,7 +36,8 @@ var ScatterBaseModel = markmodel.MarkModel.extend({
             y: { orientation: "vertical", dimension: "y" },
             color: { dimension: "color" },
             size: { dimension: "size" },
-            opacity: { dimension: "opacity" }
+            opacity: { dimension: "opacity" },
+            rotation: { dimension: "rotation" }
         },
         colors: [],
         default_opacities: [],


### PR DESCRIPTION
This was forgotten, and causing the pyplot PanZoom to fail when a rotation scale was specified.