### PR TITLE
new: Image mark

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -38,6 +38,7 @@ Marks
    Map
 """
 from warnings import warn
+import ipywidgets as widgets
 from ipywidgets import Widget, DOMWidget, CallbackDispatcher, Color, widget_serialization
 from traitlets import (
         Int, Unicode, List, Enum, Dict, Bool, Float, Instance, Tuple,
@@ -1411,3 +1412,17 @@ class Graph(Mark):
 
     _model_name = Unicode('GraphModel').tag(sync=True)
     _view_name = Unicode('Graph').tag(sync=True)
+
+@register_mark('bqplot.Image')
+class Image(Mark):
+    _view_name = Unicode('Image').tag(sync=True)
+    _model_name = Unicode('ImageModel').tag(sync=True)
+    image = Instance(widgets.Image).tag(sync=True, **widget_serialization)
+    x0 = (Float(0.0) | Date() | Unicode()).tag(sync=True)
+    y0 = (Float(0.0) | Date() | Unicode()).tag(sync=True)
+    x1 = (Float(1.0) | Date() | Unicode()).tag(sync=True)
+    y1 = (Float(1.0) | Date() | Unicode()).tag(sync=True)
+    scales_metadata = Dict({
+        'x': {'orientation': 'horizontal', 'dimension': 'x'},
+        'y': {'orientation': 'vertical', 'dimension': 'y'},
+    }).tag(sync=True)

--- a/js/src/Image.js
+++ b/js/src/Image.js
@@ -1,3 +1,18 @@
+/* Copyright 2015 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 var d3 = require("d3");
 var mark = require("./Mark");
 var utils = require("./utils");

--- a/js/src/Image.js
+++ b/js/src/Image.js
@@ -1,0 +1,97 @@
+var d3 = require("d3");
+var mark = require("./Mark");
+var utils = require("./utils");
+var _ = require("underscore");
+
+
+var Image = mark.Mark.extend({
+
+    render: function() {
+        var base_render_promise = Image.__super__.render.apply(this);
+        var el = this.d3el || this.el;
+        window.last_el = el;
+        window.last_image = this;
+        this.im = el.append("image")
+            .attr("x", 0)
+            .attr("y", 0)
+            .attr("width", 1)
+            .attr("height", 1)
+            .attr("preserveAspectRatio", "none")
+        this.update_image()
+
+        return base_render_promise.then(() => {
+            this.create_listeners();
+            this.draw();
+        });
+    },
+    
+    set_positional_scales: function() {
+        var x_scale = this.scales.x,
+            y_scale = this.scales.y;
+        this.listenTo(x_scale, "domain_changed", function() {
+            if (!this.model.dirty) {
+                this.set_ranges()
+             }
+        });
+        this.listenTo(y_scale, "domain_changed", function() {
+            if (!this.model.dirty) {
+                this.set_ranges()
+            }
+        });
+    },
+    
+    set_ranges: function() {
+            var x_scale = this.scales.x
+            var y_scale = this.scales.y
+            if(x_scale) {
+                x_scale.set_range(this.parent.padded_range("x", x_scale.model));
+            } else {
+                x_scale = this.parent.scale_x;
+            }
+            if(y_scale) {
+                y_scale.set_range(this.parent.padded_range("y", y_scale.model));
+            } else {
+                y_scale = this.parent.scale_y;
+            }
+            var that = this;
+            var animation_duration = this.parent.model.get("animation_duration");
+            var el = this.d3el || this.el;
+            el.selectAll("image").transition()
+                .duration(animation_duration)
+                .attr("transform", function(d) {
+                    var tx = x_scale.scale(that.model.get('x0')) + x_scale.offset
+                    var ty = y_scale.scale(that.model.get('y1')) + y_scale.offset
+                    var width  = x_scale.scale(that.model.get('x1')) - x_scale.scale(that.model.get('x0'))
+                    var height = y_scale.scale(that.model.get('y0')) - y_scale.scale(that.model.get('y1'))
+                    var sx = width
+                    var sy = height
+                    return "translate(" + tx + "," + ty + ") scale(" + sx + ", " + sy + ")"});
+    },
+    
+    create_listeners: function() {
+        Image.__super__.create_listeners.apply(this);
+        this.listenTo(this.model, "change:image", this.update_image, this);
+        this.listenTo(this.model, "change:x0 change:x1 change:y0 change:y1", this.set_ranges, this);
+    },
+    
+    update_image: function() {
+        if(this.im.attr('href'))
+            URL.revokeObjectURL(this.im.attr('href'));
+        var image = this.model.get('image')
+        var blob = new Blob([image.get('value')], {type: 'image/' + image.get('format')});
+        var url = URL.createObjectURL(blob);
+        this.im.attr("href", url)
+    },
+    
+    remove: function() {
+        URL.revokeObjectURL(this.im.attr('href'));
+        Image.__super__.remove.apply(this);
+    },
+    
+    draw: function() {
+    },
+});
+
+module.exports = {
+    Image: Image
+};

--- a/js/src/ImageModel.js
+++ b/js/src/ImageModel.js
@@ -37,7 +37,7 @@ var ImageModel = markmodel.MarkModel.extend({
 
     initialize: function() {
         ImageModel.__super__.initialize.apply(this, arguments);
-        this.on("change:x0 change:y0 change:x1 change:y1", this.update_data, this);
+        this.on_some_change(['x0', 'y0', 'x1', 'y1'], this.update_data, this);
         this.on_some_change(["preserve_domain"], this.update_domains, this);
         this.update_data();
     },

--- a/js/src/ImageModel.js
+++ b/js/src/ImageModel.js
@@ -1,0 +1,86 @@
+/* Copyright 2015 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var widgets = require("@jupyter-widgets/base");
+var d3 = require("d3");
+var _ = require("underscore");
+var markmodel = require("./MarkModel");
+
+var ImageModel = markmodel.MarkModel.extend({
+
+    defaults: function() {
+        return _.extend(markmodel.MarkModel.prototype.defaults(), {
+            _model_name: "ImageModel",
+            _view_name: "Image",
+            x0: 0.0,
+            y0: 0.0,
+            x1: 1.0,
+            y1: 1.0,
+            scales_metadata: {
+                'x': {'orientation': 'horizontal', 'dimension': 'x'},
+                'y': {'orientation': 'vertical', 'dimension': 'y'},
+            },
+        });
+    },
+
+    initialize: function() {
+        ImageModel.__super__.initialize.apply(this, arguments);
+        this.on("change:x0 change:y0 change:x1 change:y1", this.update_data, this);
+        this.on_some_change(["preserve_domain"], this.update_domains, this);
+        this.update_data();
+    },
+
+    update_data: function() {
+        this.update_domains();
+        this.trigger("data_updated");
+    },
+
+    update_domains: function() {
+        if(!this.mark_data) {
+            return;
+        }
+        var scales = this.get("scales");
+        var x_scale = scales.x;
+        var y_scale = scales.y;
+
+        if(x_scale) {
+            var x = (y_scale.type === "date") ?
+                [this.get_date_elem("x0"), this.get_date_elem("x1")] : [this.get("x0"), this.get("x1")];
+            if(!this.get("preserve_domain").x) {
+                x_scale.compute_and_set_domain(x, this.model_id + "_x");
+            } else {
+                x_scale.del_domain([], this.model_id + "_x");
+            }
+        }
+        if(y_scale) {
+            var y = (y_scale.type === "date") ?
+                [this.get_date_elem("y0"), this.get_date_elem("y1")] : [this.get("y0"), this.get("y1")];
+            if(!this.get("preserve_domain").y) {
+                y_scale.compute_and_set_domain(y, this.model_id + "_y");
+            } else {
+                y_scale.del_domain([], this.model_id + "_y");
+            }
+        }
+    },
+
+}, {
+    serializers: _.extend({
+        image: { deserialize: widgets.unpack_models },
+    }, markmodel.MarkModel.serializers)
+});
+
+module.exports = {
+    ImageModel: ImageModel
+};

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -87,7 +87,9 @@ var loadedModules = [
     require("./HeatMapModel"),
     require("./Toolbar"),
     require("./GraphModel"),
-    require("./Graph")
+    require("./Graph"),
+    require("./Image"),
+    require("./ImageModel")
 ];
 
 for (var i in loadedModules) {


### PR DESCRIPTION
Usage
```python
import bqplot
import ipywidgets as widgets

with open("sample.png", 'rb') as f:
    data = f.read()
image = widgets.Image(value=data)

scale_x = bqplot.LinearScale(min=-1, max=2)
scale_y = bqplot.LinearScale(min=-0.5, max=2)
image_mark = bqplot.Image(image=image, scales={'x': scale_x, 'y': scale_y})
fig = bqplot.Figure(padding_x=0, padding_y=0)
fig.marks = [image_mark]
fig.axes = [bqplot.Axis(scale=scale_x), bqplot.Axis(scale=scale_y, orientation='vertical')]
fig
```
It uses the widget.Image widget. Maybe it doesn't do all the things, like colorscales and all, but I think this makes a lot possible already.