### PR TITLE
aligning label to be in the center

### DIFF
--- a/js/src/Label.js
+++ b/js/src/Label.js
@@ -124,6 +124,7 @@ var Label = scatterbase.ScatterBase.extend({
         var that = this;
         this.d3el.selectAll(".object_grp")
             .select("text")
+            .attr("dominant-baseline", "central")
             .style("font-size", function(d, i) {
                 return that.get_element_size(d);
             })


### PR DESCRIPTION
This fix aligns labels to be in the center of a rectangle (for e.g. in GridHeatMap if we add labels they are not aligned in center)