### PR TITLE
Improve classic notebook layout

### DIFF
--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -136,10 +136,9 @@ class Figure(DOMWidget):
     # min width is based on hardcoded padding values
     layout = LayoutTraitType(kw=dict(min_width='125px'))\
         .tag(sync=True, **widget_serialization)
-    min_aspect_ratio = Float(1.0).tag(sync=True)
-    # Max aspect ratio is such that we can have 3 charts stacked vertically
-    # on a 16:9 monitor: 16/9*3 ~ 5.333
-    max_aspect_ratio = Float(6.0).tag(sync=True)
+
+    min_aspect_ratio = Float(0).tag(sync=True)
+    max_aspect_ratio = Float(100).tag(sync=True)
 
     fig_margin = Dict(dict(top=60, bottom=60, left=60, right=60))\
         .tag(sync=True)

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -216,8 +216,12 @@ var Figure = widgets.DOMWidgetView.extend({
                     //and not displayed.
                     that.relayout();
                 }
-                that.model.on("msg:custom", that.handle_custom_messages,
-			  that);
+                that.model.on("msg:custom", that.handle_custom_messages, that);
+                // In the classic notebook, we should relayout the figure on
+                // resize of the main window.
+                window.addEventListener('resize', function() {
+                    that.relayout();
+                })
             });
         });
     },

--- a/js/src/FigureModel.js
+++ b/js/src/FigureModel.js
@@ -42,11 +42,9 @@ var FigureModel = basemodel.BaseModel.extend({
             legend_style: {},
             legend_text: {},
 
-            min_width: "",
-            min_height: "",
             preserve_aspect: false,
-            min_aspect_ratio: 1,
-            max_aspect_ratio: 16 / 9,
+            min_aspect_ratio: 0,
+            max_aspect_ratio: 100,
 
             fig_margin: {
                 top: 60,

--- a/js/src/bqplot.less
+++ b/js/src/bqplot.less
@@ -136,7 +136,7 @@
         stroke-width: .5px;
         stroke-opacity: .5;
     }
-     
+
     .g_legend {
         fill: none;
     }


### PR DESCRIPTION
This PR makes three changes related to layout

 1. It fixes #641, meaning that if you set the layout of a figure to be e.g. 100%, the figure was not being re-laid out like it was in JupyterLab.
 2. ~~It makes the natural width of the Figure 100%. Natural min-width and min-height are 480px.~~
 3. Min and max aspect ratio are set to 0 and 100 (an arbitrary large number corresponding to something very oblong because JSON does not support IEEE infinities).

- Item (1) is a bug fix, which was impacting users of the classic notebook.
- Item (3) is a minor change that should not have much impact expect in complicated JupyterLab layouts.
- ~~item (2) is a major change that may change people's layouts in applications. However I like how charts now take up more real estate by default.~~

Screencast of figure getting the relayout upon window resize in the classic notebook. (when setting `layout.width='100%'`)

![full-width](https://user-images.githubusercontent.com/2397974/40553357-3b4583ec-5ff7-11e8-9528-f77ff98f8bdd.gif)
