### PR TITLE
pandas version dependency fix in DNA example

### DIFF
--- a/examples/Applications/Outlier Detection.ipynb
+++ b/examples/Applications/Outlier Detection.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -29,7 +29,7 @@
     "from bqplot import *\n",
     "from traitlets import List, Float, observe\n",
     "from ipywidgets import IntRangeSlider, Layout, VBox, HBox, jslink\n",
-    "from pandas.tseries.index import DatetimeIndex\n",
+    "from pandas import DatetimeIndex\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true
    },
@@ -177,13 +177,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "551a4008fb7b41f6b6adc4f482bbf39c"
+       "model_id": "fd367b960a774eb88cce57a9511398c9"
       }
      },
      "metadata": {},
@@ -204,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true,
     "scrolled": true
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {
     "collapsed": true
    },
@@ -259,13 +259,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e949d84a844e40eaa7f00b693baa2f9a"
+       "model_id": "317e91c8c8194b84bccc7f018891dc99"
       }
      },
      "metadata": {},
@@ -294,7 +294,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
`pandas.tseries.index` is only in pandas version `0.20.2`. Directly importing `DatetimeIndex` from `pandas` removes that explicit dependency.