### PR TITLE
Adding fill-between options in Lines

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -278,7 +278,7 @@ class Lines(Mark):
         of lines, the colors are reused.
     close_path: bool (default: False)
         Whether to close the paths or not.
-    fill: {'none', 'bottom', 'top', 'inside'}
+    fill: {'none', 'bottom', 'top', 'inside', 'between'}
         Fill in the area defined by the curves
     fill_colors: list of colors (default: [])
         Fill colors for the areas. Defaults to stroke-colors when no color provided.
@@ -358,7 +358,7 @@ class Lines(Mark):
                           'cardinal', 'cardinal-open', 'cardinal-closed', 'monotone', 'step-before', 'step-after'],
                          default_value='linear').tag(sync=True, display_name='Interpolation')
     close_path = Bool().tag(sync=True, display_name='Close path')
-    fill = Enum(['none', 'bottom', 'top', 'inside'], default_value='none').tag(sync=True, display_name='Fill')
+    fill = Enum(['none', 'bottom', 'top', 'inside', 'between'], default_value='none').tag(sync=True, display_name='Fill')
     marker = Enum(['circle', 'cross', 'diamond', 'square', 'triangle-down',
                    'triangle-up', 'arrow', 'rectangle', 'ellipse'],
                   default_value=None, allow_none=True).tag(sync=True,

--- a/js/src/LinesModel.js
+++ b/js/src/LinesModel.js
@@ -98,7 +98,7 @@ var LinesModel = markmodel.MarkModel.extend({
                 });
             } else {
                 this.mark_data = curve_labels.map(function(name, i) {
-                    var xy_data = d3.zip(that.x_data[i], that.y_data[i][j]);
+                    var xy_data = d3.zip(that.x_data[i], that.y_data[i]);
                     return {
                         name: name,
                         values: xy_data.map(function(d, j) {

--- a/js/src/LinesModel.js
+++ b/js/src/LinesModel.js
@@ -80,13 +80,16 @@ var LinesModel = markmodel.MarkModel.extend({
                 this.y_data : [this.y_data];
             curve_labels = this.get_labels();
 
-            if (this.x_data.length == 1 && this.y_data.length > 1) {
+            var y_length = this.y_data.length;
+
+            if (this.x_data.length == 1 && y_length > 1) {
                 // same x for all y
                 this.mark_data = curve_labels.map(function(name, i) {
                     return {
                         name: name,
                         values: that.y_data[i].map(function(d, j) {
                             return {x: that.x_data[0][j], y: d,
+                                    y0: that.y_data[Math.min(i + 1, y_length - 1)][j],
                                     sub_index: j};
                         }),
                         color: that.color_data[i],
@@ -95,11 +98,13 @@ var LinesModel = markmodel.MarkModel.extend({
                 });
             } else {
                 this.mark_data = curve_labels.map(function(name, i) {
-                    var xy_data = d3.zip(that.x_data[i], that.y_data[i]);
+                    var xy_data = d3.zip(that.x_data[i], that.y_data[i][j]);
                     return {
                         name: name,
                         values: xy_data.map(function(d, j) {
-                            return {x: d[0], y: d[1], sub_index: j};
+                            return {x: d[0], y: d[1],
+                                    y0: that.y_data[Math.min(i + 1, y_length - 1)][j],
+                                    sub_index: j};
                         }),
                         color: that.color_data[i],
                         index: i,


### PR DESCRIPTION
Adresses issue #523 

As it stands now, the last line will have a color that is different from the corresponding area (if there are n lines, there are only n-1 areas). A way around that is to set its opacity to 0, or to set the colors manually.
Any ideas on how to address this? Otherwise the PR is good to merge as is.