### PR TITLE
Fix bqplot.Figure documentation typo

### DIFF
--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -18,8 +18,7 @@ r"""
 Figure
 ======
 
-.. currentmodule:: bqplot.figure::
-
+.. currentmodule:: bqplot.figure
 
 .. autosummary::
    :toctree: _generate/


### PR DESCRIPTION
At the request of @ssunkara1, this addresses an omission in the fix in #488.