### PR TITLE
Do light/dark styling with JupyterLab theming system.

### DIFF
--- a/js/src/bqplot.less
+++ b/js/src/bqplot.less
@@ -143,7 +143,7 @@
 
 }
 
-.theme-light {
+.theme-light, [data-theme-light="true"] {
     .common();
     .bqplot > svg {
         .axis {
@@ -244,7 +244,7 @@
 /* by default, activate theme-light*/
 .theme-light();
 
-.theme-dark {
+.theme-dark, [data-theme-light="false"] {
     .common();
     .bqplot > svg {
         background: #1a1a1a;


### PR DESCRIPTION
This enables the dark theme on JupyterLab:

<img width="714" alt="screen shot 2018-09-17 at 9 40 55 pm" src="https://user-images.githubusercontent.com/192614/45664851-f44e6400-bac2-11e8-9ab8-9fcf7200a2d4.png">
