### PR TITLE
model id rename bug fix

### DIFF
--- a/js/src/BarsModel.js
+++ b/js/src/BarsModel.js
@@ -159,9 +159,9 @@ var BarsModel = markmodel.MarkModel.extend({
         });
         if(color_scale && color.length > 0) {
                 if(!this.get("preserve_domain").color) {
-                    color_scale.compute_and_set_domain(color, this.id + "_color");
+                    color_scale.compute_and_set_domain(color, this.model_id + "_color");
                 } else {
-                    color_scale.del_domain([], this.id + "_color");
+                    color_scale.del_domain([], this.model_id + "_color");
                 }
         }
     },
@@ -178,17 +178,17 @@ var BarsModel = markmodel.MarkModel.extend({
         if(!this.get("preserve_domain").x) {
             dom_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                 return elem.key;
-            }), this.id + "_x");
+            }), this.model_id + "_x");
         }
         else {
-            dom_scale.del_domain([], this.id + "_x");
+            dom_scale.del_domain([], this.model_id + "_x");
         }
 
         if(!this.get("preserve_domain").y) {
             if(this.get("type") === "stacked") {
                 range_scale.compute_and_set_domain([d3.min(this.mark_data, function(c) { return c.neg_max; }),
                                                 d3.max(this.mark_data, function(c) { return c.pos_max; }), this.base_value],
-                                                this.id + "_y");
+                                                this.model_id + "_y");
             } else {
                 var min = d3.min(this.mark_data,
                     function(c) {
@@ -201,10 +201,10 @@ var BarsModel = markmodel.MarkModel.extend({
                         return val.y_ref;
                     });
                 });
-                range_scale.compute_and_set_domain([min, max, this.base_value], this.id + "_y");
+                range_scale.compute_and_set_domain([min, max, this.base_value], this.model_id + "_y");
             }
         } else {
-            range_scale.del_domain([], this.id + "_y");
+            range_scale.del_domain([], this.model_id + "_y");
         }
     }
 });

