### PR TITLE
Support arrays with object type if they are all strings

### DIFF
--- a/bqplot/traits.py
+++ b/bqplot/traits.py
@@ -33,6 +33,8 @@ import numpy as np
 import pandas as pd
 import warnings
 import datetime as dt
+import six
+import warnings
 
 # Date
 
@@ -140,6 +142,20 @@ def array_from_json(value, obj=None):
 def array_to_json(ar, obj=None, force_contiguous=True):
     if ar is None:
         return None
+    if ar.dtype.kind in ['O']:
+        has_strings = False
+        all_strings = True  # empty array we can interpret as an empty list
+        for el in ar:
+            if isinstance(el, six.string_types):
+                has_strings = True
+            else:
+                all_strings = False
+        if all_strings:
+            ar = ar.astype('U')
+        else:
+            if has_strings:
+                warnings.warn('Your array contains mixed strings and other types')
+
     if ar.dtype.kind in ['S', 'U']:  # strings to as plain json
         return ar.tolist()
     type = None

--- a/tests/binary_serialization_test.py
+++ b/tests/binary_serialization_test.py
@@ -1,5 +1,8 @@
 import bqplot
 import numpy as np
+from bqplot.traits import array_to_json
+import pytest
+
 
 def test_binary_serialize_1d(figure):
     x = np.arange(10, dtype=np.float64)
@@ -60,3 +63,14 @@ def test_binary_serialize_text():
 
     assert label2.text.tolist() == label.text.tolist()
 
+def test_dtype_with_str():
+    # dtype object is not supported
+    text = np.array(['foo', None, 'bar'])
+    assert text.dtype == np.object
+    with pytest.raises(ValueError, match='.*unsupported dtype: object.*'), pytest.warns(UserWarning):
+        array_to_json(text)
+    # but if they contain all strings, it should convert them.
+    # This is for backward compatibility of expecting pandas dataframe
+    # string columns to work (which are of dtype==np.object)
+    text[1] = 'foobar'
+    assert array_to_json(text) == ['foo', 'foobar', 'bar']


### PR DESCRIPTION
Since pandas is using dtype=object for strings, we need to support that again.
This makes the Wealth of Nations work again.
