### PR TITLE
(WIP) Enable 'y' selection for BrushIntervalSelector

### DIFF
--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -36,7 +36,7 @@ Interacts
    TwoDSelector
 """
 
-from traitlets import Bool, Int, Float, Unicode, Dict, Instance, List, TraitError
+from traitlets import Bool, Int, Float, Unicode, Dict, Instance, List, TraitError, Enum
 from traittypes import Array
 from ipywidgets import Widget, Color, widget_serialization, register
 
@@ -336,11 +336,14 @@ class BrushIntervalSelector(OneDSelector):
         This attribute can be used to trigger computationally intensive code
         which should be run only on the interval selection being completed as
         opposed to code which should be run whenever selected is changing.
+    orientation: {'horizontal', 'vertical'}
+        The orientation of the interval, either vertical or horizontal
     color: Color or None (default: None)
         Color of the rectangle representing the brush selector.
     """
     brushing = Bool().tag(sync=True)
     selected = Array(None, allow_none=True).tag(sync=True, **array_serialization)
+    orientation = Enum(['horizontal', 'vertical'], default_value='horizontal').tag(sync=True)
     color = Color(None, allow_none=True).tag(sync=True)
 
     _view_name = Unicode('BrushIntervalSelector').tag(sync=True)

--- a/js/src/Lines.js
+++ b/js/src/Lines.js
@@ -260,19 +260,23 @@ var Lines = mark.Mark.extend({
         this.update_line_xy();
     },
 
-    invert_range: function(start_pxl, end_pxl) {
+    invert_range: function(start_pxl, end_pxl, orientation) {
         if(start_pxl === undefined || end_pxl === undefined) {
             this.model.set("selected", null);
             this.touch();
             return [];
         }
-        var x_scale = this.scales.x;
-
-        var indices = _.range(this.x_pixels.length);
+        var pixels = (orientation == "y") ? this.y_pixels : this.x_pixels;
+        var indices = _.range(pixels.length);
         var that = this;
         var selected = _.filter(indices, function(index) {
-            var elem = that.x_pixels[index];
-            return (elem >= start_pxl && elem <= end_pxl);
+            var elem = pixels[index];
+            if (orientation == "x") {
+                return (elem >= start_pxl && elem <= end_pxl);
+            } else {
+                return (elem <= start_pxl && elem >= end_pxl)
+            }
+            
         });
         this.model.set("selected", selected);
         this.touch();
@@ -522,6 +526,9 @@ var Lines = mark.Mark.extend({
         this.x_pixels = (this.model.mark_data.length > 0) ? this.model.mark_data[0].values.map(function(el)
                                                                     { return x_scale.scale(el.x) + x_scale.offset; })
                                                           : [];
+        this.y_pixels = (this.model.mark_data.length > 0) ? this.model.mark_data[0].values.map(function(el)
+                                                                    { return y_scale.scale(el.y) + y_scale.offset; })
+                                                          : [];                                                  
     },
 
     draw: function(animate) {

--- a/js/src/Selector.js
+++ b/js/src/Selector.js
@@ -99,14 +99,16 @@ var BaseXSelector = BaseSelector.extend({
     update_scale_domain: function() {
         // When the domain of the scale is updated, the domain of the scale
         // for the selector must be expanded to account for the padding.
-        var initial_range = this.parent.padded_range("x", this.scale.model);
-        var target_range = this.parent.range("x");
+        var xy = (this.model.get("orientation") == "vertical") ? "y" : "x"
+        var initial_range = this.parent.padded_range(xy, this.scale.model);
+        var target_range = this.parent.range(xy);
         this.scale.expand_domain(initial_range, target_range);
     },
 
     set_range: function(array) {
+        var xy = (this.model.get("orientation") == "vertical") ? "y" : "x"
         for(var iter = 0; iter < array.length; iter++) {
-            array[iter].set_range(this.parent.range("x"));
+            array[iter].set_range(this.parent.range(xy));
         }
     },
 });

--- a/js/src/SelectorModel.js
+++ b/js/src/SelectorModel.js
@@ -100,7 +100,8 @@ var BrushIntervalSelectorModel = OneDSelectorModel.extend({
             _view_name: "BrushIntervalSelector",
             brushing: false,
             selected: [],
-            color: null
+            color: null,
+            orientation: "horizontal"
         });
     }
 });


### PR DESCRIPTION
`BrushIntervalSelector` can be used vertically, by setting its `orientation` attribute to 'vertical'

Addresses issue #616