### PR TITLE
First pass at imshow

### DIFF
--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -705,7 +705,7 @@ def plot(*args, **kwargs):
         return _draw_mark(Lines, **kwargs)
 
 
-def imshow(image, format='widget', **kwargs):
+def imshow(image, format, **kwargs):
     """Draw an image in the current context figure.
     Parameters
     ----------

--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -51,12 +51,13 @@ import sys
 from collections import OrderedDict
 from IPython.display import display
 from ipywidgets import VBox
+from ipywidgets import Image as ipyImage
 from numpy import arange, issubdtype, array, column_stack, shape
 from .figure import Figure
 from .scales import Scale, LinearScale, Mercator
 from .axes import Axis
 from .marks import (
-        Lines, Scatter, Hist, Bars, OHLC, Pie, Map,
+        Lines, Scatter, Hist, Bars, OHLC, Pie, Map, Image,
         Label, HeatMap, GridHeatMap, topo_load, Boxplot
     )
 from .toolbar import Toolbar
@@ -702,6 +703,43 @@ def plot(*args, **kwargs):
             return _draw_mark(Lines, **kwargs)
     else:
         return _draw_mark(Lines, **kwargs)
+
+
+def imshow(image, format='ipyimage', **kwargs):
+    """Draw an image in the current context figure.
+    Parameters
+    ----------
+    image: image data 
+        Image data, depending on the passed format, can be one of:
+            - an instance of an ipywidgets Image
+            - a file name
+            - an raw byte string
+    format: {'ipyimage', 'filename', 'raw'}
+        type of the input argument
+    options: dict (default: {})
+        Options for the scales to be created. If a scale labeled 'x' is
+        required for that mark, options['x'] contains optional keyword
+        arguments for the constructor of the corresponding scale type.
+    axes_options: dict (default: {})
+        Options for the axes to be created. If an axis labeled 'x' is required
+        for that mark, axes_options['x'] contains optional keyword arguments
+        for the constructor of the corresponding axis type.
+    """
+    if format == 'ipyimage':
+        ipyimage = image
+    elif format == 'filename':
+        with open(image, 'rb') as f:
+            data = f.read()
+            ipyimage = ipyImage(value=data)
+    elif format == 'raw':
+        ipyimage = ipyImage(value=image)
+    kwargs['image'] = ipyimage
+
+    kwargs.setdefault('x', [0., 1.])
+    kwargs.setdefault('y', [0., 1.])
+
+    return _draw_mark(Image, **kwargs)
+
 
 def ohlc(*args, **kwargs):
     """Draw OHLC bars or candle bars in the current context figure.

--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -714,7 +714,7 @@ def imshow(image, format='ipyimage', **kwargs):
             - an instance of an ipywidgets Image
             - a file name
             - an raw byte string
-    format: {'ipyimage', 'filename', 'raw'}
+    format: {'ipyimage', 'filename', 'bytestring'}
         type of the input argument
     options: dict (default: {})
         Options for the scales to be created. If a scale labeled 'x' is
@@ -731,8 +731,13 @@ def imshow(image, format='ipyimage', **kwargs):
         with open(image, 'rb') as f:
             data = f.read()
             ipyimage = ipyImage(value=data)
-    elif format == 'raw':
+    elif format == 'bytestring':
         ipyimage = ipyImage(value=image)
+    else:
+        raise ValueError(
+            '''`format` must be one of {}, but a value of '{}'
+            was specified'''.format(['ipyimage', 'filename', 'bytestring'], format)
+            )
     kwargs['image'] = ipyimage
 
     kwargs.setdefault('x', [0., 1.])

--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -705,7 +705,7 @@ def plot(*args, **kwargs):
         return _draw_mark(Lines, **kwargs)
 
 
-def imshow(image, format='ipyimage', **kwargs):
+def imshow(image, format='widget', **kwargs):
     """Draw an image in the current context figure.
     Parameters
     ----------
@@ -714,8 +714,10 @@ def imshow(image, format='ipyimage', **kwargs):
             - an instance of an ipywidgets Image
             - a file name
             - an raw byte string
-    format: {'ipyimage', 'filename', 'bytestring'}
-        type of the input argument
+    format: {'widget', 'filename', ...}
+        Type of the input argument.
+        If not 'widget' or 'filename', must be a format supported by the 
+        ipywidgets Image.
     options: dict (default: {})
         Options for the scales to be created. If a scale labeled 'x' is
         required for that mark, options['x'] contains optional keyword
@@ -725,19 +727,14 @@ def imshow(image, format='ipyimage', **kwargs):
         for that mark, axes_options['x'] contains optional keyword arguments
         for the constructor of the corresponding axis type.
     """
-    if format == 'ipyimage':
+    if format == 'widget':
         ipyimage = image
     elif format == 'filename':
         with open(image, 'rb') as f:
             data = f.read()
             ipyimage = ipyImage(value=data)
-    elif format == 'bytestring':
-        ipyimage = ipyImage(value=image)
     else:
-        raise ValueError(
-            '''`format` must be one of {}, but a value of '{}'
-            was specified'''.format(['ipyimage', 'filename', 'bytestring'], format)
-            )
+        ipyimage = ipyImage(value=image, format=format)
     kwargs['image'] = ipyimage
 
     kwargs.setdefault('x', [0., 1.])


### PR DESCRIPTION
@SylvainCorlay @maartenbreddels 
Takes either an `ipywidgets` `Image` (default), a file name, or a byte string:
```python
import bqplot.pyplot as plt
from ipywidgets import Image

with open('sample.png', 'rb') as f:
    image = Image(value=f.read())
plt.figure()
plt.imshow(image)
plt.show()
```
or
```python
plt.imshow('sample.png', format='filename')
```
or
```python
with open('sample.png', 'rb') as f:
    plt.imshow(f.read(), format='openfile')
```

What do you think should be the default?

The matplotlib `imshow` takes a matrix as input so ideally we should support that too, although it would very close to what our `heatmap` does. 