### PR TITLE
panzoom fix: register it

### DIFF
--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -38,7 +38,7 @@ Interacts
 
 from traitlets import Bool, Int, Float, Unicode, Dict, Instance, List, TraitError
 from traittypes import Array
-from ipywidgets import Widget, Color, widget_serialization
+from ipywidgets import Widget, Color, widget_serialization, register
 
 from .scales import Scale, DateScale
 from .traits import Date, array_serialization
@@ -131,6 +131,7 @@ class HandDraw(Interaction):
 
 
 @register_interaction('bqplot.PanZoom')
+@register
 class PanZoom(Interaction):
 
     """An interaction to pan and zoom wrt scales.


### PR DESCRIPTION
Panzoom wasn't working in jupyter lab. The problem was that PanZoomModel was created at the frontend but not registered at the frontend, hence:
```python
[IPKernelApp] ERROR | Exception opening comm with target: jupyter.widget
Traceback (most recent call last):
  File "/Users/maartenbreddels/miniconda3/envs/jupytercon7/lib/python3.6/site-packages/ipykernel/comm/manager.py", line 90, in comm_open
    f(comm, msg)
  File "/Users/maartenbreddels/miniconda3/envs/jupytercon7/lib/python3.6/site-packages/ipywidgets/widgets/widget.py", line 333, in handle_comm_opened
    state['_view_name'])
  File "/Users/maartenbreddels/miniconda3/envs/jupytercon7/lib/python3.6/site-packages/ipywidgets/widgets/widget.py", line 254, in get
    view_modules = model_names[model_name]
KeyError: 'PanZoomModel'
[IPKernelApp] WARNING | No such comm: d7d11d54fc9b011413a8c8c9a3c243e9
```
(this is only visible in the console)
That is worked in the notebook was actually a surprise.

PS: Some exceptions occured at the frontend, which did not show up in the notebook (can only see them at the websocket, and some of it at the console where jupyter notebook/lab is running), meaning that part isn't fixed yet @jasongrout 