--- a/js/src/BoxplotModel.js
+++ b/js/src/BoxplotModel.js
@@ -56,10 +56,10 @@ var BoxplotModel = markmodel.MarkModel.extend({
         var x_data = this.get_typed_field("x");
         var y_data = this.get_typed_field("y");
 
-        y_data.forEach(function(elm) { 
-            elm.sort(function(a, b) { 
+        y_data.forEach(function(elm) {
+            elm.sort(function(a, b) {
                 return a - b;
-            }); 
+            });
         });
 
         if(x_data.length > y_data.length) {
@@ -87,9 +87,9 @@ var BoxplotModel = markmodel.MarkModel.extend({
         if(!this.get("preserve_domain").x && this.mark_data) {
             x_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                 return elem[0];
-            }), this.id + "_x");
+            }), this.model_id + "_x");
         } else {
-            x_scale.del_domain([], this.id + "_x");
+            x_scale.del_domain([], this.model_id + "_x");
         }
         if(!this.get("preserve_domain").y && this.mark_data) {
            //The values are sorted, so we are using that to calculate the min/max
@@ -102,10 +102,10 @@ var BoxplotModel = markmodel.MarkModel.extend({
                 return values[values.length-1];
             }));
 
-            y_scale.set_domain([min,max], this.id + "_y");
+            y_scale.set_domain([min,max], this.model_id + "_y");
 
         } else {
-            y_scale.del_domain([], this.id + "_y");
+            y_scale.del_domain([], this.model_id + "_y");
         }
     }
 });

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -276,7 +276,7 @@ var Figure = widgets.DOMWidgetView.extend({
         if(!scale_model.get("allow_padding")) {
             return this.range(direction);
         }
-        var scale_id = scale_model.id;
+        var scale_id = scale_model.model_id;
 
         if(direction==="x") {
             scale_padding = (this.x_padding_arr[scale_id] !== undefined) ?
@@ -303,7 +303,7 @@ var Figure = widgets.DOMWidgetView.extend({
         if(!(scale_model.get("allow_padding"))) {
             return this.plotarea_height;
         }
-        var scale_id = scale_model.id;
+        var scale_id = scale_model.model_id;
         var scale_padding = (this.y_padding_arr[scale_id] !== undefined) ?
             this.y_padding_arr[scale_id] : 0;
         return (this.plotarea_height) * (1 - this.figure_padding_y) - scale_padding - scale_padding;
@@ -314,7 +314,7 @@ var Figure = widgets.DOMWidgetView.extend({
             return this.plotarea_width;
         }
 
-        var scale_id = scale_model.id;
+        var scale_id = scale_model.model_id;
         var scale_padding = (this.x_padding_arr[scale_id] !== undefined) ?
             this.x_padding_arr[scale_id] : 0;
         return (this.plotarea_width) * (1 - this.figure_padding_x) - scale_padding - scale_padding;
@@ -337,9 +337,9 @@ var Figure = widgets.DOMWidgetView.extend({
         if(scale_model === undefined || scale_model === null) {
             return;
         }
-        var scale_id = scale_model.id;
+        var scale_id = scale_model.model_id;
         if(dict[scale_id] !== undefined) {
-            delete dict[scale_id][mark_view.model.id + "_" + mark_view.cid];
+            delete dict[scale_id][mark_view.model.model_id + "_" + mark_view.cid];
             if(Object.keys(dict[scale_id]).length === 0) {
                 delete dict[scale_id];
             }
@@ -347,11 +347,11 @@ var Figure = widgets.DOMWidgetView.extend({
     },
 
     update_padding_dict: function(dict, mark_view, scale_model, value) {
-        var scale_id = scale_model.id;
+        var scale_id = scale_model.model_id;
         if(!(dict[scale_id])) {
             dict[scale_id]= {};
         }
-        dict[scale_id][mark_view.model.id + "_" + mark_view.cid] = value;
+        dict[scale_id][mark_view.model.model_id + "_" + mark_view.cid] = value;
     },
 
     mark_scales_updated: function(view) {

--- a/js/src/GraphModel.js
+++ b/js/src/GraphModel.js
@@ -99,9 +99,9 @@ var GraphModel = markmodel.MarkModel.extend({
             if (color_scale) {
                 if (!this.get("preserve_domain").color) {
                     color_scale.compute_and_set_domain(color,
-                                                       this.id + "_color");
+                                                       this.model_id + "_color");
                 } else {
-                    color_scale.del_domain([], this.id + "_color");
+                    color_scale.del_domain([], this.model_id + "_color");
                 }
             }
 
@@ -166,9 +166,9 @@ var GraphModel = markmodel.MarkModel.extend({
                 if (!this.get("preserve_domain")[key]) {
                     scale.compute_and_set_domain(this.mark_data.map(function(d) {
                         return d[key] || d[data_scale_key_map[key]];
-                    }), this.id + key);
+                    }), this.model_id + key);
                 } else {
-                    scale.del_domain([], this.id + key);
+                    scale.del_domain([], this.model_id + key);
                 }
             }
        }

--- a/js/src/GridHeatMap.js
+++ b/js/src/GridHeatMap.js
@@ -447,7 +447,7 @@ var GridHeatMap = mark.Mark.extend({
             new_domain = this.expand_scale_domain(row_scale, this.model.rows, this.model.modes.row, (row_start_aligned));
             if(d3.min(new_domain) < d3.min(row_scale.model.domain) || d3.max(new_domain) > d3.max(row_scale.model.domain)) {
                 // Update domain if domain has changed
-                row_scale.model.compute_and_set_domain(new_domain, row_scale.model.id);
+                row_scale.model.compute_and_set_domain(new_domain, row_scale.model.model_id);
             }
         }
 
@@ -455,7 +455,7 @@ var GridHeatMap = mark.Mark.extend({
             new_domain = this.expand_scale_domain(column_scale, this.model.columns, this.model.modes.column, col_start_aligned);
             if(d3.min(new_domain) < d3.min(column_scale.model.domain) || d3.max(new_domain) > d3.max(column_scale.model.domain)) {
                 // Update domain if domain has changed
-                column_scale.model.compute_and_set_domain(new_domain, column_scale.model.id);
+                column_scale.model.compute_and_set_domain(new_domain, column_scale.model.model_id);
             }
         }
 

--- a/js/src/GridHeatMapModel.js
+++ b/js/src/GridHeatMapModel.js
@@ -96,23 +96,23 @@ var GridHeatMapModel = markmodel.MarkModel.extend({
         var color_scale = scales.color;
 
         if(!this.get("preserve_domain").row) {
-            y_scale.compute_and_set_domain(this.rows, this.id + "_row");
+            y_scale.compute_and_set_domain(this.rows, this.model_id + "_row");
         } else {
-            y_scale.del_domain([], this.id + "_row");
+            y_scale.del_domain([], this.model_id + "_row");
         }
 
         if(!this.get("preserve_domain").column) {
-            x_scale.compute_and_set_domain(this.columns, this.id + "_column");
+            x_scale.compute_and_set_domain(this.columns, this.model_id + "_column");
         } else {
-            x_scale.del_domain([], this.id + "_column");
+            x_scale.del_domain([], this.model_id + "_column");
         }
         if(color_scale !== null && color_scale !== undefined) {
             if(!this.get("preserve_domain").color) {
                 color_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                     return elem.color;
-                }), this.id + "_color");
+                }), this.model_id + "_color");
             } else {
-                color_scale.del_domain([], this.id + "_color");
+                color_scale.del_domain([], this.model_id + "_color");
             }
         }
     },

--- a/js/src/HandDraw.js
+++ b/js/src/HandDraw.js
@@ -48,9 +48,9 @@ var HandDraw = interaction.Interaction.extend({
         var that = this;
         return Promise.all(fig.mark_views.views).then(function(views) {
             var fig_mark_ids = fig.mark_views._models.map(function(mark_model) {
-                return mark_model.id; // Model ids of the marks in the figure
+                return mark_model.model_id; // Model ids of the marks in the figure
             });
-            var mark_index = fig_mark_ids.indexOf(lines_model.id);
+            var mark_index = fig_mark_ids.indexOf(lines_model.model_id);
             that.lines_view = views[mark_index];
         });
     },
@@ -164,7 +164,7 @@ var HandDraw = interaction.Interaction.extend({
             return idx-1;
         }
     },
-    
+
     update_line_index: function() {
         // Called when the line index is changed in the model
         this.line_index = this.model.get("line_index");

--- a/js/src/HeatMapModel.js
+++ b/js/src/HeatMapModel.js
@@ -67,21 +67,21 @@ var HeatMapModel = markmodel.MarkModel.extend({
         var flat_colors = [].concat.apply([], this.mark_data.color);
 
         if(!this.get("preserve_domain").x) {
-            x_scale.compute_and_set_domain(this.mark_data.x, this.id + "_x");
+            x_scale.compute_and_set_domain(this.mark_data.x, this.model_id + "_x");
         } else {
-            x_scale.del_domain([], this.id + "_x");
+            x_scale.del_domain([], this.model_id + "_x");
         }
 
         if(!this.get("preserve_domain").y) {
-            y_scale.compute_and_set_domain(this.mark_data.y, this.id + "_y");
+            y_scale.compute_and_set_domain(this.mark_data.y, this.model_id + "_y");
         } else {
-            y_scale.del_domain([], this.id + "_y");
+            y_scale.del_domain([], this.model_id + "_y");
         }
         if(color_scale !== null && color_scale !== undefined) {
             if(!this.get("preserve_domain").color) {
-                color_scale.compute_and_set_domain(flat_colors, this.id + "_color");
+                color_scale.compute_and_set_domain(flat_colors, this.model_id + "_color");
             } else {
-                color_scale.del_domain([], this.id + "_color");
+                color_scale.del_domain([], this.model_id + "_color");
             }
         }
     },

--- a/js/src/HistModel.js
+++ b/js/src/HistModel.js
@@ -60,9 +60,9 @@ var HistModel = markmodel.MarkModel.extend({
         // Draw, while update_data is generally followed by a Draw.
 
         if(!this.get("preserve_domain").sample) {
-            x_scale.compute_and_set_domain(x_data, this.id + "_sample");
+            x_scale.compute_and_set_domain(x_data, this.model_id + "_sample");
         } else {
-            x_scale.del_domain([], this.id + "_sample");
+            x_scale.del_domain([], this.model_id + "_sample");
         }
 
         this.min_x = x_scale.domain[0];
@@ -138,7 +138,7 @@ var HistModel = markmodel.MarkModel.extend({
         if(!this.get("preserve_domain").count) {
             y_scale.set_domain([0, d3.max(this.mark_data, function(d) {
                 return d.y;
-            }) * 1.05], this.id + "_count");
+            }) * 1.05], this.model_id + "_count");
         }
     },
 

--- a/js/src/LinesModel.js
+++ b/js/src/LinesModel.js
@@ -150,25 +150,25 @@ var LinesModel = markmodel.MarkModel.extend({
         if(!this.get("preserve_domain").x) {
             x_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                 return elem.values.map(function(d) { return d.x; });
-            }), this.id + "_x");
+            }), this.model_id + "_x");
         } else {
-            x_scale.del_domain([], this.id + "_x");
+            x_scale.del_domain([], this.model_id + "_x");
         }
 
         if(!this.get("preserve_domain").y) {
             y_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                 return elem.values.map(function(d) { return d.y; });
-            }), this.id + "_y");
+            }), this.model_id + "_y");
         } else {
-            y_scale.del_domain([], this.id + "_y");
+            y_scale.del_domain([], this.model_id + "_y");
         }
         if(color_scale !== null && color_scale !== undefined) {
             if(!this.get("preserve_domain").color) {
                 color_scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                     return elem.color;
-                }), this.id + "_color");
+                }), this.model_id + "_color");
             } else {
-                color_scale.del_domain([], this.id + "_color");
+                color_scale.del_domain([], this.model_id + "_color");
             }
         }
     },
