### PR TITLE
remove marks and axis

### DIFF
--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -635,6 +635,12 @@ var Figure = widgets.DOMWidgetView.extend({
         this.title.text(this.model.get("title"));
     },
 
+    remove: function() {
+        Figure.__super__.remove.apply(this, arguments);
+        this.mark_views.remove()
+        this.axis_views.remove()
+    },
+
     save_png: function() {
 
         var  replaceAll = function (find, replace, str) {

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -636,9 +636,9 @@ var Figure = widgets.DOMWidgetView.extend({
     },
 
     remove: function() {
-        Figure.__super__.remove.apply(this, arguments);
         this.mark_views.remove()
         this.axis_views.remove()
+        return Figure.__super__.remove.apply(this, arguments);
     },
 
     save_png: function() {


### PR DESCRIPTION
I noticed the Mark's `remove` method was not called, this fixes that, and I think the same for axis. As discussed with @jasongrout 