### PR TITLE
Fixup numpy depreation warning on np.float as second argument to issubdtype

### DIFF
--- a/bqplot/traits.py
+++ b/bqplot/traits.py
@@ -134,7 +134,7 @@ def array_from_json(value, obj=None):
 
 def array_to_json(a, obj=None):
     if a is not None:
-        if np.issubdtype(a.dtype, np.float):
+        if np.issubdtype(a.dtype, np.floating):
             # replace nan with None
             dtype = 'float'
             a = np.where(np.isnan(a), None, a)


### PR DESCRIPTION
This fixes some of the future warnings with numpy `1.14.0`.