### PR TITLE
Use LTS node on travis instead of node 10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ addons:
 install:
   - sudo apt-get update
   - . $HOME/.nvm/nvm.sh
-  - nvm install stable
-  - nvm use stable
+  - nvm install --lts
+  - nvm use --lts
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then


### PR DESCRIPTION
It seems that node 10.0 may have issues installing JupyterLab.