### PR TITLE
Add tick_transform parameter

### DIFF
--- a/bqplot/axes.py
+++ b/bqplot/axes.py
@@ -111,6 +111,8 @@ class Axis(BaseAxis):
         Dictionary containing the CSS-style of the text for the ticks.
         For example: font-size of the text can be changed by passing
         `{'font-size': 14}`
+    tick_rotate: int (default: 0)
+        Degrees to rotate tick labels by.
     """
     icon = 'fa-arrows'
     orientation = Enum(['horizontal', 'vertical'], default_value='horizontal')\
@@ -136,6 +138,7 @@ class Axis(BaseAxis):
 
     visible = Bool(True).tag(sync=True)
     tick_style = Dict().tag(sync=True)
+    tick_rotate = Int(0).tag(sync=True)
 
     _view_name = Unicode('Axis').tag(sync=True)
     _model_name = Unicode('AxisModel').tag(sync=True)

--- a/js/src/AxisModel.js
+++ b/js/src/AxisModel.js
@@ -45,7 +45,8 @@ var AxisModel = basemodel.BaseModel.extend({
             color: null,
             label_offset: null,
             visible: true,
-            tick_style: {}
+            tick_style: {},
+            tick_rotate: 0
         });
     },
 


### PR DESCRIPTION
I’ll follow up with a more comprehensive reworking later, but wanted to at least get the main fixes in for now:
- Added `tick_transform` parameter, which allows users to rotate the tick axis labels: 
   - `tick_transform = {‘rotate’: -35}`
   `tick_style = {'text-anchor': 'end'}`
- Fixed several state management issues that caused the ticks to be redrawn incorrectly if attributes such as `tick_style` are modified after the plot was created.