### PR TITLE
Selectors

### DIFF
--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -36,7 +36,7 @@ Interacts
    TwoDSelector
 """
 
-from traitlets import Bool, Int, Float, Unicode, Dict, Instance, List, TraitError
+from traitlets import Bool, Int, Float, Unicode, Dict, Instance, List, TraitError, Enum
 from traittypes import Array
 from ipywidgets import Widget, Color, widget_serialization, register
 
@@ -336,11 +336,14 @@ class BrushIntervalSelector(OneDSelector):
         This attribute can be used to trigger computationally intensive code
         which should be run only on the interval selection being completed as
         opposed to code which should be run whenever selected is changing.
+    orientation: {'horizontal', 'vertical'}
+        The orientation of the interval, either vertical or horizontal
     color: Color or None (default: None)
         Color of the rectangle representing the brush selector.
     """
     brushing = Bool().tag(sync=True)
     selected = Array(None, allow_none=True).tag(sync=True, **array_serialization)
+    orientation = Enum(['horizontal', 'vertical'], default_value='horizontal').tag(sync=True)
     color = Color(None, allow_none=True).tag(sync=True)
 
     _view_name = Unicode('BrushIntervalSelector').tag(sync=True)

--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -523,21 +523,7 @@ class LassoSelector(TwoDSelector):
     color: Color (default: None)
         Color of the lasso.
     """
-    marks = List(Instance(Lines) | Instance(Scatter)).tag(sync=True, **widget_serialization)
     color = Color(None, allow_none=True).tag(sync=True)
-
-    def __init__(self, marks=None, **kwargs):
-        _marks = []
-        if marks is not None:
-            for mark in marks:
-                try:
-                    mark_trait = self.class_traits()['marks']
-                    _marks.append(mark_trait.validate_elements(self, [mark])[0])
-                except TraitError:
-                    pass
-
-        kwargs['marks'] = _marks
-        super(LassoSelector, self).__init__(**kwargs)
 
     _view_name = Unicode('LassoSelector').tag(sync=True)
     _model_name = Unicode('LassoSelectorModel').tag(sync=True)

--- a/js/src/BrushSelector.js
+++ b/js/src/BrushSelector.js
@@ -202,7 +202,7 @@ var BrushIntervalSelector = selector.BaseXSelector.extend(BaseBrushSelector).ext
     },
 
     create_listeners: function() {
-        BrushSelector.__super__.create_listeners.apply(this);
+        BrushIntervalSelector.__super__.create_listeners.apply(this);
         this.listenTo(this.model, "change:color", this.change_color, this);
     },
 

--- a/js/src/BrushSelector.js
+++ b/js/src/BrushSelector.js
@@ -19,170 +19,9 @@ var selector = require("./Selector");
 var utils = require("./utils");
 var sel_utils = require("./lasso_test");
 
-var BrushSelector = selector.BaseXYSelector.extend({
+var BaseBrushSelector = {
 
-    render: function() {
-        BrushSelector.__super__.render.apply(this);
-        var that = this;
-        var scale_creation_promise = this.create_scales();
-
-        //TODO: For all selectors, the brush background etc can be created
-        //without waiting for the promise. But the issue is with resizing
-        //and how they should resize when the parent is resized. So as a
-        //defensive move, I am creating them inside the promise. Should be
-        //moved outside the promise.
-        Promise.all([this.mark_views_promise, scale_creation_promise]).then(function() {
-            that.brush = d3.svg.brush()
-                .x(that.x_scale.scale)
-                .y(that.y_scale.scale)
-                .on("brushstart", _.bind(that.brush_start, that))
-                .on("brush", _.bind(that.brush_move, that))
-                .on("brushend", _.bind(that.brush_end, that));
-
-            that.is_x_date = (that.x_scale.model.type === "date");
-            that.is_y_date = (that.y_scale.model.type === "date");
-
-            that.brushsel = that.d3el.attr("class", "selector brushintsel")
-                .call(that.brush);
-
-            if (that.model.get("color") !== null) {
-                that.brushsel.style("fill", that.model.get("color"));
-            }
-            that.create_listeners();
-        });
-    },
-
-    create_listeners: function() {
-        BrushSelector.__super__.create_listeners.apply(this);
-        this.listenTo(this.model, "change:color", this.color_change, this);
-    },
-
-    color_change: function() {
-         if (this.model.get("color") !== null) {
-            this.brushsel.style("fill", this.model.get("color"));
-        }
-    },
-
-    brush_start: function () {
-        this.model.set("brushing", true);
-        this.touch();
-    },
-
-    brush_move: function () {
-        var extent = this.brush.empty() ? [] : this.brush.extent();
-        this.convert_and_save(extent);
-    },
-
-    brush_end: function () {
-        var extent = this.brush.empty() ? [] : this.brush.extent();
-        this.model.set("brushing", false);
-        this.convert_and_save(extent);
-    },
-
-    convert_and_save: function(extent) {
-        if(extent.length === 0) {
-            this.model.set("selected", [], {js_ignore: true});
-            _.each(this.mark_views, function(mark_view) {
-                mark_view.invert_2d_range([]);
-            });
-            this.touch();
-            return;
-        }
-        var extent_x = [extent[0][0], extent[1][0]];
-        var extent_y = [extent[0][1], extent[1][1]];
-
-        if(this.x_scale.model.type == "ordinal") {
-            extent_x = this.x_scale.invert_range(extent_x);
-        }
-        if(this.y_scale.model.type == "ordinal") {
-            extent_y = this.y_scale.invert_range(extent_y);
-        }
-
-        var that = this;
-        _.each(this.mark_views, function(mark_view) {
-            mark_view.invert_2d_range(that.x_scale.scale(extent_x[0]),
-                                      that.x_scale.scale(extent_x[1]),
-                                      that.y_scale.scale(extent_y[0]),
-                                      that.y_scale.scale(extent_y[1]));
-        });
-        // TODO: The call to the function can be removed once _pack_models is
-        // changed
-        this.model.set("selected", this.get_typed_selected([[extent_x[0],
-                                                             extent_y[0]],
-                                                            [extent_x[1],
-                                                             extent_y[1]]]),
-                        {js_ignore: true});
-        this.touch();
-    },
-
-    get_typed_selected: function(extent) {
-        if(this.is_x_date) {
-            extent[0][0] = this.x_scale.model.convert_to_json(extent[0][0]);
-            extent[1][0] = this.x_scale.model.convert_to_json(extent[1][0]);
-        }
-        if(this.is_y_date) {
-            extent[0][1] = this.y_scale.model.convert_to_json(extent[0][1]);
-            extent[1][1] = this.y_scale.model.convert_to_json(extent[1][1]);
-        }
-        return extent;
-    },
-
-    scale_changed: function() {
-        this.brush.clear();
-        this.create_scales();
-    },
-
-    relayout: function() {
-        BrushSelector.__super__.relayout.apply(this);
-        this.d3el.select(".background")
-            .attr("width", this.width)
-            .attr("height", this.height);
-
-        this.set_x_range([this.x_scale]);
-        this.set_y_range([this.y_scale]);
-    },
-
-    reset: function() {
-        this.brush.clear();
-        this._update_brush();
-
-        this.model.set("selected", [], {js_ignore: true});
-        _.each(this.mark_views, function(mark_view) {
-            mark_view.invert_2d_range([]);
-        });
-        this.touch();
-    },
-
-    update_xscale_domain: function() {
-        // Call the base class function to update the scale.
-        BrushSelector.__super__.update_xscale_domain.apply(this);
-        if(this.brush !== undefined && this.brush !== null) {
-            this.brush.x(this.x_scale.scale);
-        }
-        // TODO:If there is a selection, update the visual element.
-
-    },
-
-    update_yscale_domain: function() {
-        // Call the base class function to update the scale.
-        BrushSelector.__super__.update_yscale_domain.apply(this);
-        if(this.brush !== undefined && this.brush !== null) {
-            this.brush.y(this.y_scale.scale);
-        }
-    },
-
-    _update_brush: function() {
-        //programmatically setting the brush does not redraw it. It is
-        //being redrawn below
-        this.brushsel = this.d3el.call(this.brush);
-        this.d3el.call(this.brush.event);
-    },
-});
-
-var BrushIntervalSelector = selector.BaseXSelector.extend({
-
-    render: function() {
-        BrushIntervalSelector.__super__.render.apply(this);
+    brush_render: function() {
         var that = this;
         var scale_creation_promise = this.create_scales();
         Promise.all([this.mark_views_promise, scale_creation_promise]).then(function() {
@@ -207,13 +46,8 @@ var BrushIntervalSelector = selector.BaseXSelector.extend({
         });
     },
 
-    create_listeners: function() {
-        BrushSelector.__super__.create_listeners.apply(this);
-        this.listenTo(this.model, "change:color", this.change_color, this);
-    },
-
-    change_color: function() {
-        if (this.model.get("color") !== null) {
+    color_change: function() {
+         if (this.model.get("color") !== null) {
             this.brushsel.style("fill", this.model.get("color"));
         }
     },
@@ -234,8 +68,157 @@ var BrushIntervalSelector = selector.BaseXSelector.extend({
         this.convert_and_save(extent);
     },
 
+    reset: function() {
+        this.brush.clear();
+        this._update_brush();
+
+        this.model.set("selected", [], {js_ignore: true});
+        this.update_mark_selected([]);
+        this.touch();
+    },
+
+    reset_mark_selected: function() {
+
+    },
+
+    scale_changed: function() {
+        this.brush.clear();
+        this.create_scales();
+        this.set_brush_scale();
+    },
+
+    _update_brush: function() {
+        //programmatically setting the brush does not redraw it. It is
+        //being redrawn below
+        this.brushsel = this.d3el.call(this.brush);
+        this.d3el.call(this.brush.event);
+    },
+
+    update_mark_selected: function(extent_x, extent_y) {
+
+        if(extent_x.length === 0) {
+            // Reset all the selected in marks
+            _.each(this.mark_views, function(mark_view) {
+                return mark_view.selector_changed();
+            });
+        }
+        if (extent_y === undefined) {
+            // 1d brush
+            var orient = this.model.get("orientation");
+            var x = (orient == "vertical") ? [] : extent_x,
+                y = (orient == "vertical") ? extent_x : [];
+        } else {
+            // 2d brush
+            var x = extent_x, y = extent_y;
+        }
+
+        var point_selector = function(p) {
+            return sel_utils.point_in_rectangle(p, x, y);
+        };
+        var rect_selector = function(xy) {
+            return sel_utils.rect_inter_rect(xy[0], xy[1], x, y);
+        };
+
+        _.each(this.mark_views, function(mark_view) {
+            mark_view.selector_changed(point_selector, rect_selector);
+        }, this);
+    },
+}
+
+var BrushSelector = selector.BaseXYSelector.extend(BaseBrushSelector).extend({
+
+    render: function() {
+        BrushSelector.__super__.render.apply(this);
+        this.brush_render();
+        // Put inside promise?
+        //this.is_x_date = (this.x_scale.model.type === "date");
+        //this.is_y_date = (this.y_scale.model.type === "date");
+    },
+
+    create_listeners: function() {
+        BrushSelector.__super__.create_listeners.apply(this);
+        this.listenTo(this.model, "change:color", this.color_change, this);
+    },
+
     convert_and_save: function(extent) {
-        var that = this;
+        if(extent.length === 0) {
+            this.update_mark_selected([]);
+            return;
+        }
+        var extent_x = [extent[0][0], extent[1][0]];
+        var extent_y = [extent[0][1], extent[1][1]];
+
+        var x_ordinal = (this.x_scale.model.type === "ordinal"),
+            y_ordinal = (this.y_scale.model.type === "ordinal");
+        var pixel_extent_x = x_ordinal ? extent_x : extent_x.map(this.x_scale.scale),
+            pixel_extent_y = y_ordinal ? extent_y : extent_y.map(this.y_scale.scale);
+        
+        extent_x = x_ordinal ? this.x_scale.invert_range(extent_x) : extent_x;
+        extent_y = y_ordinal ? this.y_scale.invert_range(extent_y) : extent_y;
+
+        this.update_mark_selected(pixel_extent_x, pixel_extent_y);
+        // TODO: The call to the function can be removed once _pack_models is
+        // changed
+        this.model.set("selected", [[extent_x[0], extent_y[0]],
+                                    [extent_x[1], extent_y[1]]],
+                       {js_ignore: true});
+        this.touch();
+    },
+
+    relayout: function() {
+        BrushSelector.__super__.relayout.apply(this);
+        this.d3el.select(".background")
+            .attr("width", this.width)
+            .attr("height", this.height);
+
+        this.set_x_range([this.x_scale]);
+        this.set_y_range([this.y_scale]);
+    },
+
+    adjust_rectangle: function() {
+    },
+
+    set_brush_scale: function() {
+        this.brush.y(this.y_scale.scale)
+            .x(this.x_scale.scale);
+    },
+
+    update_xscale_domain: function() {
+        // Call the base class function to update the scale.
+        BrushSelector.__super__.update_xscale_domain.apply(this);
+        if(this.brush !== undefined && this.brush !== null) {
+            this.brush.x(this.x_scale.scale);
+        }
+        // TODO:If there is a selection, update the visual element.
+
+    },
+
+    update_yscale_domain: function() {
+        // Call the base class function to update the scale.
+        BrushSelector.__super__.update_yscale_domain.apply(this);
+        if(this.brush !== undefined && this.brush !== null) {
+            this.brush.y(this.y_scale.scale);
+        }
+    },
+});
+
+var BrushIntervalSelector = selector.BaseXSelector.extend(BaseBrushSelector).extend({
+
+    render: function() {
+        BrushIntervalSelector.__super__.render.apply(this);
+        this.brush_render();
+    },
+
+    create_listeners: function() {
+        BrushSelector.__super__.create_listeners.apply(this);
+        this.listenTo(this.model, "change:color", this.change_color, this);
+    },
+
+    convert_and_save: function(extent) {
+        if(extent.length === 0) {
+            this.update_mark_selected([]);
+            return;
+        }
         var ordinal = (this.scale.model.type === "ordinal");
         var pixel_extent = ordinal ? extent : extent.map(this.scale.scale);
         extent = ordinal ? this.scale.invert_range(extent) : extent;
@@ -243,23 +226,6 @@ var BrushIntervalSelector = selector.BaseXSelector.extend({
         this.update_mark_selected(pixel_extent);
 
         this.model.set_typed_field("selected", extent, {js_ignore: true});
-        this.touch();
-    },
-
-    scale_changed: function() {
-        this.brush.clear();
-        this.create_scale();
-        this.set_brush_scale();
-    },
-
-    reset: function() {
-        this.brush.clear();
-        this._update_brush();
-
-        this.model.set_typed_field("selected", [], {js_ignore : true});
-        _.each(this.mark_views, function(mark_view) {
-            mark_view.selector_changed();
-        });
         this.touch();
     },
 
@@ -296,45 +262,12 @@ var BrushIntervalSelector = selector.BaseXSelector.extend({
             // invalid value for selected. Ignoring the value
             return;
         } else {
-            var that = this;
             selected = selected.sort(function(a, b) { return a - b; });
             var extent = [selected[0], selected[1]];
             this.brush.extent(extent);
             this._update_brush();
-            this.update_mark_selected(extent);
+            this.update_mark_selected(extent.map(this.scale.scale));
         }
-    },
-
-    update_mark_selected: function(extent) {
-
-        if(extent.length === 0) {
-            // Reset all the selected in marks
-            _.each(this.mark_views, function(mark_view) {
-                return mark_view.selector_changed();
-            });
-        }
-
-        var orient = this.model.get("orientation");
-        var x = (orient == "vertical") ? [] : extent,
-            y = (orient == "vertical") ? extent : [];
-
-        var point_selector = function(p) {
-            return sel_utils.point_in_rectangle(p, x, y);
-        };
-        var rect_selector = function(xy) {
-            return sel_utils.rect_inter_rect(xy[0], xy[1], x, y);
-        };
-
-        _.each(this.mark_views, function(mark_view) {
-            mark_view.selector_changed(point_selector, rect_selector);
-        }, this);
-    },
-
-    _update_brush: function() {
-        //programmatically setting the brush does not redraw it. It is
-        //being redrawn below
-        this.brushsel = this.d3el.call(this.brush);
-        this.d3el.call(this.brush.event);
     },
 
     remove: function() {

--- a/js/src/BrushSelector.js
+++ b/js/src/BrushSelector.js
@@ -321,8 +321,8 @@ var BrushIntervalSelector = selector.BaseXSelector.extend({
         var point_selector = function(p) {
             return sel_utils.point_in_rectangle(p, x, y);
         };
-        var rect_selector = function(xm, ym) {
-            return sel_utils.rect_inter_rect(xm, ym, x, y);
+        var rect_selector = function(xy) {
+            return sel_utils.rect_inter_rect(xy[0], xy[1], x, y);
         };
 
         _.each(this.mark_views, function(mark_view) {

--- a/js/src/BrushSelector.js
+++ b/js/src/BrushSelector.js
@@ -17,7 +17,7 @@ var d3 = require("d3");
 var _ = require("underscore");
 var selector = require("./Selector");
 var utils = require("./utils");
-var sel_utils = require("./lasso_test");
+var sel_utils = require("./selector_utils");
 
 var BaseBrushSelector = {
 

--- a/js/src/FastIntervalSelector.js
+++ b/js/src/FastIntervalSelector.js
@@ -17,7 +17,7 @@ var _ = require("underscore");
 var d3 = require("d3");
 var baseselector = require("./Selector");
 var mark = require("./Mark");
-var sel_utils = require("./lasso_test");
+var sel_utils = require("./selector_utils");
 
 var FastIntervalSelector = baseselector.BaseXSelector.extend({
 

--- a/js/src/FastIntervalSelector.js
+++ b/js/src/FastIntervalSelector.js
@@ -17,6 +17,7 @@ var _ = require("underscore");
 var d3 = require("d3");
 var baseselector = require("./Selector");
 var mark = require("./Mark");
+var sel_utils = require("./lasso_test");
 
 var FastIntervalSelector = baseselector.BaseXSelector.extend({
 
@@ -48,17 +49,15 @@ var FastIntervalSelector = baseselector.BaseXSelector.extend({
                 .on("dblclick", _.bind(that.dblclick, that));
 
             that.rect = that.d3el.append("rect")
-            .attr("class", "selector intsel")
-            .attr("x", 0)
-            .attr("y", 0)
-            .attr("width", that.size)
-            .attr("height", that.height)
-            .attr("pointer-events", "none")
-            .attr("display", "none");
+                .attr("class", "selector intsel")
+                .attr("x", 0)
+                .attr("y", 0)
+                .attr("width", that.size)
+                .attr("height", that.height)
+                .attr("pointer-events", "none")
+                .attr("display", "none");
 
-            if(that.model.get("color") !== null) {
-                that.rect.style("fill", that.model.get("color"));
-            }
+            that.color_change();
 
             that.create_listeners();
         });
@@ -90,7 +89,6 @@ var FastIntervalSelector = baseselector.BaseXSelector.extend({
         if (this.freeze_dont_move || !this.active) {
             return;
         }
-
         var mouse_pos = d3.mouse(this.background.node());
         var int_len = this.size > 0 ?
             this.size : parseInt(this.rect.attr("width"));
@@ -110,17 +108,40 @@ var FastIntervalSelector = baseselector.BaseXSelector.extend({
         //update the interval location and size
         this.rect.attr("x", start);
         this.rect.attr("width", interval_size);
+        var pixel_extent = [start, start + interval_size];
         this.model.set_typed_field("selected",
-                                   this.invert_range(start,
-                                                     start + interval_size), { js_ignore : true});
-        _.each(this.mark_views, function(mark_view) {
-            mark_view.invert_range(start, start + interval_size);
-        });
+                                   this.scale.invert_range(pixel_extent),
+                                   { js_ignore : true });
+        this.update_mark_selected(pixel_extent);
         this.touch();
     },
 
-    invert_range: function(start, end) {
-        return this.scale.invert_range([start, end]);
+    update_mark_selected: function(extent_x, extent_y) {
+
+        if(extent_x === undefined || extent_x.length === 0) {
+            // Reset all the selected in marks
+            _.each(this.mark_views, function(mark_view) {
+                return mark_view.selector_changed();
+            });
+        } if (extent_y === undefined) {
+            // 1d brush
+            var orient = this.model.get("orientation");
+            var x = (orient == "vertical") ? [] : extent_x,
+                y = (orient == "vertical") ? extent_x : [];
+        } else {
+            // 2d brush
+            var x = extent_x, y = extent_y;
+        }
+        var point_selector = function(p) {
+            return sel_utils.point_in_rectangle(p, x, y);
+        };
+        var rect_selector = function(xy) {
+            return sel_utils.rect_inter_rect(xy[0], xy[1], x, y);
+        };
+
+        _.each(this.mark_views, function(mark_view) {
+            mark_view.selector_changed(point_selector, rect_selector);
+        }, this);
     },
 
     scale_changed: function() {
@@ -130,9 +151,12 @@ var FastIntervalSelector = baseselector.BaseXSelector.extend({
 
     relayout: function() {
         FastIntervalSelector.__super__.relayout.apply(this);
-        this.background.attr("width", this.width)
+
+        this.adjust_rectangle();
+        this.background
+            .attr("width", this.width)
             .attr("height", this.height);
-        this.rect.attr("height", this.height);
+
         this.set_range([this.scale]);
     },
 
@@ -140,9 +164,7 @@ var FastIntervalSelector = baseselector.BaseXSelector.extend({
         this.rect.attr("x", 0)
             .attr("width", 0);
         this.model.set_typed_field("selected", [], {js_ignore : true});
-        _.each(this.mark_views, function(mark_view) {
-            mark_view.invert_range([]);
-        });
+        this.update_mark_selected();
         this.touch();
     },
 
@@ -170,8 +192,7 @@ var FastIntervalSelector = baseselector.BaseXSelector.extend({
             // invalid value for selected. Ignoring the value
             return;
         } else {
-            var that = this;
-            var pixels = selected.map(function(d) { return that.scale.scale(d); });
+            var pixels = selected.map(this.scale.scale);
             pixels = pixels.sort(function(a, b) { return a - b; });
 
             this.rect.attr({
@@ -179,11 +200,21 @@ var FastIntervalSelector = baseselector.BaseXSelector.extend({
                 width: (pixels[1] - pixels[0])
             }).style("display", "inline");
             this.active = true;
-            _.each(this.mark_views, function(mark_view) {
-                mark_view.invert_range(pixels[0], pixels[1]);
-            });
+            this.update_mark_selected(pixels)
         }
-    }
+    },
+
+    adjust_rectangle: function() {
+        if (this.model.get("orientation") == "vertical") {
+            this.d3el.selectAll("rect")
+                .attr("x", 0)
+                .attr("width", this.width);
+        } else {
+            this.d3el.selectAll("rect")
+                .attr("y", 0)
+                .attr("height", this.height);
+        }
+    },
 });
 
 module.exports = {

--- a/js/src/Hist.js
+++ b/js/src/Hist.js
@@ -431,20 +431,6 @@ var Hist = mark.Mark.extend({
         this.touch();
     },
 
-    invert_range: function(start_pxl, end_pxl) {
-        if(start_pxl === undefined || end_pxl === undefined ) {
-            this.model.set("selected", null);
-            this.touch();
-            return [];
-        }
-
-        var selected = this.calc_data_indices_from_data_range(d3.min([start_pxl, end_pxl]),
-                                                              d3.max([start_pxl, end_pxl]));
-        this.model.set("selected", selected);
-        this.touch();
-        return selected;
-    },
-
     selector_changed: function(point_selector, rect_selector) {
         if(point_selector === undefined) {
             this.model.set("selected", null);

--- a/js/src/Hist.js
+++ b/js/src/Hist.js
@@ -247,6 +247,11 @@ var Hist = mark.Mark.extend({
         this.bin_pixels = this.model.x_bins.map(function(el) {
             return x_scale.scale(el) + x_scale.offset;
         });
+        // pixel coords contains the [x0, x1] and [y0, y1] of each bin
+        this.pixel_coords = this.model.mark_data.map(function(d) {
+            var x = x_scale.scale(d.x);
+            return [[x, x+bar_width], [0, d.y].map(y_scale.scale)];
+        });
         this.update_stroke_and_opacities();
     },
 
@@ -438,6 +443,21 @@ var Hist = mark.Mark.extend({
         this.model.set("selected", selected);
         this.touch();
         return selected;
+    },
+
+    selector_changed: function(point_selector, rect_selector) {
+        if(point_selector === undefined) {
+            this.model.set("selected", null);
+            this.touch();
+            return [];
+        }
+        var pixels = this.pixel_coords;
+        var indices = _.range(pixels.length);
+        var selected_bins = _.filter(indices, function(index) {
+            return rect_selector(pixels[index]);
+        });
+        this.model.set("selected", this.calc_data_indices(selected_bins));
+        this.touch();
     },
 
     calc_data_indices: function(indices) {

--- a/js/src/LassoSelector.js
+++ b/js/src/LassoSelector.js
@@ -17,7 +17,7 @@ var d3 = require("d3");
 var _ = require("underscore");
 var utils = require("./utils");
 var baseselector = require("./Selector");
-var lasso = require("./lasso_test");
+var sel_utils = require("./selector_utils");
 
 var LassoSelector = baseselector.BaseXYSelector.extend({
     render: function() {
@@ -110,12 +110,12 @@ var LassoSelector = baseselector.BaseXYSelector.extend({
         }
         var point_selector = function(p) {
             for (var l in vertices) {
-                if (lasso.point_in_lasso(p, vertices[l])) { return true; }
+                if (sel_utils.point_in_lasso(p, vertices[l])) { return true; }
             } return false;
         };
         var rect_selector = function(xy) {
             for (var l in vertices) {
-                if (lasso.lasso_inter_rect(xy[0], xy[1], vertices[l])) { return true; }
+                if (sel_utils.lasso_inter_rect(xy[0], xy[1], vertices[l])) { return true; }
             } return false;
         };
 

--- a/js/src/Lines.js
+++ b/js/src/Lines.js
@@ -282,6 +282,21 @@ var Lines = mark.Mark.extend({
         this.touch();
     },
 
+    selector_changed: function(point_selector, rect_selector) {
+        if(point_selector === undefined) {
+            this.model.set("selected", null);
+            this.touch();
+            return [];
+        }
+        var pixels = this.pixel_coords;
+        var indices = _.range(pixels.length);
+        var selected = _.filter(indices, function(index) {
+            return point_selector(pixels[index]);
+        });
+        this.model.set("selected", selected);
+        this.touch();
+    },
+
     invert_point: function(pixel) {
         if(pixel === undefined) {
             this.model.set("selected", null);
@@ -528,7 +543,11 @@ var Lines = mark.Mark.extend({
                                                           : [];
         this.y_pixels = (this.model.mark_data.length > 0) ? this.model.mark_data[0].values.map(function(el)
                                                                     { return y_scale.scale(el.y) + y_scale.offset; })
-                                                          : [];                                                  
+                                                          : [];
+        this.pixel_coords = (this.model.mark_data.length > 0) ?
+            this.model.mark_data[0].values.map(function(el) {
+                return [x_scale.scale(el.x) + x_scale.offset, y_scale.scale(el.y) + y_scale.offset];
+            }) : [];
     },
 
     draw: function(animate) {

--- a/js/src/Lines.js
+++ b/js/src/Lines.js
@@ -260,19 +260,23 @@ var Lines = mark.Mark.extend({
         this.update_line_xy();
     },
 
-    invert_range: function(start_pxl, end_pxl) {
+    invert_range: function(start_pxl, end_pxl, orientation) {
         if(start_pxl === undefined || end_pxl === undefined) {
             this.model.set("selected", null);
             this.touch();
             return [];
         }
-        var x_scale = this.scales.x;
-
-        var indices = _.range(this.x_pixels.length);
+        var pixels = (orientation == "y") ? this.y_pixels : this.x_pixels;
+        var indices = _.range(pixels.length);
         var that = this;
         var selected = _.filter(indices, function(index) {
-            var elem = that.x_pixels[index];
-            return (elem >= start_pxl && elem <= end_pxl);
+            var elem = pixels[index];
+            if (orientation == "x") {
+                return (elem >= start_pxl && elem <= end_pxl);
+            } else {
+                return (elem <= start_pxl && elem >= end_pxl)
+            }
+            
         });
         this.model.set("selected", selected);
         this.touch();
@@ -522,6 +526,9 @@ var Lines = mark.Mark.extend({
         this.x_pixels = (this.model.mark_data.length > 0) ? this.model.mark_data[0].values.map(function(el)
                                                                     { return x_scale.scale(el.x) + x_scale.offset; })
                                                           : [];
+        this.y_pixels = (this.model.mark_data.length > 0) ? this.model.mark_data[0].values.map(function(el)
+                                                                    { return y_scale.scale(el.y) + y_scale.offset; })
+                                                          : [];                                                  
     },
 
     draw: function(animate) {

--- a/js/src/Lines.js
+++ b/js/src/Lines.js
@@ -683,47 +683,6 @@ var Lines = mark.Mark.extend({
         this.d3el.selectAll(".dot").attr("d", this.dot.size(marker_size));
     },
 
-    update_selected_in_lasso: function(lasso_name, lasso_vertices,
-                                       point_in_lasso_func) {
-        var x_scale = this.scales.x, y_scale = this.scales.y;
-        var idx = this.model.get("selected");
-        var selected = idx ? utils.deepCopy(idx) : [];
-        var data_in_lasso = false;
-        var that = this;
-        if(lasso_vertices !== null && lasso_vertices.length > 0) {
-            // go through each line and check if its data is in lasso
-            _.each(this.model.mark_data, function(line_data) {
-               var line_name = line_data.name;
-               var data = line_data.values;
-               var indices = _.range(data.length);
-               var idx_in_lasso = _.filter(indices, function(index) {
-                   var elem = data[index];
-                   var point = [x_scale.scale(elem.x), y_scale.scale(elem.y)];
-                   return point_in_lasso_func(point, lasso_vertices);
-               });
-               if (idx_in_lasso.length > 0) {
-                   data_in_lasso = true;
-                   selected.push({
-                       line_name: line_name,
-                       lasso_name: lasso_name,
-                       indices: idx_in_lasso,
-                   });
-               }
-           });
-           that.model.set("selected", selected);
-           that.touch();
-        } else {
-            // delete the lasso specific selected
-            this.model.set("selected", _.filter(selected, function(lasso) {
-                return lasso.lasso_name !== lasso_name;
-            }));
-            this.touch();
-        }
-
-        //return true if there are any mark data inside lasso
-        return data_in_lasso;
-    },
-
     process_interactions: function() {
         var interactions = this.model.get("interactions");
         if(_.isEmpty(interactions)) {

--- a/js/src/Lines.js
+++ b/js/src/Lines.js
@@ -260,28 +260,6 @@ var Lines = mark.Mark.extend({
         this.update_line_xy();
     },
 
-    invert_range: function(start_pxl, end_pxl, orientation) {
-        if(start_pxl === undefined || end_pxl === undefined) {
-            this.model.set("selected", null);
-            this.touch();
-            return [];
-        }
-        var pixels = (orientation == "y") ? this.y_pixels : this.x_pixels;
-        var indices = _.range(pixels.length);
-        var that = this;
-        var selected = _.filter(indices, function(index) {
-            var elem = pixels[index];
-            if (orientation == "x") {
-                return (elem >= start_pxl && elem <= end_pxl);
-            } else {
-                return (elem <= start_pxl && elem >= end_pxl)
-            }
-            
-        });
-        this.model.set("selected", selected);
-        this.touch();
-    },
-
     selector_changed: function(point_selector, rect_selector) {
         if(point_selector === undefined) {
             this.model.set("selected", null);

--- a/js/src/ScatterBase.js
+++ b/js/src/ScatterBase.js
@@ -522,20 +522,23 @@ var ScatterBase = mark.Mark.extend({
         this.touch();
     },
 
-    invert_range: function(start_pxl, end_pxl) {
+    invert_range: function(start_pxl, end_pxl, orientation) {
         if(start_pxl === undefined || end_pxl === undefined) {
             this.model.set("selected", null);
             this.touch();
             return [];
         }
-
-        var x_scale = this.scales.x;
+        var pixels = (orientation == "y") ? this.y_pixels : this.x_pixels;
+        var indices = _.range(pixels.length);
         var that = this;
-        var indices = _.range(this.model.mark_data.length);
-
         var selected = _.filter(indices, function(index) {
-            var elem = that.x_pixels[index];
-            return (elem >= start_pxl && elem <= end_pxl);
+            var elem = pixels[index];
+            if (orientation == "x") {
+                return (elem >= start_pxl && elem <= end_pxl);
+            } else {
+                return (elem <= start_pxl && elem >= end_pxl)
+            }
+            
         });
         this.model.set("selected", selected);
         this.touch();

--- a/js/src/Selector.js
+++ b/js/src/Selector.js
@@ -169,8 +169,8 @@ var BaseXYSelector = BaseSelector.extend({
     update_yscale_domain: function() {
         // When the domain of the scale is updated, the domain of the scale
         // for the selector must be expanded to account for the padding.
-        var initial_range = this.parent.padded_range("x", this.y_scale.model);
-        var target_range = this.parent.range("x");
+        var initial_range = this.parent.padded_range("y", this.y_scale.model);
+        var target_range = this.parent.range("y");
         this.y_scale.expand_domain(initial_range, target_range);
     }
 });

--- a/js/src/Selector.js
+++ b/js/src/Selector.js
@@ -99,14 +99,16 @@ var BaseXSelector = BaseSelector.extend({
     update_scale_domain: function() {
         // When the domain of the scale is updated, the domain of the scale
         // for the selector must be expanded to account for the padding.
-        var initial_range = this.parent.padded_range("x", this.scale.model);
-        var target_range = this.parent.range("x");
+        var xy = (this.model.get("orientation") == "vertical") ? "y" : "x"
+        var initial_range = this.parent.padded_range(xy, this.scale.model);
+        var target_range = this.parent.range(xy);
         this.scale.expand_domain(initial_range, target_range);
     },
 
     set_range: function(array) {
+        var xy = (this.model.get("orientation") == "vertical") ? "y" : "x"
         for(var iter = 0; iter < array.length; iter++) {
-            array[iter].set_range(this.parent.range("x"));
+            array[iter].set_range(this.parent.range(xy));
         }
     },
 });

--- a/js/src/SelectorModel.js
+++ b/js/src/SelectorModel.js
@@ -100,7 +100,8 @@ var BrushIntervalSelectorModel = OneDSelectorModel.extend({
             _view_name: "BrushIntervalSelector",
             brushing: false,
             selected: [],
-            color: null
+            color: null,
+            orientation: "horizontal"
         });
     }
 });

--- a/js/src/lasso_test.js
+++ b/js/src/lasso_test.js
@@ -69,7 +69,7 @@ function point_in_rectangle(point, x, y) {
 
 // checks whether two rectangles intersect
 function rect_inter_rect(x0, y0, x1, y1) {
-    return seg_inter_seg(x0, x1) || seg_inter_seg(y0, y1);
+    return seg_inter_seg(x0, x1) && seg_inter_seg(y0, y1);
 }
 
 function lasso_inter_rect(x, y, vertices) {

--- a/js/src/lasso_test.js
+++ b/js/src/lasso_test.js
@@ -31,8 +31,8 @@
  * SOFTWARE.
  */
 
-// checks if a point is in lasso
 function point_in_lasso(point, vertices) {
+    // Checks if a point is in lasso
     var xi, xj, yi, yj, intersect,
         x = point[0], y = point[1], is_inside = false;
 
@@ -47,56 +47,6 @@ function point_in_lasso(point, vertices) {
     return is_inside;
 }
 
-function point_in_rectangle(point, x, y) {
-    // checks whether `point` is within the rectangle of coordinates
-    // (x0, y0) (x1, y0) (x1, y1) (x0, y1)
-    // If one of x or y is undefined, treat them as [-inf, inf]
-    
-    if (x.length == 0 && y.length == 0) { return false; }
-
-    var is_inside = true;
-    x.sort(function(a, b){return a-b});
-    y.sort(function(a, b){return a-b});
-
-    if (x.length != 0) {
-        is_inside = is_inside && x[0] <= point[0] && point[0] <= x[1];
-    }
-    if (y.length != 0) {
-        is_inside = is_inside && y[0] <= point[1] && point[1] <= y[1];
-    } 
-    return is_inside;
-}
-
-// checks whether two rectangles intersect
-function rect_inter_rect(x0, y0, x1, y1) {
-    return seg_inter_seg(x0, x1) && seg_inter_seg(y0, y1);
-}
-
-function lasso_inter_rect(x, y, vertices) {
-    // checks whether the lasso intersects the rectangle of coordinates
-    // (x0, y0) (x1, y0) (x1, y1) (x0, y1)
-
-    for (var i = 0; i < vertices.length; i++) {
-        if (point_in_rectangle(vertices[i], x, y)) { return true; }
-    }
-    return false;
-}
-
-function seg_inter_seg(p, q) {
-    // Checks whether the 1d segments [p0, p1] and [q0, q1] intersect
-    // If one of the segments is empty, treat it as [-inf, inf]
-    if (p.length == 0 || q.length == 0) {
-        return (p.length != 0 || q.length != 0);
-    }
-    p.sort(function(a, b){return a-b});
-    q.sort(function(a, b){return a-b});
-    return ((p[0] < q[0] != p[0] < q[1]) || (p[1] < q[0] != p[1] < q[1]) ||
-            (q[0] < p[0] != q[0] < p[1]) || (q[1] < p[0] != q[1] < p[1]));
-}
-
 module.exports = {
     point_in_lasso: point_in_lasso,
-    point_in_rectangle: point_in_rectangle,
-    rect_inter_rect: rect_inter_rect,
-    lasso_inter_rect: lasso_inter_rect,
 }

--- a/js/src/lasso_test.js
+++ b/js/src/lasso_test.js
@@ -47,6 +47,56 @@ function point_in_lasso(point, vertices) {
     return is_inside;
 }
 
+function point_in_rectangle(point, x, y) {
+    // checks whether `point` is within the rectangle of coordinates
+    // (x0, y0) (x1, y0) (x1, y1) (x0, y1)
+    // If one of x or y is undefined, treat them as [-inf, inf]
+    
+    if (x.length == 0 && y.length == 0) { return false; }
+
+    var is_inside = true;
+    x.sort(function(a, b){return a-b});
+    y.sort(function(a, b){return a-b});
+
+    if (x.length != 0) {
+        is_inside = is_inside && x[0] <= point[0] && point[0] <= x[1];
+    }
+    if (y.length != 0) {
+        is_inside = is_inside && y[0] <= point[1] && point[1] <= y[1];
+    } 
+    return is_inside;
+}
+
+// checks whether two rectangles intersect
+function rect_inter_rect(x0, y0, x1, y1) {
+    return seg_inter_seg(x0, x1) || seg_inter_seg(y0, y1);
+}
+
+function lasso_inter_rect(x, y, vertices) {
+    // checks whether the lasso intersects the rectangle of coordinates
+    // (x0, y0) (x1, y0) (x1, y1) (x0, y1)
+
+    for (var i = 0; i < vertices.length; i++) {
+        if (point_in_rectangle(vertices[i])) { return true; }
+    }
+    return false;
+}
+
+function seg_inter_seg(p, q) {
+    // Checks whether the 1d segments [p0, p1] and [q0, q1] intersect
+    // If one of the segments is empty, treat it as [-inf, inf]
+    if (p.length == 0 || q.length == 0) {
+        return (p.length != 0 || q.length != 0);
+    }
+    p.sort(function(a, b){return a-b});
+    q.sort(function(a, b){return a-b});
+    return ((p[0] < q[0] != p[0] < q[1]) || (p[1] < q[0] != p[1] < q[1]) ||
+            (q[0] < p[0] != q[0] < p[1]) || (q[1] < p[0] != q[1] < p[1]));
+}
+
 module.exports = {
-    point_in_lasso: point_in_lasso
+    point_in_lasso: point_in_lasso,
+    point_in_rectangle: point_in_rectangle,
+    rect_inter_rect: rect_inter_rect,
+    lasso_inter_rect: lasso_inter_rect,
 }

--- a/js/src/lasso_test.js
+++ b/js/src/lasso_test.js
@@ -77,7 +77,7 @@ function lasso_inter_rect(x, y, vertices) {
     // (x0, y0) (x1, y0) (x1, y1) (x0, y1)
 
     for (var i = 0; i < vertices.length; i++) {
-        if (point_in_rectangle(vertices[i])) { return true; }
+        if (point_in_rectangle(vertices[i], x, y)) { return true; }
     }
     return false;
 }

--- a/js/src/selector_utils.js
+++ b/js/src/selector_utils.js
@@ -1,0 +1,74 @@
+/* Copyright 2015 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* This module contains elementary geometric functions to determine whether
+ * shapes are contained within selectors.
+ */
+
+var lasso = require("./lasso_test");
+
+function point_in_rectangle(point, x, y) {
+    // Checks whether `point` is within the rectangle of coordinates
+    // (x0, y0) (x1, y0) (x1, y1) (x0, y1)
+    // If one of x or y is undefined, treat them as [-inf, inf]
+    
+    if (x.length == 0 && y.length == 0) { return false; }
+
+    var is_inside = true;
+    x.sort(function(a, b){return a-b});
+    y.sort(function(a, b){return a-b});
+
+    if (x.length != 0) {
+        is_inside = is_inside && x[0] <= point[0] && point[0] <= x[1];
+    }
+    if (y.length != 0) {
+        is_inside = is_inside && y[0] <= point[1] && point[1] <= y[1];
+    } 
+    return is_inside;
+}
+
+function rect_inter_rect(x0, y0, x1, y1) {
+    // Checks whether two rectangles intersect
+    return seg_inter_seg(x0, x1) && seg_inter_seg(y0, y1);
+}
+
+function lasso_inter_rect(x, y, vertices) {
+    // checks whether the lasso intersects the rectangle of coordinates
+    // (x0, y0) (x1, y0) (x1, y1) (x0, y1)
+
+    for (var i = 0; i < vertices.length; i++) {
+        if (point_in_rectangle(vertices[i], x, y)) { return true; }
+    }
+    return false;
+}
+
+function seg_inter_seg(p, q) {
+    // Checks whether the 1d segments [p0, p1] and [q0, q1] intersect
+    // If one of the segments is empty, treat it as [-inf, inf]
+    if (p.length == 0 || q.length == 0) {
+        return (p.length != 0 || q.length != 0);
+    }
+    p.sort(function(a, b){return a-b});
+    q.sort(function(a, b){return a-b});
+    return ((p[0] < q[0] != p[0] < q[1]) || (p[1] < q[0] != p[1] < q[1]) ||
+            (q[0] < p[0] != q[0] < p[1]) || (q[1] < p[0] != q[1] < p[1]));
+}
+
+module.exports = {
+    point_in_lasso: lasso.point_in_lasso,
+    point_in_rectangle: point_in_rectangle,
+    rect_inter_rect: rect_inter_rect,
+    lasso_inter_rect: lasso_inter_rect,
+}


### PR DESCRIPTION
This PR changes how the selectors work on the javascript side.
Apart from simplifying the code, it features:
- Horizontal brush selectors (contains PR #625)
- Selectors working with almost **all** the marks. This means we can have a 2d brush on a Lines or a lasso selector on a horizontal barchart for example.
- Full backwards compatibility, all features that used to work still work in the same way.