### PR TITLE
Defaults fixes

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -513,7 +513,7 @@ class Scatter(_ScatterBase):
     marker: {'circle', 'cross', 'diamond', 'square', 'triangle-down',
              'triangle-up', 'arrow', 'rectangle', 'ellipse'}
         Marker shape
-    colors: list of colors (default: ['DeepSkyBlue'])
+    colors: list of colors (default: ['steelblue'])
         List of colors of the markers. If the list is shorter than the number
         of points, the colors are reused.
     default_colors: Deprecated
@@ -598,7 +598,7 @@ class Scatter(_ScatterBase):
                    'triangle-up', 'arrow', 'rectangle', 'ellipse'],
                   default_value='circle').tag(sync=True, display_name='Marker')
     colors = List(trait=Color(default_value=None, allow_none=True),
-                  default_value=['DeepSkyBlue']).tag(sync=True,
+                  default_value=['steelblue']).tag(sync=True,
                   display_name='Colors')
     scales_metadata = Dict({
         'x': {'orientation': 'horizontal', 'dimension': 'x'},
@@ -824,7 +824,7 @@ class Boxplot(Mark):
     }).tag(sync=True)
 
     stroke = Color(None, allow_none=True).tag(sync=True, display_name='Stroke color')
-    box_fill_color = Color('dodgerblue', sync=True, display_name='Fill color for the box')
+    box_fill_color = Color('steelblue', sync=True, display_name='Fill color for the box')
     outlier_fill_color = Color('gray').tag(sync=True, display_name='Outlier fill color')
     opacities = List(trait=Float(1.0, min=0, max=1, allow_none=True)).tag(sync=True, display_name='Opacities')
     box_width = Int(30, min=5).tag(sync=True, display_name='Box Width')
@@ -858,7 +858,7 @@ class Bars(Mark):
         Y respectively.
     type: {'stacked', 'grouped'}
         whether 2-dimensional bar charts should appear grouped or stacked.
-    colors: list of colors (default: CATEGORY10)
+    colors: list of colors (default: ['steelblue'])
         list of colors for the bars.
     orientation: {'horizontal', 'vertical'}
         Specifies whether the bar chart is drawn horizontally or vertically.
@@ -911,7 +911,7 @@ class Bars(Mark):
     color_mode = Enum(['auto', 'group', 'element'], default_value='auto').tag(sync=True)
     type = Enum(['stacked', 'grouped'], default_value='stacked').tag(sync=True,
                 display_name='Type')
-    colors = List(trait=Color(default_value=None, allow_none=True), default_value=CATEGORY10).tag(sync=True, display_name='Colors')
+    colors = List(trait=Color(default_value=None, allow_none=True), default_value=['steelblue']).tag(sync=True, display_name='Colors')
     padding = Float(0.05).tag(sync=True)
     stroke = Color(None, allow_none=True).tag(sync=True)
     base = Float().tag(sync=True)
@@ -994,7 +994,7 @@ class OHLC(Mark):
     stroke = Color(None, display_name='Stroke color', allow_none=True).tag(sync=True)
     stroke_width = Float(1.0).tag(sync=True, display_name='Stroke Width')
     colors = List(trait=Color(default_value=None, allow_none=True),
-                  default_value=['limegreen', 'red']).tag(sync=True, display_name='Colors')
+                  default_value=['green', 'red']).tag(sync=True, display_name='Colors')
     opacities = List(trait=Float(1.0, min=0, max=1, allow_none=True)).tag(sync=True, display_name='Opacities')
     format = Unicode('ohlc').tag(sync=True, display_name='Format')
 

--- a/examples/Marks/Bars.ipynb
+++ b/examples/Marks/Bars.ipynb
@@ -56,7 +56,7 @@
     "x_ord = OrdinalScale()\n",
     "y_sc = LinearScale()\n",
     "\n",
-    "bar = Bars(x=np.arange(5), y=np.arange(2, 6), scales={'x': x_ord, 'y': y_sc})\n",
+    "bar = Bars(x=np.arange(10), y=np.random.rand(10), scales={'x': x_ord, 'y': y_sc})\n",
     "ax_x = Axis(scale=x_ord)\n",
     "ax_y = Axis(scale=y_sc, tick_format='0.2f', orientation='vertical')\n",
     "\n",

