### PR TITLE
Fix/workaround for when nan's enter brush selector causing infinite loop

### DIFF
--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -42,7 +42,7 @@ from traittypes import Array
 from ipywidgets import Widget, Color, widget_serialization, register
 
 from .scales import Scale, DateScale
-from .traits import Date, array_serialization
+from .traits import Date, array_serialization, _array_equal
 from .marks import Lines
 from ._version import __frontend_version__
 import numpy as np
@@ -435,9 +435,12 @@ class BrushSelector(TwoDSelector):
             (x0, y0), (x1, y1) = value
             x = [x0, x1]
             y = [y0, y1]
+
             with self.hold_sync():
-                self.selected_x = None if np.isnan(x).any() else x
-                self.selected_y = None if np.isnan(y).any() else y
+                if not _array_equal(self.selected_x, x):
+                    self.selected_x = x
+                if not _array_equal(self.selected_y, y):
+                    self.selected_y =y
 
     _view_name = Unicode('BrushSelector').tag(sync=True)
     _model_name = Unicode('BrushSelectorModel').tag(sync=True)

--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -436,8 +436,8 @@ class BrushSelector(TwoDSelector):
             x = [x0, x1]
             y = [y0, y1]
             with self.hold_sync():
-                self.selected_x = x
-                self.selected_y = y
+                self.selected_x = None if np.isnan(x).any() else x
+                self.selected_y = None if np.isnan(y).any() else y
 
     _view_name = Unicode('BrushSelector').tag(sync=True)
     _model_name = Unicode('BrushSelectorModel').tag(sync=True)

--- a/bqplot/traits.py
+++ b/bqplot/traits.py
@@ -223,3 +223,10 @@ def series_to_json(value, obj):
     return value.to_dict()
 
 series_serialization = dict(to_json=series_to_json, from_json=series_from_json)
+
+def _array_equal(a, b):
+    """Really tests if arrays are equal, where nan == nan == True"""
+    try:
+        return np.allclose(a, b, 0, 0, equal_nan=True)
+    except (TypeError, ValueError):
+        return False

--- a/tests/selector_test.py
+++ b/tests/selector_test.py
@@ -1,5 +1,6 @@
 import bqplot
 from mock import Mock
+import numpy as np
 
 def test_brush_selector():
     selector = bqplot.interacts.BrushSelector()
@@ -40,4 +41,26 @@ def test_brush_selector():
     selector.selected_y = None
     assert selector.selected is None
     assert selector.selected_x is None
+    assert selector.selected_y is None
+
+    selector.selected = [[np.nan, 4], [5, 6]]
+    assert selector.selected_x is None
+    assert selector.selected_y.tolist() == [4, 6]
+
+    selector.selected = [[3, np.nan], [5, 6]]
+    assert selector.selected_x.tolist() == [3, 5]
+    assert selector.selected_y is None
+
+    selector.selected = [3, 4], [5, 6]
+    assert selector.selected_x.tolist() == [3, 5]
+    assert selector.selected_y.tolist() == [4, 6]
+    selector.selected_x = [3, np.nan]
+    assert selector.selected_x is None
+    assert selector.selected_y.tolist() == [4, 6]
+    selector.selected = [3, 4], [5, 6]
+    assert selector.selected_x.tolist() == [3, 5]
+    assert selector.selected_y.tolist() == [4, 6]
+
+    selector.selected_y = [4, np.nan]
+    assert selector.selected_x.tolist() == [3, 5]
     assert selector.selected_y is None

--- a/tests/selector_test.py
+++ b/tests/selector_test.py
@@ -1,6 +1,8 @@
 import bqplot
 from mock import Mock
 import numpy as np
+from bqplot.traits import _array_equal
+
 
 def test_brush_selector():
     selector = bqplot.interacts.BrushSelector()
@@ -44,23 +46,23 @@ def test_brush_selector():
     assert selector.selected_y is None
 
     selector.selected = [[np.nan, 4], [5, 6]]
-    assert selector.selected_x is None
-    assert selector.selected_y.tolist() == [4, 6]
+    assert _array_equal(selector.selected_x.tolist(), [np.nan, 5])
+    assert _array_equal(selector.selected_y.tolist(), [4, 6])
 
     selector.selected = [[3, np.nan], [5, 6]]
-    assert selector.selected_x.tolist() == [3, 5]
-    assert selector.selected_y is None
+    assert _array_equal(selector.selected_x.tolist(), [3, 5])
+    assert _array_equal(selector.selected_y.tolist(), [np.nan, 6])
 
     selector.selected = [3, 4], [5, 6]
-    assert selector.selected_x.tolist() == [3, 5]
-    assert selector.selected_y.tolist() == [4, 6]
+    assert _array_equal(selector.selected_x.tolist(), [3, 5])
+    assert _array_equal(selector.selected_y.tolist(), [4, 6])
     selector.selected_x = [3, np.nan]
-    assert selector.selected_x is None
-    assert selector.selected_y.tolist() == [4, 6]
+    assert _array_equal(selector.selected_x.tolist(), [3, np.nan])
+    assert _array_equal(selector.selected_y.tolist(), [4, 6])
     selector.selected = [3, 4], [5, 6]
-    assert selector.selected_x.tolist() == [3, 5]
-    assert selector.selected_y.tolist() == [4, 6]
+    assert _array_equal(selector.selected_x.tolist(), [3, 5])
+    assert _array_equal(selector.selected_y.tolist(), [4, 6])
 
     selector.selected_y = [4, np.nan]
-    assert selector.selected_x.tolist() == [3, 5]
-    assert selector.selected_y is None
+    assert _array_equal(selector.selected_x.tolist(), [3, 5])
+    assert _array_equal(selector.selected_y.tolist(), [4, np.nan])


### PR DESCRIPTION
Because of https://github.com/jupyter-widgets/traittypes/issues/30 selected and selected_x keep updating each other, if they contain a nan.