### PR TITLE
Make selectors render on multiple figures, and on notebook loading

### DIFF
--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -379,11 +379,20 @@ class BrushSelector(TwoDSelector):
 
     Attributes
     ----------
-    selected: numpy.ndarray
+    selected_x: numpy.ndarray
         Two element array containing the start and end of the interval selected
-        in terms of the scales of the selector.
+        in terms of the x_scale of the selector.
         This attribute changes while the selection is being made with the
-        ``BrushIntervalSelector``.
+        ``BrushSelector``.
+    selected_y: numpy.ndarray
+        Two element array containing the start and end of the interval selected
+        in terms of the y_scale of the selector.
+        This attribute changes while the selection is being made with the
+        ``BrushSelector``.
+    selected_x: list
+        Readonly 2x2 array containing the coordinates 
+        [[selected_x[0], selected_y[0]],
+         [selected_x[1], selected_y[1]]]
     brushing: bool (default: False)
         boolean attribute to indicate if the selector is being dragged.
         It is True when the selector is being moved and False when it is not.
@@ -395,31 +404,18 @@ class BrushSelector(TwoDSelector):
     """
     clear = Bool().tag(sync=True)
     brushing = Bool().tag(sync=True)
-    selected = List().tag(sync=True)
+    selected_x = Array(None, allow_none=True).tag(sync=True, **array_serialization)
+    selected_y = Array(None, allow_none=True).tag(sync=True, **array_serialization)
     color = Color(None, allow_none=True).tag(sync=True)
 
-    def __init__(self, **kwargs):
-        # Stores information regarding the scales. The date scaled values have
-        # to be converted into dateobjects because they are transmitted as
-        # strings.
-        try:
-            self.read_json_x = kwargs.get('x_scale').domain_class.from_json
-        except AttributeError:
-            self.read_json_x = None
-        try:
-            self.read_json_y = kwargs.get('y_scale').domain_class.from_json
-        except AttributeError:
-            self.read_json_y = None
-        super(BrushSelector, self).__init__(**kwargs)
-
-    def _selected_changed(self, name, selected):
-        if(len(self.selected) == 2):
-            if(self.read_json_x is not None):
-                self.selected[0][0] = self.read_json_x(self.selected[0][0])
-                self.selected[1][0] = self.read_json_x(self.selected[1][0])
-            if(self.read_json_y is not None):
-                self.selected[0][1] = self.read_json_y(self.selected[0][1])
-                self.selected[1][1] = self.read_json_y(self.selected[1][1])
+    # This is for backward compatibility
+    @property
+    def selected(self):
+        if self.selected_x is None or len(self.selected_x) == 0:
+            return []
+        else:
+            return [[self.selected_x[0], self.selected_y[0]],
+                    [self.selected_x[1], self.selected_y[1]]]
 
     _view_name = Unicode('BrushSelector').tag(sync=True)
     _model_name = Unicode('BrushSelectorModel').tag(sync=True)

--- a/js/src/BaseModel.js
+++ b/js/src/BaseModel.js
@@ -67,6 +67,11 @@ var BaseModel = widgets.WidgetModel.extend({
         var that = this;
         var current_type = this.get(param).type;
 
+        if (saved_value[0] instanceof Array && saved_value[0][0] instanceof Date ||
+            saved_value[0] instanceof Date) {
+            current_type = "date";
+        }
+
         if(saved_value[0] instanceof Array) {
             if(current_type === "date")
                 saved_value = saved_value.map(function(val) {

--- a/js/src/BrushSelector.js
+++ b/js/src/BrushSelector.js
@@ -512,7 +512,7 @@ var MultiSelector = selector.BaseXSelector.extend(BaseBrushSelector).extend({
         selected[this.get_label(item)] = extent;
         var pixel_extent = extent.map(this.scale.scale);
         this.update_mark_selected(pixel_extent);
-        this.model.set_typed_field("_selected", selected);
+        this.model.set("_selected", selected);
         this.touch();
     },
 

--- a/js/src/BrushSelector.js
+++ b/js/src/BrushSelector.js
@@ -24,12 +24,13 @@ var BaseBrushSelector = {
     brush_render: function() {
         var that = this;
         var scale_creation_promise = this.create_scales();
+        this.brushing = false;
         
         Promise.all([this.mark_views_promise, scale_creation_promise]).then(function() {
             that.brush = d3.svg.brush()
-                .on("brushstart", _.bind(that.brush_start, that))
-                .on("brush", _.bind(that.brush_move, that))
-                .on("brushend", _.bind(that.brush_end, that));
+              .on("brushstart", _.bind(that.brush_start, that))
+              .on("brush", _.bind(that.brush_move, that))
+              .on("brushend", _.bind(that.brush_end, that));
             that.set_brush_scale();
 
             that.d3el.attr("class", "selector brushintsel");
@@ -37,7 +38,7 @@ var BaseBrushSelector = {
             that.adjust_rectangle();
             that.color_change();
             that.create_listeners();
-            // that.selected_changed();
+            that.selected_changed();
         });
     },
 
@@ -50,6 +51,7 @@ var BaseBrushSelector = {
     brush_start: function () {
         this.model.set("brushing", true);
         this.touch();
+        this.brushing = true;
     },
 
     brush_move: function () {
@@ -61,18 +63,7 @@ var BaseBrushSelector = {
         var extent = this.brush.empty() ? [] : this.brush.extent();
         this.model.set("brushing", false);
         this.convert_and_save(extent);
-    },
-
-    reset: function() {
-        this.brush.clear();
-        this._update_brush();
-
-        this.model.set("selected", [], {js_ignore: true});
-        this.update_mark_selected();
-        this.touch();
-    },
-
-    reset_mark_selected: function() {
+        this.brushing = false;
     },
 
     scale_changed: function() {
@@ -84,12 +75,12 @@ var BaseBrushSelector = {
     adjust_rectangle: function() {
         if (this.model.get("orientation") == "vertical") {
             this.d3el.selectAll("rect")
-                .attr("x", 0)
-                .attr("width", this.width);
+              .attr("x", 0)
+              .attr("width", this.width);
         } else {
             this.d3el.selectAll("rect")
-                .attr("y", 0)
-                .attr("height", this.height);
+              .attr("y", 0)
+              .attr("height", this.height);
         }
     },
 
@@ -107,6 +98,7 @@ var BaseBrushSelector = {
             _.each(this.mark_views, function(mark_view) {
                 return mark_view.selector_changed();
             });
+            return;
         } if (extent_y === undefined) {
             // 1d brush
             var orient = this.model.get("orientation");
@@ -142,6 +134,19 @@ var BrushSelector = selector.BaseXYSelector.extend(BaseBrushSelector).extend({
     create_listeners: function() {
         BrushSelector.__super__.create_listeners.apply(this);
         this.listenTo(this.model, "change:color", this.color_change, this);
+        // Move these to BaseXYSelector
+        this.listenTo(this.model, "change:selected_x", this.selected_changed);
+        this.listenTo(this.model, "change:selected_y", this.selected_changed);
+    },
+
+    reset: function() {
+        // FIXME move this to BaseBrushSelector
+        this.brush.clear();
+        this._update_brush();
+        this.model.set("selected_x", {});
+        this.model.set("selected_y", {});
+        this.update_mark_selected();
+        this.touch();
     },
 
     convert_and_save: function(extent) {
@@ -161,19 +166,41 @@ var BrushSelector = selector.BaseXYSelector.extend(BaseBrushSelector).extend({
         extent_y = y_ordinal ? this.y_scale.invert_range(extent_y) : extent_y;
 
         this.update_mark_selected(pixel_extent_x, pixel_extent_y);
-        // TODO: The call to the function can be removed once _pack_models is
-        // changed
-        this.model.set("selected", [[extent_x[0], extent_y[0]],
-                                    [extent_x[1], extent_y[1]]],
-                       {js_ignore: true});
+        this.model.set_typed_field("selected_x", extent_x);
+        this.model.set_typed_field("selected_y", extent_y);
         this.touch();
+    },
+
+    selected_changed: function(model, value) {
+        if(this.brushing) {
+            return;
+        }
+        //reposition the interval selector and set the selected attribute.
+        var selected_x = this.model.get_typed_field("selected_x"),
+            selected_y = this.model.get_typed_field("selected_y");
+        if(selected_x.length === 0 || selected_y.length === 0) {
+            this.reset();
+        } else if(selected_x.length != 2 || selected_y.length != 2) {
+            // invalid value for selected. Ignoring the value
+            return;
+        } else {
+            var extent = [[selected_x[0], selected_y[0]],
+                          [selected_x[1], selected_y[1]]];
+            this.brush.extent(extent);
+            this._update_brush();
+            var pixel_extent_x = selected_x.map(this.x_scale.scale).sort(
+                function(a, b) { return a - b; });
+            var pixel_extent_y = selected_y.map(this.y_scale.scale).sort(
+                function(a, b) { return a - b; });
+            this.update_mark_selected(pixel_extent_x, pixel_extent_y);
+        }
     },
 
     relayout: function() {
         BrushSelector.__super__.relayout.apply(this);
         this.d3el.select(".background")
-            .attr("width", this.width)
-            .attr("height", this.height);
+          .attr("width", this.width)
+          .attr("height", this.height);
 
         this.set_x_range([this.x_scale]);
         this.set_y_range([this.y_scale]);
@@ -184,7 +211,7 @@ var BrushSelector = selector.BaseXYSelector.extend(BaseBrushSelector).extend({
 
     set_brush_scale: function() {
         this.brush.y(this.y_scale.scale)
-            .x(this.x_scale.scale);
+          .x(this.x_scale.scale);
     },
 
     update_xscale_domain: function() {
@@ -218,6 +245,15 @@ var BrushIntervalSelector = selector.BaseXSelector.extend(BaseBrushSelector).ext
         this.listenTo(this.model, "change:color", this.change_color, this);
     },
 
+    reset: function() {
+        this.brush.clear();
+        this._update_brush();
+
+        this.model.set("selected", {});
+        this.update_mark_selected();
+        this.touch();
+    },
+
     convert_and_save: function(extent) {
         if(extent.length === 0) {
             this.update_mark_selected([]);
@@ -229,7 +265,7 @@ var BrushIntervalSelector = selector.BaseXSelector.extend(BaseBrushSelector).ext
 
         this.update_mark_selected(pixel_extent);
 
-        this.model.set_typed_field("selected", extent, {js_ignore: true});
+        this.model.set_typed_field("selected", extent);
         this.touch();
     },
 
@@ -252,10 +288,8 @@ var BrushIntervalSelector = selector.BaseXSelector.extend(BaseBrushSelector).ext
             }
     },
 
-    selected_changed: function(model, value, options) {
-        if(options && options.js_ignore) {
-            //this change was most probably triggered from the js side and
-            //should be ignored.
+    selected_changed: function(model, value) {
+        if(this.brushing) {
             return;
         }
         //reposition the interval selector and set the selected attribute.
@@ -285,8 +319,8 @@ var BrushIntervalSelector = selector.BaseXSelector.extend(BaseBrushSelector).ext
 
         this.adjust_rectangle();
         this.d3el.select(".background")
-            .attr("width", this.width)
-            .attr("height", this.height);
+          .attr("width", this.width)
+          .attr("height", this.height);
 
         this.set_range([this.scale]);
     },
@@ -349,7 +383,7 @@ var MultiSelector = selector.BaseXSelector.extend(BaseBrushSelector).extend({
                 delete selected[prev_label];
             }
         });
-        this.model.set("_selected", selected);
+        this.model.set_typed_field("_selected", selected);
         this.touch();
     },
 
@@ -478,7 +512,7 @@ var MultiSelector = selector.BaseXSelector.extend(BaseBrushSelector).extend({
         selected[this.get_label(item)] = extent;
         var pixel_extent = extent.map(this.scale.scale);
         this.update_mark_selected(pixel_extent);
-        this.model.set("_selected", selected);
+        this.model.set_typed_field("_selected", selected);
         this.touch();
     },
 

--- a/js/src/SelectorModel.js
+++ b/js/src/SelectorModel.js
@@ -99,7 +99,7 @@ var BrushIntervalSelectorModel = OneDSelectorModel.extend({
             _model_name: "BrushIntervalSelectorModel",
             _view_name: "BrushIntervalSelector",
             brushing: false,
-            selected: [],
+            selected: {},
             color: null,
             orientation: "horizontal"
         });
@@ -114,7 +114,8 @@ var BrushSelectorModel = TwoDSelectorModel.extend({
             _view_name: "BrushSelector",
             clear: false,
             brushing: false,
-            selected: [],
+            selected_x: {},
+            selected_y: {},
             color: null
         });
     }

--- a/js/src/SelectorModel.js
+++ b/js/src/SelectorModel.js
@@ -72,7 +72,7 @@ var FastIntervalSelectorModel = OneDSelectorModel.extend({
         return _.extend(OneDSelectorModel.prototype.defaults(), {
             _model_name: "FastIntervalSelectorModel",
             _view_name: "FastIntervalSelector",
-            selected: [],
+            selected: {},
             color: null,
             size: null
         });
@@ -85,7 +85,7 @@ var IndexSelectorModel = OneDSelectorModel.extend({
         return _.extend(OneDSelectorModel.prototype.defaults(), {
             _model_name: "IndexSelectorModel",
             _view_name: "IndexSelector",
-            selected: [],
+            selected: {},
             line_width: 2,
             color: null
         });


### PR DESCRIPTION
This PR makes the views of Selectors synchronize, as well as rendering Selectors when loading the notebook.

To accomodate for potential different types in the x-scale and y-scale of the 2d `BrushSelector`, its `selected` attribute is split into `selected_x` and `selected_y`. `BrushSelector.selected` is still available for backwards compatibility.