### PR TITLE
Removing extra bars on redraw

### DIFF
--- a/js/src/Bars.js
+++ b/js/src/Bars.js
@@ -332,6 +332,8 @@ var Bars = mark.Mark.extend({
           .attr("width", 0)
           .attr("height", 0);
 
+        bars_sel.exit().remove();
+
         this.draw_bars(animate);
 
         this.apply_styles();


### PR DESCRIPTION
This fixes issue #508 
Extra bars (when the number of rows in `y` decreases) were not being removed in a redraw