### PR TITLE
WIP: Added a more general ToolbarWidget

### DIFF
--- a/bqplot/toolbar.py
+++ b/bqplot/toolbar.py
@@ -26,10 +26,10 @@ Toolbar
    Toolbar
 """
 
-from traitlets import Unicode, Instance, Bool
-from ipywidgets import DOMWidget, register, widget_serialization
+from traitlets import Unicode, Instance, Bool, CInt, List, Tuple
+from ipywidgets import Widget, DOMWidget, Button, register, widget_serialization
 
-from .interacts import PanZoom
+from .interacts import Interaction, PanZoom
 from .figure import Figure
 from ._version import __frontend_version__
 
@@ -74,6 +74,22 @@ class Toolbar(DOMWidget):
 
     _view_name = Unicode('Toolbar').tag(sync=True)
     _model_name = Unicode('ToolbarModel').tag(sync=True)
+    _view_module = Unicode('bqplot').tag(sync=True)
+    _model_module = Unicode('bqplot').tag(sync=True)
+    _view_module_version = Unicode(__frontend_version__).tag(sync=True)
+    _model_module_version = Unicode(__frontend_version__).tag(sync=True)
+
+
+class ToolbarWidget(Widget):
+    child = Instance(DOMWidget, allow_none=True).tag(sync=True, **widget_serialization)
+    actions = List(Tuple(Instance(Button), Unicode())).tag(sync=True, **widget_serialization)
+    toolbar_widgets = List(Instance(DOMWidget), allow_none=True).tag(sync=True, **widget_serialization)
+    interacts = List(Instance(Interaction)).tag(sync=True, **widget_serialization)
+    interact_index = CInt(None, allow_none=True).tag(sync=True)
+    interact = Instance(Interaction, default_value=None, allow_none=True).tag(sync=True,  **widget_serialization)
+
+    _view_name = Unicode('ToolbarWidget').tag(sync=True)
+    _model_name = Unicode('ToolbarWidgetModel').tag(sync=True)
     _view_module = Unicode('bqplot').tag(sync=True)
     _model_module = Unicode('bqplot').tag(sync=True)
     _view_module_version = Unicode(__frontend_version__).tag(sync=True)

--- a/js/src/ToolbarWidget.js
+++ b/js/src/ToolbarWidget.js
@@ -1,0 +1,159 @@
+/* Copyright 2015 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var widgets = require("@jupyter-widgets/base");
+var phosphor_widget = require('@phosphor/widgets');
+var phosphor_messaging = require('@phosphor/messaging');
+var screenfull = require("screenfull")
+
+var _ = require("underscore");
+var semver_range = "^" + require("../package.json").version;
+
+var ToolbarWidgetModel = widgets.DOMWidgetModel.extend({
+
+    defaults: function() {
+        return _.extend(widgets.DOMWidgetModel.prototype.defaults(), {
+            _model_name: "ToolbarWidgetModel",
+            _view_name: "ToolbarWidget",
+            _model_module: "bqplot",
+            _view_module: "bqplot",
+            _model_module_version: semver_range,
+            _view_module_version: semver_range,
+
+            // figure: null,
+            interacts: [],
+            interact_active: null,
+            interact_index: null,
+        });
+    },
+    initialize: function() {
+        ToolbarWidgetModel.__super__.initialize.apply(this, arguments);
+        this.on('change:interact_index', () => {
+            var interacts = this.get('interacts');
+            if(!interacts) {
+                console.error('interacts is null');
+                return;
+            }
+            var index = this.get('interact_index')
+            if(index === null) {
+                this.set('interact_active', null);
+                this.save_changes();
+                return;
+            }
+            if((index < 0) || (index >= interacts.length)) {
+                console.error('interact_index out of bound')
+                return;
+            }
+            console.log('set', interacts[index])
+            this.set('interact', interacts[index]);
+            this.save_changes();
+        })
+    }
+
+
+}, {
+    serializers: _.extend({
+        child: { deserialize: widgets.unpack_models },
+        actions: { deserialize: widgets.unpack_models },
+        toolbar_widgets: { deserialize: widgets.unpack_models },
+        interacts: { deserialize: widgets.unpack_models },
+        interact: { deserialize: widgets.unpack_models },
+    }, widgets.DOMWidgetModel.serializers)
+});
+
+var ToolbarWidget = widgets.DOMWidgetView.extend({
+
+    fullscreen: function() {
+        var el = this.childView.el;
+        var old_width = el.style.width
+        var old_height = el.style.height
+        var restore = () => {
+            if(!screenfull.isFullscreen) {
+                el.style.width = old_width;
+                el.style.height = old_height
+                screenfull.off('change', restore)
+            } else {
+                el.style.width = '100vw'
+                el.style.height = '100vh'
+            }
+            phosphor_messaging.MessageLoop.postMessage(this.childView.pWidget, phosphor_widget.Widget.ResizeMessage.UnknownSize);
+        }
+        screenfull.onchange(restore)
+        screenfull.request(el);
+
+    },
+    render: function() {
+        this.el.classList.add("jupyter-widgets");
+        this.el.classList.add('widget-container')
+        // this.el.classList.add('widget-box')
+        this.el_toolbar = document.createElement('div')
+        this.el_content = document.createElement('div')
+        this.el_toolbar.classList.add('jupyter-widgets')
+        this.el_toolbar.classList.add('widget-container')
+        this.el.appendChild(this.el_toolbar)
+        this.el.appendChild(this.el_content)
+        
+        var toolbarWidgetsViewList = new widgets.ViewList((model, index) => {
+            var viewPromise = this.create_child_view(model);
+            viewPromise.then((view) => {
+                this.el_toolbar.appendChild(view.el)
+            })
+
+        }, () => {
+
+        });
+        toolbarWidgetsViewList.update(this.model.get('toolbar_widgets'));
+
+
+        var actionButtonViewList = new widgets.ViewList((model, index) => {
+            var viewPromise = this.create_child_view(model);
+            viewPromise.then((view) => {
+                // iew.listenTo(view.model, 'click', () => {
+                view.el.onclick = () => {
+                    console.log('click', index)
+                    var handler_name = this.model.get('actions')[index][1];
+                    if(this.childView[handler_name]) {
+                        this.childView[handler_name]()
+                    } else if(this[handler_name]) {
+                        this[handler_name]();
+                    } else if(!handler) {
+                        console.log('no event handler found for', handler_name);
+                        return;
+                    }
+
+                }
+                this.el_toolbar.appendChild(view.el)
+            })
+
+        }, () => {
+
+        });
+        actionButtonViewList.update(this.model.get('actions').map((tuple) => tuple[0]));
+
+
+
+        this.create_child_view(this.model.get("child")).then((view) => {
+            this.childView = view;
+            this.el_content.appendChild(view.el)
+            phosphor_messaging.MessageLoop.postMessage(view.pWidget, phosphor_widget.Widget.ResizeMessage.UnknownSize);
+        })
+});
+
+
+
+module.exports = {
+    ToolbarWidget: ToolbarWidget,
+    ToolbarWidgetModel: ToolbarWidgetModel
+};

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -86,6 +86,7 @@ var loadedModules = [
     require("./HeatMap"),
     require("./HeatMapModel"),
     require("./Toolbar"),
+    require("./ToolbarWidget"),
     require("./GraphModel"),
     require("./Graph"),
     require("./Image"),

--- a/toolbar.ipynb
+++ b/toolbar.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import bqplot\n",
+    "import ipywidgets as widgets\n",
+    "import glue.icons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "icon_brush = widgets.Icon.from_file(glue.icons.icon_path('glue_square', icon_format='svg'))\n",
+    "icon_pan = widgets.Icon.from_file(glue.icons.icon_path('glue_move', icon_format='svg'))\n",
+    "icon_brush_x = widgets.Icon.from_file(glue.icons.icon_path('glue_xrange_select', icon_format='svg'))\n",
+    "icon_brush_y = widgets.Icon.from_file(glue.icons.icon_path('glue_yrange_select', icon_format='svg'))\n",
+    "icon_brush_lasso = widgets.Icon.from_file(glue.icons.icon_path('glue_lasso', icon_format='svg'))\n",
+    "\n",
+    "icons = [icon_pan, icon_brush, icon_brush_x, icon_brush_y, icon_brush_lasso]\n",
+    "toggle_buttons = widgets.ToggleButtons(options=['Pan/zoom', 'Brush'], icons=icons)\n",
+    "\n",
+    "\n",
+    "button_png = widgets.Button(description='png', icon='save')\n",
+    "button_svg = widgets.Button(description='svg', icon='save')\n",
+    "fullscreen = widgets.Button(description='', icon='arrows-alt')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for icon in icons:\n",
+    "    icon.width = 24"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import bqplot.pyplot as plt\n",
+    "import ipywidgets as widgets\n",
+    "import numpy as np\n",
+    "import bqplot\n",
+    "fig = plt.figure()\n",
+    "x = np.linspace(0, 2, 10)\n",
+    "y = x**2\n",
+    "s = plt.scatter(x, y, display_legend=True)\n",
+    "# s = plt.scatter(x, y+0.2, display_legend=True)\n",
+    "# s.unselected_style = {'fill': 'red', 'stroke': 'none'} # now unselected points are red again\n",
+    "s.selected_style = {'fill': 'orange', 'stroke': 'blue'} # now unselected points are red again\n",
+    "# plt.show()\n",
+    "# s.selected = [1,4,6]\n",
+    "# s.unselected_style = {'fill': 'orange', 'stroke': 'none'}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "marks = [s]\n",
+    "scale_x = s.scales['x']\n",
+    "scale_y = s.scales['y']\n",
+    "in1 = bqplot.PanZoom(scales={'x': [scale_x], 'y': [scale_y]})\n",
+    "in2 = bqplot.interacts.BrushSelector(x_scale=scale_x, y_scale=scale_y, marks=marks)\n",
+    "brush_x = bqplot.interacts.BrushIntervalSelector(scale=scale_x, color=\"green\", marks=marks)\n",
+    "brush_y = bqplot.interacts.BrushIntervalSelector(scale=scale_y, color=\"green\", orientation='vertical', marks=marks)\n",
+    "lasso = bqplot.interacts.LassoSelector(x_scale=scale_x, y_scale=scale_y, marks=marks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "toggle_buttons = widgets.ToggleButtons(options=[(' ' * k, str(k)) for k in range(len(icons))], icons=icons)\n",
+    "tbw = bqplot.ToolbarWidget(actions=[(button_png, 'save_png'), (button_svg, 'save_svg'), (fullscreen, 'fullscreen')],\n",
+    "                           child=fig,\n",
+    "                          interacts=[in1, in2, brush_x, brush_y, lasso],\n",
+    "                          toolbar_widgets=[toggle_buttons])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "widgets.jslink((toggle_buttons, 'index'), (tbw, 'interact_index'))\n",
+    "widgets.jslink((tbw, 'interact'), (fig, 'interaction'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.layout.min_width = '500px'\n",
+    "fig.layout.min_height = '500px'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tbw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "button.icon = 'save'\n",
+    "button.description = 'png'\n",
+    "fullscreen.icon = 'arrows-alt'\n",
+    "fullscreen.description = ''\n",
+    "fullscreen.layout.width = '52px'\n",
+    "fullscreen.layout.max_width = '50px'\n",
+    "fullscreen.layout.min_width = '50px'\n",
+    "fullscreen.layout.visibility = 'visible'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "toggle_buttons.style.button_width = '50px'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This is more of an exploration of doing toolbars (for bqplot and ipyvolume) a different way.

By making a ToolbarWidget that is a container (it has a single child widget), it can create a view of that child widget and send it messages (save to png, fullscreen).
What is does now as well, is keep a list of Interacts, and the current index and current value, which can be linked to a ToggleButtons widgets. I think a more general approach of this is to have a 'WidgetList' widget, that will keep a list, an index, and a current widget.

cc @astrofrog
In the attached screenshot (or the toolbar notebook) I used the glue icon using this PR https://github.com/jupyter-widgets/ipywidgets/pull/2182
<img width="1033" alt="screen shot 2018-09-28 at 16 31 19" src="https://user-images.githubusercontent.com/1765949/46215285-4dc55700-c33d-11e8-91d9-7f44345ef149.png">

Maybe we should talk about using/including/modifying these icons, for a uniform UI for bqplot/ipyvolume/glue-jupyter