### PR TITLE
Fixing transitions

### DIFF
--- a/js/src/Axis.js
+++ b/js/src/Axis.js
@@ -160,7 +160,8 @@ var Axis = widgets.WidgetView.extend({
 
         if(this.g_axisline) {
              this.g_axisline
-                .transition().duration(animate === true ? this.parent.model.get("animation_duration") : 0)
+                .transition("set_tick_values")
+                .duration(animate === true ? this.parent.model.get("animation_duration") : 0)
                 .call(this.axis);
         }
     },
@@ -489,7 +490,7 @@ var Axis = widgets.WidgetView.extend({
             .classed("short", grid_type === "none");
 
         this.g_axisline
-            .transition().duration(animation_duration)
+            .transition("update_grid_lines").duration(animation_duration)
             .call(this.axis)
             .selectAll(".tick line")
             .attr(is_x ? "y1" : "x1",

--- a/js/src/Bars.js
+++ b/js/src/Bars.js
@@ -380,7 +380,7 @@ var Bars = mark.Mark.extend({
             });
         }
         if (this.model.get("type") === "stacked") {
-            bars_sel.transition().duration(animation_duration)
+            bars_sel.transition("draw_bars").duration(animation_duration)
                 .attr(dom, 0)
                 .attr(dom_control, this.x.rangeBand().toFixed(2))
                 .attr(rang, function(d) {
@@ -390,7 +390,7 @@ var Bars = mark.Mark.extend({
                     return Math.abs(range_scale.scale(d.y1 + d.y_ref) - range_scale.scale(d.y1));
                 });
         } else {
-            bars_sel.transition().duration(animation_duration)
+            bars_sel.transition("draw_bars").duration(animation_duration)
               .attr(dom, function(datum, index) {
                     return that.x1(index);
               })

--- a/js/src/FlexLine.js
+++ b/js/src/FlexLine.js
@@ -105,7 +105,8 @@ var FlexLine = lines.Lines.extend({
             .attr("class", "curve");
 
         curves_sel.exit()
-            .transition().duration(this.parent.model.get("animation_duration"))
+            .transition("draw")
+            .duration(this.parent.model.get("animation_duration"))
             .remove();
 
         var x_scale = this.scales.x, y_scale = this.scales.y;
@@ -154,7 +155,8 @@ var FlexLine = lines.Lines.extend({
 
         var that = this;
         this.d3el.selectAll(".curve").selectAll(".line-elem")
-            .transition().duration(this.parent.model.get("animation_duration"))
+            .transition("relayout")
+            .duration(this.parent.model.get("animation_duration"))
             .attr({
                 x1: function(d) { return x_scale.scale(d.x1); },
                 x2: function(d) { return x_scale.scale(d.x2); },

--- a/js/src/Hist.js
+++ b/js/src/Hist.js
@@ -182,7 +182,8 @@ var Hist = mark.Mark.extend({
             });
         var bar_width = this.calculate_bar_width();
         this.d3el.selectAll(".bargroup").select("rect")
-          .transition().duration(this.parent.model.get("animation_duration"))
+          .transition("relayout")
+          .duration(this.parent.model.get("animation_duration"))
           .attr("x", 2)
           .attr("width", bar_width)
           .attr("height", function(d) {
@@ -232,7 +233,7 @@ var Hist = mark.Mark.extend({
               });
           })
           .attr("id", function(d, i) { return "rect" + i; })
-          .transition()
+          .transition("draw")
           .duration(this.parent.model.get("animation_duration"))
           .attr("width", bar_width)
           .attr("height", function(d) {

--- a/js/src/Label.js
+++ b/js/src/Label.js
@@ -36,7 +36,7 @@ var Label = scatterbase.ScatterBase.extend({
             // update opacity scale range?
             var that = this;
             this.d3el.selectAll(".label")
-                .transition()
+                .transition("update_default_opacities")
                 .duration(animation_duration)
                 .style("opacity", function(d, i) {
                     return that.get_element_opacity(d, i);
@@ -51,7 +51,7 @@ var Label = scatterbase.ScatterBase.extend({
             var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
             var that = this;
             this.d3el.selectAll(".label")
-                .transition()
+                .transition("update_default_size")
                 .duration(animation_duration)
                 .style("font-size", function(d, i) {
                     return that.get_element_size(d);
@@ -142,7 +142,7 @@ var Label = scatterbase.ScatterBase.extend({
 
         this.d3el.selectAll(".object_grp")
             .select("text")
-            .transition()
+            .transition("color_scale_updated")
             .duration(animation_duration)
             .style("fill", function(d, i) {
                   return that.get_element_color(d, i);
@@ -176,7 +176,7 @@ var Label = scatterbase.ScatterBase.extend({
         d3.select(dragged_node)
           .select("text")
           .classed("drag_label", true)
-          .transition()
+          .transition("set_drag_style")
           .style("font-size", (dragged_size));
     },
 
@@ -184,7 +184,7 @@ var Label = scatterbase.ScatterBase.extend({
         d3.select(dragged_node)
           .select("text")
           .classed("drag_label", false)
-          .transition()
+          .transition("reset_drag_style")
           .style("font-size", this.get_element_size(d));
     },
 });

--- a/js/src/Lines.js
+++ b/js/src/Lines.js
@@ -245,7 +245,8 @@ var Lines = mark.Mark.extend({
               return that.line(d.values) + that.path_closure();
           });
         this.d3el.selectAll(".curve").select(".area")
-          .transition().duration(0) //FIXME
+          .transition("update_path_style")
+          .duration(0) //FIXME
           .attr("d", function(d) { return that.area(d.values); });
         if (this.legend_el) {
             this.legend_line.interpolate(interpolation);
@@ -480,17 +481,20 @@ var Lines = mark.Mark.extend({
         var curves_sel = this.d3el.selectAll(".curve");
 
         curves_sel.select(".line")
-          .transition().duration(animation_duration)
+          .transition("update_line_xy")
+          .duration(animation_duration)
           .attr("d", function(d) {
               return that.line(d.values) + that.path_closure();
           });
 
         curves_sel.select(".area")
-          .transition().duration(animation_duration)
+          .transition("update_line_xy")
+          .duration(animation_duration)
           .attr("d", function(d) { return that.area(d.values); });
 
         curves_sel.select(".curve_label")
-          .transition().duration(animation_duration)
+          .transition("update_line_xy")
+          .duration(animation_duration)
           .attr("transform", function(d) {
               var last_xy = d.values[d.values.length - 1];
               return "translate(" + x_scale.scale(last_xy.x) +
@@ -572,7 +576,7 @@ var Lines = mark.Mark.extend({
             var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
             var dots = this.d3el.selectAll(".curve").selectAll(".dot");
 
-            dots.transition().duration(animation_duration)
+            dots.transition("update_dots_xy").duration(animation_duration)
                 .attr("transform", function(d) { return "translate(" + (x_scale.scale(d.x) + x_scale.offset) +
                         "," + (y_scale.scale(d.y) + y_scale.offset) + ")";
                 })

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -156,10 +156,11 @@ var Map = mark.Mark.extend({
         var el = d3.select(d3.event.target);
         if(this.is_hover_element(el)) {
             var that = this;
-            el.transition().style("fill", function(d, i) {
+            el.transition("mouseout_handler")
+            .style("fill", function(d, i) {
                 return that.fill_g_colorfill(d, i);
-            });
-            el.transition().style("stroke", function(d, i) {
+            })
+            .style("stroke", function(d, i) {
                 return that.hoverfill(d, i);
             });
             that.highlight_g.selectAll(".hovered").remove();
@@ -175,7 +176,8 @@ var Map = mark.Mark.extend({
             var elem_index = selected.indexOf(data.id);
             if(elem_index > -1) {
                 selected.splice(elem_index, 1);
-                el.style("fill-opacity", 0.0).transition();
+                el.transition("click_handler")
+                    .style("fill-opacity", 0.0);
                 this.highlight_g.selectAll(".hovered").remove();
                 var choice = "#c".concat(data.id.toString());
                 d3.select(choice).remove();

--- a/js/src/Mark.js
+++ b/js/src/Mark.js
@@ -131,7 +131,7 @@ var Mark = widgets.WidgetView.extend({
 
     remove: function() {
         this.model.off(null, null, this);
-        this.d3el.transition().duration(0).remove();
+        this.d3el.transition("remove").duration(0).remove();
         this.tooltip_div.remove();
         Mark.__super__.remove.apply(this);
     },
@@ -257,7 +257,7 @@ var Mark = widgets.WidgetView.extend({
             } else {
                 this.tooltip_div.style("pointer-events", "all");
             }
-            this.tooltip_div.transition()
+            this.tooltip_div.transition("show_tooltip")
                 .style(this.model.get("tooltip_style"))
                 .style("display", null);
 
@@ -282,7 +282,7 @@ var Mark = widgets.WidgetView.extend({
         //this function hides the tooltip. But the location of the tooltip
         //is the last location set by a call to show_tooltip.
         this.tooltip_div.style("pointer-events", "none");
-        this.tooltip_div.transition()
+        this.tooltip_div.transition("hide_tooltip")
             .style("opacity", 0)
             .style("display", "none");
     },

--- a/js/src/MarketMap.js
+++ b/js/src/MarketMap.js
@@ -588,7 +588,7 @@ var MarketMap = figure.Figure.extend({
         var mouse_pos = d3.mouse(this.el);
         var that = this;
         var tooltip_div = this.tooltip_div;
-        tooltip_div.transition()
+        tooltip_div.transition("show_tooltip")
             .style("opacity", 0.9)
             .style("display", null);
 
@@ -618,7 +618,7 @@ var MarketMap = figure.Figure.extend({
 
     hide_tooltip: function() {
          this.tooltip_div.style("pointer-events", "none");
-         this.tooltip_div.transition()
+         this.tooltip_div.transition("hide_tooltip")
             .style("opacity", 0)
             .style("display", "none");
     },

--- a/js/src/Pie.js
+++ b/js/src/Pie.js
@@ -188,7 +188,7 @@ var Pie = mark.Mark.extend({
         var transform = "translate(" + (x_scale.scale(x) + x_scale.offset) +
                                 ", " + (y_scale.scale(y) + y_scale.offset) + ")";
         this.d3el.select(".pielayout")
-            .transition().duration(animation_duration)
+            .transition("position_center").duration(animation_duration)
             .attr("transform", transform);
     },
 
@@ -200,12 +200,12 @@ var Pie = mark.Mark.extend({
         var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
         slices.select("path")
-            .transition().duration(animation_duration)
+            .transition("update_radii").duration(animation_duration)
             .attr("d", this.arc);
 
         var that = this;
         slices.select("text")
-            .transition().duration(animation_duration)
+            .transition("update_radii").duration(animation_duration)
             .attr("transform", function(d) {
                 return "translate(" + that.arc.centroid(d) + ")";
             });
@@ -244,7 +244,7 @@ var Pie = mark.Mark.extend({
 
         var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
         //animate slices on data changes using custom tween
-        var t = slices.transition().duration(animation_duration);
+        var t = slices.transition("draw").duration(animation_duration);
         t.select("path").attrTween("d", updateTween);
         t.select("text").attr("transform", function(d) {
             return "translate(" + that.arc.centroid(d) + ")";

--- a/js/src/Scatter.js
+++ b/js/src/Scatter.js
@@ -128,7 +128,7 @@ var Scatter = scatterbase.ScatterBase.extend({
             // update opacity scale range?
             var that = this;
             this.d3el.selectAll(".dot")
-                .transition()
+                .transition("update_default_opacities")
                 .duration(animation_duration)
                 .style("opacity", function(d, i) {
                     return that.get_element_opacity(d, i);
@@ -148,7 +148,7 @@ var Scatter = scatterbase.ScatterBase.extend({
     update_marker: function(model, marker) {
         if (!this.model.dirty) {
             this.d3el.selectAll(".dot")
-                .transition()
+                .transition("update_marker")
                 .duration(this.parent.model.get("animation_duration"))
                 .attr("d", this.dot.type(marker));
             this.legend_el.select("path")
@@ -161,7 +161,7 @@ var Scatter = scatterbase.ScatterBase.extend({
             var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
             var that = this;
             this.d3el.selectAll(".dot")
-                .transition()
+                .transition("update_default_skew")
                 .duration(animation_duration)
                 .attr("d", this.dot.skew(function(d) {
                     return that.get_element_skew(d);
@@ -176,7 +176,7 @@ var Scatter = scatterbase.ScatterBase.extend({
             var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
             var that = this;
             this.d3el.selectAll(".dot")
-                .transition()
+                .transition("update_default_size")
                 .duration(animation_duration)
                 .attr("d", this.dot.size(function(d) {
                     return that.get_element_size(d);
@@ -194,7 +194,7 @@ var Scatter = scatterbase.ScatterBase.extend({
 
         this.d3el.selectAll(".object_grp").select("text")
             .text(function(d) { return d.name; })
-            .transition()
+            .transition("update_names")
             .duration(animation_duration)
             .attr("transform", function(d) {
                 var text_loc = Math.sqrt(that.get_element_size(d)) / 2.0;
@@ -212,7 +212,7 @@ var Scatter = scatterbase.ScatterBase.extend({
 
         this.d3el.selectAll(".object_grp")
           .select("path")
-          .transition()
+          .transition("color_scale_updated")
           .duration(animation_duration)
           .style("fill", fill ?
               function(d, i) {
@@ -231,7 +231,7 @@ var Scatter = scatterbase.ScatterBase.extend({
 
         elements_added.append("path").attr("class", "dot element");
         elements_added.append("text").attr("class", "dot_text");
-        elements.select("path").transition()
+        elements.select("path").transition("draw_elements")
             .duration(animation_duration)
             .attr("d", this.dot
                 .size(function(d) { return that.get_element_size(d); })
@@ -290,7 +290,7 @@ var Scatter = scatterbase.ScatterBase.extend({
         d3.select(dragged_node)
           .select("path")
           .classed("drag_scatter", true)
-          .transition()
+          .transition("set_drag_style")
           .attr("d", this.dot.size(5 * this.model.get("default_size")));
 
         var drag_color = this.model.get("drag_color");
@@ -309,7 +309,7 @@ var Scatter = scatterbase.ScatterBase.extend({
         d3.select(dragged_node)
           .select("path")
           .classed("drag_scatter", false)
-          .transition()
+          .transition("reset_drag_style")
           .attr("d", this.dot.size(this.get_element_size(d)));
 
         if (this.model.get("drag_color")) {

--- a/js/src/ScatterBase.js
+++ b/js/src/ScatterBase.js
@@ -265,7 +265,7 @@ var ScatterBase = mark.Mark.extend({
         var that = this;
         var animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
-        this.d3el.selectAll(".object_grp").transition()
+        this.d3el.selectAll(".object_grp").transition("update_position")
             .duration(animation_duration)
             .attr("transform", function(d) {
                 return "translate(" + (x_scale.scale(d.x) + x_scale.offset) +


### PR DESCRIPTION
Added a name to each transition. The convention I followed was to add the name of the  function which contains the transition. In this way, transitions started by other functions are not interrupted. Luckily, we do not have more than 1 transition on the same selection in the same function :)

Fixes #456.