--- a/examples/Marks/Bars.ipynb
+++ b/examples/Marks/Bars.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -13,7 +17,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "size = 100\n",
@@ -27,7 +35,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Basic Bar Chart"
    ]
@@ -35,7 +46,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "x_ord = OrdinalScale()\n",
@@ -43,37 +58,47 @@
     "\n",
     "bar = Bars(x=np.arange(5), y=np.arange(2, 6), scales={'x': x_ord, 'y': y_sc})\n",
     "ax_x = Axis(scale=x_ord)\n",
-    "ax_y = Axis(scale=y_sc, tick_format='0.2f', orientation=\"vertical\")\n",
+    "ax_y = Axis(scale=y_sc, tick_format='0.2f', orientation='vertical')\n",
     "\n",
     "Figure(marks=[bar], axes=[ax_x, ax_y], padding_x=0.025, padding_y=0.025)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Horizontal Bar Chart"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
-    "To generate a horizontal bar chart, pass `orientation=\"horizontal\"` to the bar."
+    "To generate a horizontal bar chart, pass `orientation='horizontal'` to the bar."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "x_ord = OrdinalScale()\n",
     "y_sc = LinearScale()\n",
     "\n",
     "bar = Bars(x=np.arange(10), y=np.arange(-5, 5), scales={'x': x_ord, 'y': y_sc},\n",
-    "           orientation=\"horizontal\")\n",
-    "ax_x = Axis(scale=x_ord, orientation=\"vertical\")\n",
+    "           orientation='horizontal')\n",
+    "ax_x = Axis(scale=x_ord, orientation='vertical')\n",
     "ax_y = Axis(scale=y_sc, tick_format='0.2f')\n",
     "\n",
     "Figure(marks=[bar], axes=[ax_x, ax_y], padding_x=0.025, padding_y=0.025)"
@@ -81,7 +106,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Changing the reference value from which the Bars are drawn"
    ]
@@ -89,7 +117,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "x_ord = LinearScale()\n",
@@ -106,7 +138,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -117,7 +151,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "bar.align = 'right'"
@@ -125,7 +163,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Bar Chart Properties"
    ]
@@ -133,7 +174,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "# Increasing the spacing between the bars\n",
@@ -151,7 +196,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -164,18 +211,23 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
-    "bar.orientation = \"horizontal\"\n",
-    "ax_x.orientation = \"vertical\"\n",
-    "ax_y.orientation = \"horizontal\""
+    "bar.orientation = 'horizontal'\n",
+    "ax_x.orientation = 'vertical'\n",
+    "ax_y.orientation = 'horizontal'"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Stacked Bar Chart for 2-d data"
    ]
@@ -183,14 +235,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "x_ord = OrdinalScale()\n",
     "y_sc = LinearScale()\n",
     "\n",
     "bar = Bars(x=x_data, y=[y_data[:20], y_data_2[:20]], \n",
-    "           scales={'x': x_ord, 'y': y_sc}, padding=0.2)\n",
+    "           scales={'x': x_ord, 'y': y_sc}, padding=0.2,\n",
+    "           colors=CATEGORY10)\n",
     "ax_x = Axis(scale=x_ord)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
@@ -199,7 +256,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Grouped Bar Chart"
    ]
@@ -208,7 +268,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -219,14 +281,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "x_ord = OrdinalScale()\n",
     "y_sc = LinearScale()\n",
     "\n",
     "bar = Bars(x=x_data, y=[y_data[:20], y_data_2[:20]], \n",
-    "           scales={'x': x_ord, 'y': y_sc}, padding=0.2, type='stacked', orientation='horizontal')\n",
+    "           scales={'x': x_ord, 'y': y_sc}, padding=0.2, \n",
+    "           colors=CATEGORY10, type='stacked', orientation='horizontal')\n",
     "ax_x = Axis(scale=x_ord, orientation='vertical')\n",
     "ax_y = Axis(scale=y_sc, tick_format='0.2f')\n",
     "\n",
@@ -237,7 +304,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -246,7 +315,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Modifying color mode"
    ]
