### PR TITLE
new: Image mark has pixelated trait, to avoid interpolation

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -1566,6 +1566,7 @@ class Image(Mark):
     _view_name = Unicode('Image').tag(sync=True)
     _model_name = Unicode('ImageModel').tag(sync=True)
     image = Instance(widgets.Image).tag(sync=True, **widget_serialization)
+    pixelated = Bool(True).tag(sync=True)
     x = Array(default_value=(0, 1)).tag(sync=True, scaled=True,
                                         rtype='Number',
                                         atype='bqplot.Axis',

--- a/js/src/Image.js
+++ b/js/src/Image.js
@@ -31,7 +31,8 @@ var Image = mark.Mark.extend({
             .attr("y", 0)
             .attr("width", 1)
             .attr("height", 1)
-            .attr("preserveAspectRatio", "none");
+            .attr("preserveAspectRatio", "none")
+            .classed("image_pixelated", this.model.get('pixelated'));
         this.update_image();
 
         var that = this;
@@ -71,6 +72,9 @@ var Image = mark.Mark.extend({
 
     create_listeners: function() {
         Image.__super__.create_listeners.apply(this);
+        this.listenTo(this.model, "change:pixelated", () => {
+            this.im.classed("image_pixelated", this.model.get('pixelated'));
+        });
         this.listenTo(this.model, "change:image", this.update_image, this);
         this.listenTo(this.model, "data_updated", function() {
             //animate on data update

--- a/js/src/ImageModel.js
+++ b/js/src/ImageModel.js
@@ -24,6 +24,7 @@ var ImageModel = markmodel.MarkModel.extend({
         return _.extend(markmodel.MarkModel.prototype.defaults(), {
             _model_name: "ImageModel",
             _view_name: "Image",
+            pixelated: true,
             x: (0.0, 1.0),
             y: (0.0, 1.0),
             scales_metadata: {

--- a/js/src/bqplot.less
+++ b/js/src/bqplot.less
@@ -100,6 +100,15 @@
                stroke-width: 4;
            }
         }
+        .image_pixelated {
+          /*
+          optimizespeed does not guarantee nearest neighbor, but firefox seems to do so for now
+          https://www.w3.org/TR/SVG/single-page.html#painting-ImageRenderingProperty
+          */
+          image-rendering: optimizespeed;
+          image-rendering: pixelated; /* chrome doesn't support optimizespeed */
+          image-rendering: -moz-crisp-edges; /* this is guaranteed to work for firefox */
+        }
     }
     .tooltip_div {
         z-index: 1001;


### PR DESCRIPTION
For e.g. scientific plots, you want to see the pixels.