### PR TITLE
Scatter scale size range should starts at 0

### DIFF
--- a/js/src/ScatterBase.js
+++ b/js/src/ScatterBase.js
@@ -18,9 +18,6 @@ var _ = require("underscore");
 var utils = require("./utils");
 var mark = require("./Mark");
 
-var min_size = 10;
-
-
 var ScatterBase = mark.Mark.extend({
 
     render: function() {
@@ -89,17 +86,7 @@ var ScatterBase = mark.Mark.extend({
             y_scale.set_range(this.parent.padded_range("y", y_scale.model));
         }
         if(size_scale) {
-            // I don't know how to set the lower bound on the range of the
-            // values that the size scale takes. I guess a reasonable
-            // approximation is that the area should be proportional to the
-            // value. But I also want to set a lower bound of 10px area on
-            // the size. This is what I do in the step below.
-
-            // I don't know how to handle for ordinal scale.
-            var size_domain = size_scale.scale.domain();
-            var ratio = d3.min(size_domain) / d3.max(size_domain);
-            size_scale.set_range([d3.max([(this.model.get("default_size") * ratio), min_size]),
-                                 this.model.get("default_size")]);
+            size_scale.set_range([0, this.model.get("default_size")]);
         }
         if(opacity_scale) {
             opacity_scale.set_range([0.2, 1]);


### PR DESCRIPTION
The minimum of the range of the size_scale is no zero, which although might be convenient in some cases does not to predictable behaviour. For instance, see below where the min of the scale is set to zero, the Scatter's size equals y, but because of the minimum size of 10 (at the minimum of the domain), goes below zero (as it extrapolates):
<img width="856" alt="screen shot 2018-04-10 at 13 34 56" src="https://user-images.githubusercontent.com/1765949/38555003-e867c036-3cc4-11e8-941a-8cfb19896669.png">
Instead, if simply set to zero, it will lead to the expected behaviour:
<img width="853" alt="screen shot 2018-04-10 at 13 35 35" src="https://user-images.githubusercontent.com/1765949/38555024-f801c2da-3cc4-11e8-9a13-cc8bb5a5916b.png">
If a users wants to have a minimum size, this can easily be computed by changing the domain accordingly.