@@ -262,15 +262,15 @@ var FlexLineModel = LinesModel.extend({
         var width_scale = scales.width;
 
         if(!this.get("preserve_domain").x) {
-            x_scale.compute_and_set_domain(this.x_data[0].slice(0, this.data_len), this.id + "_x");
+            x_scale.compute_and_set_domain(this.x_data[0].slice(0, this.data_len), this.model_id + "_x");
         } else {
-            x_scale.del_domain([], this.id + "_x");
+            x_scale.del_domain([], this.model_id + "_x");
         }
 
         if(!this.get("preserve_domain").y) {
-            y_scale.compute_and_set_domain(this.y_data[0].slice(0, this.data_len), this.id + "_y");
+            y_scale.compute_and_set_domain(this.y_data[0].slice(0, this.data_len), this.model_id + "_y");
         } else {
-            y_scale.del_domain([], this.id + "_y");
+            y_scale.del_domain([], this.model_id + "_y");
         }
 
         if(color_scale !== null && color_scale !== undefined) {
@@ -279,9 +279,9 @@ var FlexLineModel = LinesModel.extend({
                     return elem.values.map(function(d) {
                         return d.color;
                     });
-                }), this.id + "_color");
+                }), this.model_id + "_color");
             } else {
-                color_scale.del_domain([], this.id + "_color");
+                color_scale.del_domain([], this.model_id + "_color");
             }
         }
         if(width_scale !== null && width_scale !== undefined) {
@@ -290,9 +290,9 @@ var FlexLineModel = LinesModel.extend({
                     return elem.values.map(function(d) {
                         return d.size;
                     });
-                }), this.id + "_width");
+                }), this.model_id + "_width");
             } else {
-                width_scale.del_domain([], this.id + "_width");
+                width_scale.del_domain([], this.model_id + "_width");
             }
         }
     }