@@ -254,7 +326,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "## Color mode has 2 values. 'group' and 'element'. \n",
@@ -264,7 +340,8 @@
     "y_sc = LinearScale()\n",
     "\n",
     "bar = Bars(x=x_data, y=[y_data[:20], y_data_2[:20]],\n",
-    "           scales={'x': x_ord, 'y': y_sc}, padding=0.2, color_mode='group')\n",
+    "           scales={'x': x_ord, 'y': y_sc}, padding=0.2, \n",
+    "           colors=CATEGORY10, color_mode='group')\n",
     "ax_x = Axis(scale=x_ord)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
@@ -274,15 +351,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "## for 1-d array for Y.\n",
     "x_ord = OrdinalScale()\n",
     "y_sc = LinearScale()\n",
     "\n",
-    "bar = Bars(x=x_data, y=y_data[:20], scales={'x': x_ord, 'y': y_sc}, padding=0.2, \n",
-    "           color_mode='element', labels=['Bar Chart'], \n",
+    "bar = Bars(x=x_data, y=y_data[:20], scales={'x': x_ord, 'y': y_sc}, padding=0.2,\n",
+    "           color_mode='element', labels=['Values'], \n",
     "           display_legend=True)\n",
     "ax_x = Axis(scale=x_ord)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
@@ -293,7 +374,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "source": [
     "## Representing additional dimension using Color"
@@ -302,7 +385,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "# In this example, the color is just the magnitude of the y data\n",
@@ -323,7 +410,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Adding color for 2-d data"
    ]
@@ -331,7 +421,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "# By default color is applied along the axis=1\n",
@@ -356,7 +450,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "# Applying color along the axis=0\n",
@@ -372,29 +470,11 @@
     "           padding=0.2, color_mode='group', stroke='orange')\n",
     "ax_x = Axis(scale=x_ord)\n",
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
-    "ax_c = ColorAxis(scale=col_sc, tick_format='0.2f')\n",
+    "ax_c = ColorAxis(scale=col_sc, tick_format='0.1f')\n",
     "\n",
     "margin = dict(top=50, bottom=80, left=50, right=50)\n",
     "Figure(marks=[bar], axes=[ax_x, ax_y, ax_c], fig_margin=margin)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -414,7 +494,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/Marks/Scatter.ipynb
+++ b/examples/Marks/Scatter.ipynb
@@ -4,6 +4,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "input_collapsed": false
    },
    "outputs": [],
@@ -20,7 +23,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Get Data"
    ]
@@ -28,7 +34,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "price_data = pd.DataFrame(np.cumsum(np.random.randn(150, 2).dot([[1.0, -0.8], [-0.8, 1.0]]), axis=0) + 100,\n",
@@ -45,6 +55,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "input_collapsed": false
    },
    "outputs": [],
@@ -62,7 +75,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Basic Scatter"
    ]
@@ -70,22 +86,29 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "sc_x = DateScale()\n",
     "sc_y = LinearScale()\n",
     "\n",
-    "scatt = Scatter(x=dates_all, y=sec2_levels, scales={'x': sc_x, 'y': sc_y}, colors=['dodgerblue'])\n",
+    "scatt = Scatter(x=dates_all, y=sec2_levels, scales={'x': sc_x, 'y': sc_y})\n",
     "ax_x = Axis(scale=sc_x, label='Date')\n",
-    "ax_y = Axis(scale=sc_y, orientation='vertical', tick_format='0.2f', label='Security 2')\n",
+    "ax_y = Axis(scale=sc_y, orientation='vertical', tick_format='0.0f', label='Security 2')\n",
     "\n",
     "Figure(marks=[scatt], axes=[ax_x, ax_y])"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Changing the marker and adding text to each point of the scatter"
    ]
@@ -93,7 +116,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "# Changing the marker as \n",
@@ -110,7 +137,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Changing the opacity of each marker"
    ]
@@ -119,7 +149,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -128,7 +160,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Representing additional dimensions of data"
    ]
@@ -136,6 +171,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "input_collapsed": false
    },
    "source": [
@@ -146,6 +183,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "input_collapsed": false
    },
    "outputs": [],
