### PR TITLE
Marker change issue for Lines

### DIFF
--- a/js/src/Lines.js
+++ b/js/src/Lines.js
@@ -622,7 +622,7 @@ var Lines = mark.Mark.extend({
                 this.legend_el.select(".dot").attr("d", this.dot.type(marker).size(25));
             }
         } else {
-            this.id3el.selectAll(".dot").remove();
+            this.d3el.selectAll(".dot").remove();
             if (this.legend_el) {
                 this.legend_el.select(".dot").attr("d", this.dot.size(0));
             }


### PR DESCRIPTION
When the `marrker` of `Lines` is set to `None` nothing happens as of now.

Also, there is a bigger issue which is not solved here. When a JS exception occurs, all the handlers attached through `on_some_change` do not work any more. That is causing a bug when `marker` is set to `None` because, the `Lines` object does not listen to change in `x`, `y`. etc anymore.