### PR TITLE
Fix widget in the documentation

### DIFF
--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -153,9 +153,12 @@ def show(key=None, display_toolbar=True):
     if display_toolbar:
         if not hasattr(figure, 'pyplot'):
             figure.pyplot = Toolbar(figure=figure)
-        display(VBox([figure, figure.pyplot]))
+        vbox = VBox([figure, figure.pyplot])
+        display(vbox)
+        return vbox
     else:
         display(figure)
+        return figure
 
 
 def figure(key=None, fig=None, **kwargs):

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -19,7 +19,7 @@ Using the pyplot API
     x = np.linspace(0.0, 10.0, n)
     y = np.cumsum(np.random.randn(n))
     plt.plot(x, y)
-    plt.show()
+    plt.show(display_toolbar=False)
 
 Using the bqplot internal object model
 


### PR DESCRIPTION
The show function now returns the displayed widget, it is needed by `jupyter-sphinx` because it checks the return value of the last line of code: https://github.com/jupyter-widgets/jupyter-sphinx/blob/master/jupyter_sphinx/embed_widgets.py#L208