### PR TITLE
ColorScale extrapolation option

### DIFF
--- a/bqplot/scales.py
+++ b/bqplot/scales.py
@@ -483,6 +483,8 @@ class ColorScale(Scale):
         if not None, mid is the value corresponding to the mid color.
     scheme: string (default: 'RdYlGn')
         Colorbrewer color scheme of the color scale.
+    extrapolation: {'constant', 'linear'} (default: 'constant')
+        How to extrapolate values outside the [min, max] domain.
     rtype: string (class-level attribute)
         The range type of a color scale is 'Color'. This should not be modifed.
     dtype: type (class-level attribute)
@@ -497,6 +499,7 @@ class ColorScale(Scale):
     max = Float(None, allow_none=True).tag(sync=True)
     mid = Float(None, allow_none=True).tag(sync=True)
     scheme = Unicode('RdYlGn').tag(sync=True)
+    extrapolation = Enum(['constant', 'linear'], default_value='constant').tag(sync=True)
 
     _view_name = Unicode('ColorScale').tag(sync=True)
     _model_name = Unicode('ColorScaleModel').tag(sync=True)

--- a/js/src/ColorScale.js
+++ b/js/src/ColorScale.js
@@ -19,7 +19,8 @@ var scale = require("./Scale");
 var ColorScale = scale.Scale.extend({
 
     render: function(){
-        this.create_d3_scale()
+        this.create_d3_scale();
+        this.update_extrapolation();
         if(this.model.domain.length > 0) {
             this.scale.domain(this.model.domain);
         }
@@ -35,6 +36,13 @@ var ColorScale = scale.Scale.extend({
     create_event_listeners: function() {
         ColorScale.__super__.create_event_listeners.apply(this);
         this.listenTo(this.model, "colors_changed", this.set_range, this);
+        this.model.on("change:extrapolation", function() {
+            this.update_extrapolation();
+            this.trigger("color_scale_range_changed"); }, this);
+    },
+
+    update_extrapolation: function() {
+        this.scale.clamp((this.model.get("extrapolation") === "constant"));
     },
 
     set_range: function() {

--- a/js/src/GridHeatMap.js
+++ b/js/src/GridHeatMap.js
@@ -47,6 +47,16 @@ var GridHeatMap = mark.Mark.extend({
         });
     },
 
+    initialize_additional_scales: function() {
+        var color_scale = this.scales.color;
+        if(color_scale) {
+            this.listenTo(color_scale, "domain_changed", function() {
+                this.apply_styles();
+            });
+            color_scale.on("color_scale_range_changed", this.apply_styles, this);
+        }
+    },
+
     set_ranges: function() {
         var row_scale = this.scales.row;
         if(row_scale) {


### PR DESCRIPTION
Adds an attribute `extrapolation` to deal with values outside of a `ColorScale`'s domain. It can be one of 2 values:
- `constant` (default): values outside of the domain will be mapped to the min_color or max_color.
- `linear` (previous default): Linear extrapolation from the 2 last (and 2 first) values of the `ColorScale`



Collateral fix: `GridHeatMap` now listens to changes in its color scale