--- a/js/src/MapModel.js
+++ b/js/src/MapModel.js
@@ -95,9 +95,9 @@ var MapModel = markmodel.MarkModel.extend({
                 color_scale.compute_and_set_domain(
                     Object.keys(this.color_data).map(function (d) {
                         return that.color_data[d];
-                    }), this.id + "_color");
+                    }), this.model_id + "_color");
             } else {
-                color_scale.del_domain([], this.id + "_color");
+                color_scale.del_domain([], this.model_id + "_color");
             }
         }
     },

--- a/js/src/MarkModel.js
+++ b/js/src/MarkModel.js
@@ -85,7 +85,7 @@ var MarkModel = basemodel.BaseModel.extend({
         // disassociates the mark with the scale
         this.dirty = true;
         for (var key in scales) {
-            scales[key].del_domain([], this.id + "_" + key);
+            scales[key].del_domain([], this.model_id + "_" + key);
         }
         this.dirty = false;
         //TODO: Check if the views are being removed

--- a/js/src/MarketMap.js
+++ b/js/src/MarketMap.js
@@ -242,7 +242,7 @@ var MarketMap = figure.Figure.extend({
         var color_scale_model = this.model.get("scales").color;
         var color_data = this.model.get_typed_field("color");
         if(color_scale_model && color_data.length > 0) {
-            color_scale_model.compute_and_set_domain(color_data, this.model.id);
+            color_scale_model.compute_and_set_domain(color_data, this.model.model_id);
         }
     },
 

--- a/js/src/OHLCModel.js
+++ b/js/src/OHLCModel.js
@@ -160,10 +160,10 @@ var OHLCModel = markmodel.MarkModel.extend({
                     return d[0];
                 }));
                 if(max instanceof Date) max = max.getTime();
-                x_scale.set_domain([min - min_x_dist/2, max + min_x_dist/2], this.id + "_x");
+                x_scale.set_domain([min - min_x_dist/2, max + min_x_dist/2], this.model_id + "_x");
             }
         } else {
-            x_scale.del_domain([], this.id + "_x");
+            x_scale.del_domain([], this.model_id + "_x");
         }
 
         // Y Scale
