### PR TITLE
Fix race condition with ordinal scale

### DIFF
--- a/js/src/OrdinalScale.js
+++ b/js/src/OrdinalScale.js
@@ -21,8 +21,6 @@ var OrdinalScale = scale.Scale.extend({
 
     render: function() {
         this.scale = d3.scale.ordinal();
-        //forcefully setting the domain
-        this.model.domain_changed();
         this.scale.domain(this.model.domain);
         this.offset = 0;
         this.create_event_listeners();


### PR DESCRIPTION
The following code results in the marks not rendering randomly (as of ipywidgets 6.0, bqplot 0.9beta)

```python
import bqplot
import numpy as np
import bqplot.pyplot as plt

# Bivariate Distribution
mean0, cov0, size0 = [-1.0, -1.0], [[1.0, -0.4], [-0.4, 1.0]], 10
mean1, cov1, size1 = [ 1.0,  1.0], [[1.0,  0.4], [ 0.4, 1.0]], 5

sample = np.vstack([
    np.random.multivariate_normal(mean0, cov0, size0),
    np.random.multivariate_normal(mean1, cov1, size1)
])
category = np.hstack([np.ones(size0), -np.ones(size1)])

plt.figure()
plt.scatter(sample[:, 0], sample[:, 1], color=category, scales={
    'color': bqplot.OrdinalColorScale()
}, enable_move=True)

plt.show()
```

However, width a linear color scale, there is no such issue.

The problem seems to come from the forced call of "update_domain" of the `OrdinalColorScale`, which is so that when the figure is actually drawn, the second `update_domain` does not see the domain change and does not trigger things to be drawn