### PR TITLE
adding missing attributes to scaled metadata

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -441,7 +441,8 @@ class _ScatterBase(Mark):
         'y': {'orientation': 'vertical', 'dimension': 'y'},
         'color': {'dimension': 'color'},
         'size': {'dimension': 'size'},
-        'opacity': {'dimension': 'opacity'}
+        'opacity': {'dimension': 'opacity'},
+        'rotation': {'dimension': 'rotation'}
     }).tag(sync=True)
     default_opacities = List(trait=Float(1.0, min=0, max=1, allow_none=True)).tag(sync=True, display_name='Opacities')
     hovered_style = Dict().tag(sync=True)
@@ -588,6 +589,16 @@ class Scatter(_ScatterBase):
     colors = List(trait=Color(default_value=None, allow_none=True),
                   default_value=['DeepSkyBlue']).tag(sync=True,
                   display_name='Colors')
+    scales_metadata = Dict({
+        'x': {'orientation': 'horizontal', 'dimension': 'x'},
+        'y': {'orientation': 'vertical', 'dimension': 'y'},
+        'color': {'dimension': 'color'},
+        'size': {'dimension': 'size'},
+        'opacity': {'dimension': 'opacity'},
+        'rotation': {'dimension': 'rotation'},
+        'skew': {'dimension': 'skew'}
+    }).tag(sync=True)
+
     @property
     def default_colors(self):
         return self.colors
@@ -1393,7 +1404,8 @@ class Graph(Mark):
                                              **array_serialization)\
         .valid(array_squeeze, array_dimension_bounds(1, 1))
 
-    link_color = Array([]).tag(sync=True, rtype='Number',
+    link_color = Array([]).tag(sync=True, rtype='Color',
+                               atype='bqplot.ColorAxis',
                                **array_serialization)\
         .valid(array_squeeze, array_dimension_bounds(1, 2))
 
@@ -1406,7 +1418,7 @@ class Graph(Mark):
         'x': {'orientation': 'horizontal', 'dimension': 'x'},
         'y': {'orientation': 'vertical', 'dimension': 'y'},
         'color': {'dimension': 'color'},
-        'link_color': {'dimension': 'color'},
+        'link_color': {'dimension': 'link_color'}
     }).tag(sync=True)
 
     _model_name = Unicode('GraphModel').tag(sync=True)


### PR DESCRIPTION
Fixes issue #544. @ChakriCherukuri can you have a look as I changed the `rtype` of `link_color` and also have a look if the scales for `link_color` and `color` should be the same by default or different.