@@ -173,7 +213,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "## Changing the default color. \n",
@@ -183,7 +227,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "## setting the fill to be empty\n",
@@ -194,7 +242,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "## Setting the fill back\n",
@@ -205,7 +257,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "## Changing the color to a different variable\n",
@@ -218,7 +274,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -228,7 +286,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Date Scale for Color Data"
    ]
@@ -236,7 +297,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "sc_x = LinearScale()\n",
@@ -250,7 +315,7 @@
     "ax_y = Axis(label='Security 1 Level', scale=sc_y, orientation='vertical', side='left')\n",
     "\n",
     "ax_x = Axis(label='Security 2', scale=sc_x)\n",
-    "ax_c = ColorAxis(scale=sc_c1, label='Date', num_ticks=10)\n",
+    "ax_c = ColorAxis(scale=sc_c1, label='Date', num_ticks=5)\n",
     "\n",
     "m_chart = dict(top=50, bottom=80, left=50, right=50)\n",
     "Figure(axes=[ax_x, ax_c, ax_y], marks=[scatter], fig_margin=m_chart)"
@@ -259,6 +324,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "input_collapsed": false
    },
    "source": [
@@ -269,6 +336,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "input_collapsed": false
    },
    "outputs": [],
@@ -287,7 +357,7 @@
     "                   legend='__no_legend__',\n",
     "                   stroke='black')\n",
     "\n",
-    "ax_y = Axis(label='Security 1 Returns', scale=sc_y, orientation='vertical', tick_format='.2%')\n",
+    "ax_y = Axis(label='Security 1 Returns', scale=sc_y, orientation='vertical', tick_format='.0%')\n",
     "\n",
     "ax_x = Axis(label='Security 2', scale=sc_x, label_location='end')\n",
     "ax_c = ColorAxis(scale=c_ord, label='Class', side='right', orientation='vertical')\n",
@@ -299,16 +369,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
-    "ax_c.tick_format = \"0.2f\"\n",
+    "ax_c.tick_format = '0.2f'\n",
     "c_ord.colors = ['blue', 'red', 'green', 'yellow', 'orange']"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "input_collapsed": false
    },
    "source": [
@@ -319,6 +395,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "input_collapsed": false
    },
    "outputs": [],
@@ -344,7 +423,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "## Changing the opacity of the scatter\n",
@@ -354,7 +437,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "## Resetting the size for the scatter\n",
@@ -365,7 +452,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -377,7 +466,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -386,7 +477,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Changing the skew of the marker"
    ]
@@ -394,7 +488,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "sc_x = LinearScale()\n",
@@ -417,7 +515,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -428,7 +528,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -437,7 +539,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Rotation scale"
    ]
@@ -445,7 +550,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "sc_x = LinearScale()\n",
@@ -469,7 +578,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -478,14 +589,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Scatter Chart Interactions"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Moving points in Scatter"
    ]
@@ -493,7 +610,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "## Enabling moving of points in scatter. Try to click and drag any of the points in the scatter and \n",
@@ -524,7 +645,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "latex_widget = Label(color='Green', font_size='16px')\n",
@@ -539,7 +664,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -550,7 +677,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -561,7 +690,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -572,7 +703,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -582,7 +715,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Adding points to Scatter"
    ]
@@ -591,7 +727,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -603,7 +741,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Updating X and Y while moving the point"
    ]
@@ -612,7 +753,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -625,7 +768,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Custom event on end of drag"
    ]
@@ -633,7 +779,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "## Whenever drag is ended, there is a custom event dispatched which can be listened to.\n",
@@ -647,7 +797,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "source": [
     "## Adding tooltip and custom hover style"
@@ -656,7 +808,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "x_sc = LinearScale()\n",
@@ -679,7 +835,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -691,22 +849,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
     "## changing the fields displayed in the tooltip\n",
     "def_tt.fields = ['y']"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -726,7 +877,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. Made default color in bar chart same for all bars (steelblue). Currently bar chart defaults to different colors for each bar which is confusing.
2. Consolidated default colors across marks to have same color (steelblue)
3. Cleaned up Scatter and Bars example notebooks

PS: Chose 'steelblue' as default color since it's similar to the first color of CATEGORY10 and also similar to matplotlib's default color.