### PR TITLE
Add functionality for specifying a filename when saving to PNG

### DIFF
--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -154,8 +154,11 @@ class Figure(DOMWidget):
     def _default_scale_y(self):
         return LinearScale(min=0, max=1, allow_padding=False)
 
-    def save_png(self):
-        self.send({"type": "save_png"})
+    def save_png(self, filename=None):
+        msg = {"type": "save_png"}
+        if filename:
+            msg["filename"] = filename
+        self.send(msg)
 
     @validate('min_aspect_ratio', 'max_aspect_ratio')
     def _validate_aspect_ratio(self, proposal):

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -223,8 +223,8 @@ var Figure = widgets.DOMWidgetView.extend({
     },
 
 	handle_custom_messages: function(msg) {
-        if (msg.type === 'save_png') {
-            this.save_png();
+      if (msg.type === 'save_png') {
+          this.save_png(msg.filename);
 	    }
 	},
 
@@ -672,7 +672,7 @@ var Figure = widgets.DOMWidgetView.extend({
         return Figure.__super__.remove.apply(this, arguments);
     },
 
-    save_png: function() {
+    save_png: function(filename) {
 
         var  replaceAll = function (find, replace, str) {
             return str.replace(new RegExp(find, "g"), replace);
@@ -752,7 +752,7 @@ var Figure = widgets.DOMWidgetView.extend({
                 var context = canvas.getContext("2d");
                 context.drawImage(image, 0, 0);
                 var a = document.createElement("a");
-                a.download = "image.png";
+                a.download = filename || "image.png";
                 a.href = canvas.toDataURL("image/png");
                 document.body.appendChild(a);
                 a.click();


### PR DESCRIPTION
It'd be nice to be able to specify what the filename is for saved PNGs.

Background: I made a figure that's affected by dropdowns, and I wanted to add a "save PNG" button that would save a file whose name is determined by the selected dropdown values.

This is somewhat related to #442 but lets the plot creator specify a filename rather than a path.