### PR TITLE
New: scaling up of png images and have a good default for high dpi screens

### DIFF
--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -161,7 +161,7 @@ class Figure(DOMWidget):
     def _default_scale_y(self):
         return LinearScale(min=0, max=1, allow_padding=False)
 
-    def save_png(self, filename='bqplot.png'):
+    def save_png(self, filename='bqplot.png', scale=None):
         '''
         Saves the Figure as a PNG file
 
@@ -169,8 +169,10 @@ class Figure(DOMWidget):
         ----------
         filename: str (default: 'bqplot.png')
             name of the saved file
+        scale: float (default: None)
+            Scale up the png resolution when scale > 1, when not given base this on the screen pixel ratio.
         '''
-        self.send({"type": "save_png", "filename": filename})
+        self.send({'type': 'save_png', 'filename': filename, 'scale': scale})
 
     def save_svg(self, filename='bqplot.svg'):
         '''

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -849,17 +849,26 @@ var Figure = widgets.DOMWidgetView.extend({
 
     },
 
-    save_png: function(filename) {
+    save_png: function(filename, scale) {
        
-       // Render a SVG data into a canvas and download as PNG.
+            // scale up the underlying canvas for high dpi screens
+            // such that image is of the same quality
+            scale = scale || window.devicePixelRatio;
+    
+            // Render a SVG data into a canvas and download as PNG.
+
+    // Render a SVG data into a canvas and download as PNG.
         this.get_svg().then((xml) => {
             var image = new Image();
             image.onload = () => {
                 var canvas = document.createElement("canvas");
                 canvas.classList.add('bqplot');
-                canvas.width = this.width;
-                canvas.height = this.height;
+                canvas.width = this.width * scale;
+                canvas.height = this.height * scale;
+                canvas.style.width = this.width;
+                canvas.style.height = this.height;
                 var context = canvas.getContext("2d");
+                context.scale(scale, scale);
                 context.drawImage(image, 0, 0);
                 var a = document.createElement("a");
                 a.download = filename || "image.png";

--- a/js/src/FigureModel.js
+++ b/js/src/FigureModel.js
@@ -67,7 +67,7 @@ var FigureModel = basemodel.BaseModel.extend({
 
     handle_custom_messages: function(msg) {
         if (msg.type === 'save_png') {
-            this.trigger("save_png", msg.filename);
+            this.trigger("save_png", msg.filename, msg.scale);
         }
         else if (msg.type === 'save_svg') {
             this.trigger("save_svg", msg.filename);


### PR DESCRIPTION
by default, it matches what you see on the screen, for instance on a mac with `window.devicePixelRatio == 2` it will give you an image of twice the resolution.