### PR TITLE
clarify what date format is used for date based tick_formats

### DIFF
--- a/bqplot/axes.py
+++ b/bqplot/axes.py
@@ -78,7 +78,7 @@ class Axis(BaseAxis):
     label: string (default: '')
         The axis label
     tick_format: string or None (default: '')
-        The tick format for the axis.
+        The tick format for the axis, for dates use d3 string formatting.
     scale: Scale
         The scale represented by the axis
     num_ticks: int or None (default: None)


### PR DESCRIPTION
I had to dive into the js to figure out that it was expecting d3 based date-string formatting. This should be in the docstring. This might make sense in other places too… but I'm not sure the best way to search exhaustively for this kind of change.