@@ -183,9 +183,9 @@ var OHLCModel = markmodel.MarkModel.extend({
                 return (d[1][top] > d[1][bottom]) ? d[1][top] : d[1][bottom];
             }));
             if(max instanceof  Date) max = max.getTime();
-            y_scale.set_domain([min - max_y_height, max + max_y_height], this.id + "_y");
+            y_scale.set_domain([min - max_y_height, max + max_y_height], this.model_id + "_y");
         } else {
-            y_scale.del_domain([], this.id + "_y");
+            y_scale.del_domain([], this.model_id + "_y");
         }
     },
 

--- a/js/src/PieModel.js
+++ b/js/src/PieModel.js
@@ -102,9 +102,9 @@ var PieModel = markmodel.MarkModel.extend({
         var color_scale = this.get("scales").color;
         if(color_scale) {
             if(!this.get("preserve_domain").color) {
-                color_scale.compute_and_set_domain(color, this.id + "_color");
+                color_scale.compute_and_set_domain(color, this.model_id + "_color");
             } else {
-                color_scale.del_domain([], this.id + "_color");
+                color_scale.del_domain([], this.model_id + "_color");
             }
         }
     },
@@ -121,16 +121,16 @@ var PieModel = markmodel.MarkModel.extend({
             var x = (x_scale.type === "date") ?
                 this.get_date_elem("x") : this.get("x");
             if(!this.get("preserve_domain").x) {
-                x_scale.compute_and_set_domain([x], this.id + "_x");
+                x_scale.compute_and_set_domain([x], this.model_id + "_x");
             } else {
-                x_scale.del_domain([], this.id + "_x");
+                x_scale.del_domain([], this.model_id + "_x");
             }
         }
         if(y_scale) {
             if(!this.get("preserve_domain").y) {
-                y_scale.compute_and_set_domain([this.get("y")], this.id + "_y");
+                y_scale.compute_and_set_domain([this.get("y")], this.model_id + "_y");
             } else {
-                y_scale.del_domain([], this.id + "_y");
+                y_scale.del_domain([], this.model_id + "_y");
             }
         }
     },

--- a/js/src/ScatterBaseModel.js
+++ b/js/src/ScatterBaseModel.js
@@ -84,9 +84,9 @@ var ScatterBaseModel = markmodel.MarkModel.extend({
 
             if(color_scale) {
                 if(!this.get("preserve_domain").color) {
-                    color_scale.compute_and_set_domain(color, this.id + "_color");
+                    color_scale.compute_and_set_domain(color, this.model_id + "_color");
                 } else {
-                    color_scale.del_domain([], this.id + "_color");
+                    color_scale.del_domain([], this.model_id + "_color");
                 }
             }
 
@@ -133,9 +133,9 @@ var ScatterBaseModel = markmodel.MarkModel.extend({
                 if(!this.get("preserve_domain")[key]) {
                     scale.compute_and_set_domain(this.mark_data.map(function(elem) {
                         return elem[key];
-                    }), this.id + key);
+                    }), this.model_id + key);
                 } else {
-                    scale.del_domain([], this.id + key);
+                    scale.del_domain([], this.model_id + key);
                 }
             }
        }

--- a/js/src/Selector.js
+++ b/js/src/Selector.js
@@ -47,11 +47,11 @@ var BaseSelector = interaction.Interaction.extend({
         var fig = this.parent;
         var that = this;
         var mark_ids = this.model.get("marks").map(function(mark_model) {
-            return mark_model.id; // Model ids of the marks of the selector
+            return mark_model.model_id; // Model ids of the marks of the selector
         });
         return Promise.all(fig.mark_views.views).then(function(views) {
             var fig_mark_ids = fig.mark_views._models.map(function(mark_model) {
-                return mark_model.id;
+                return mark_model.model_id;
             });  // Model ids of the marks in the figure
             var mark_indices = mark_ids.map(function(mark_model_id) {
                 return fig_mark_ids.indexOf(mark_model_id); // look up based on model ids


### PR DESCRIPTION
@jasongrout  Because of a change in `ipywidgets' WidgeModel` (https://github.com/jupyter-widgets/ipywidgets/pull/1451) there was a bug in `bqplot` since we were relying on the `id` attribute of `WidgetModel`. This also fixes #517. Thanks @mpacer for reporting this.