### PR TITLE
Set pointer-events to inherit in plot area for use of figures as tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ _templates/
 
 # Compiled javascript
 bqplot/static/
+js/css/bqplot.css
 
 # Node modules
 node_modules

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -127,7 +127,7 @@ var Figure = widgets.DOMWidgetView.extend({
           .attr("width", this.plotarea_width)
           .attr("height", this.plotarea_height)
           .on("click", function() { that.trigger("bg_clicked"); })
-          .style("pointer-events", "all")
+          .style("pointer-events", "inherit")
           .style(this.model.get("background_style"));
 
         this.fig_axes = this.fig.append("g");


### PR DESCRIPTION
This was causing the figure tooltips to flicker when the plot area found itself over the mouse position.