### PR TITLE
Extend fill_opacities to patches

### DIFF
--- a/examples/Marks/Object Model/Lines.ipynb
+++ b/examples/Marks/Object Model/Lines.ipynb
@@ -82,7 +82,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import numpy as np #For numerical programming and multi-dimensional arrays\n",
@@ -100,7 +102,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "security_1 = np.cumsum(np.random.randn(150)) + 100.\n",
@@ -150,7 +154,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "line.colors = ['DarkOrange']"
@@ -187,6 +193,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To switch to an area chart, set the `fill` attribute, and control the look with `fill_opacities` and `fill_colors`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "line.fill = 'bottom'\n",
+    "line.fill_opacities = [0.2]"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -218,7 +243,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "line.marker = 'triangle-down'"
@@ -311,7 +338,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "dates_new = date_range(start='06-01-2007', periods=150)"
@@ -332,7 +361,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# We pass the color scale and the color data to the lines\n",
@@ -363,7 +394,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "line.x, line.y = [dates, dates_new], [security_1, security_2]"
@@ -386,7 +419,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "x_dt = DateScale()\n",
@@ -454,7 +489,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "line.color = None"
@@ -503,28 +540,6 @@
    },
    "outputs": [],
    "source": [
-    "patch.fill = 'top'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "patch.fill = 'bottom'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
     "patch.opacities = [0.1, 0.2]"
    ]
   },
@@ -542,41 +557,33 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#patch.fill=['', 'blue']\n",
-    "patch.close_path = False"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "patch.close_path = False"
+   ]
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Pyplot/Lines.ipynb
+++ b/examples/Marks/Pyplot/Lines.ipynb
@@ -53,9 +53,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -69,9 +67,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -81,10 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Basic Line Chart"
    ]
@@ -92,11 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(title='Security 1')\n",
@@ -108,10 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "**We can explore the different attributes by changing each of them for the plot above:**"
    ]
@@ -120,9 +106,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -131,10 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "In a similar way, we can also change any attribute after the plot has been displayed to change the plot. Run each of the cells below, and try changing the attributes to explore the different features and how they affect the plot."
    ]
@@ -143,9 +124,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -157,9 +136,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -167,12 +144,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To switch to an area chart, set the `fill` attribute, and control the look with `fill_opacities` and `fill_colors`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "line.fill = 'bottom'\n",
+    "line.fill_opacities = [0.2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -183,9 +177,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -194,10 +186,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "While a `Lines` plot allows the user to extract the general shape of the data being plotted, there may be a need to visualize discrete data points along with this shape. This is where the `markers` attribute comes in."
    ]
@@ -206,9 +195,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -217,10 +204,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The `marker` attributes accepts the values `square`, `circle`, `cross`, `diamond`, `square`, `triangle-down`, `triangle-up`, `arrow`, `rectangle`, `ellipse`. Try changing the string above and re-running the cell to see how each `marker` type looks."
    ]
@@ -228,9 +212,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "source": [
     "## Plotting a Time-Series"
@@ -238,10 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The `DateScale` allows us to plot time series as a `Lines` plot conveniently with most `date` formats."
    ]
@@ -250,9 +229,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -263,11 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(title='Time Series')\n",
@@ -279,20 +252,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Plotting multiples sets of data"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The `Lines` mark allows the user to plot multiple `y`-values for a single `x`-value. This can be done by passing an `ndarray` or a list of the different `y`-values as the y-attribute of the `Lines` as shown below."
    ]
@@ -301,9 +268,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -312,10 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We pass each data set as an element of a `list`"
    ]
@@ -323,11 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure()\n",
@@ -341,10 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Similarly, we can also pass multiple `x`-values for multiple sets of `y`-values"
    ]
@@ -353,9 +308,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -364,20 +317,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Coloring Lines according to data"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The `color` attribute of a `Lines` mark can also be used to encode one more dimension of data. Suppose we have a portfolio of securities and we would like to color them based on whether we have bought or sold them. We can use the `color` attribute to encode this information."
    ]
@@ -385,11 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure()\n",
@@ -404,9 +347,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -417,9 +358,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -431,11 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# We pass the color scale and the color data to the plot method\n",
@@ -446,10 +381,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We can also reset the colors of the Line to their defaults by setting the `color` attribute to `None`."
    ]
@@ -458,9 +390,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -469,20 +399,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Patches"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The `fill` attribute of the `Lines` mark allows us to fill a path in different ways, while the `fill_colors` attribute lets us control the color of the `fill`"
    ]
@@ -490,11 +414,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(animation_duration=1000)\n",
@@ -515,35 +435,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "patch.fill = 'top'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "patch.fill = 'bottom'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -554,9 +446,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -567,9 +457,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -580,21 +468,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -9222,10 +9222,22 @@
       "dev": true,
       "optional": true
     },
+<<<<<<< HEAD
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+=======
+    "three": {
+      "version": "0.91.0",
+      "resolved": "http://registry.npmjs.org/three/-/three-0.91.0.tgz",
+      "integrity": "sha512-dzikzdcddNROFZi3vkbV8YonBmqnonbJv2FxlQBEE2wKzZutddnjiS8qBZG2+EB40l505Xw8OMClQm+GmbwI/g=="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+>>>>>>> package-lock
       "dev": true
     },
     "tunnel-agent": {

--- a/js/src/Lines.js
+++ b/js/src/Lines.js
@@ -189,36 +189,39 @@ var Lines = mark.Mark.extend({
         // update curve colors
         var curves = this.d3el.selectAll(".curve")
         curves.select(".line")
-            .style("opacity", function(d, i) { return opacities[i]; })
-            .style("stroke", function(d, i) {
-                return that.get_element_color(d, i) || fill_color[i];
-            })
-            .style("fill", function(d, i) {
-                return fill === "inside" ? that.get_fill_color(d, i) : "";
-            });
+          .style("opacity", function(d, i) { return opacities[i]; })
+          .style("stroke", function(d, i) {
+              return that.get_element_color(d, i) || fill_color[i];
+          })
+          .style("fill", function(d, i) {
+              return fill === "inside" ? that.get_fill_color(d, i) : "";
+          })
+          .style("fill-opacity", function(d, i) {
+              return fill === "inside" ? fill_opacities[i] : "";
+          });
         curves.select(".area")
-            .style("fill", function(d, i) { return that.get_fill_color(d, i); })
-            .style("opacity", function(d, i) { return fill_opacities[i]; });
+          .style("fill", function(d, i) { return that.get_fill_color(d, i); })
+          .style("opacity", function(d, i) { return fill_opacities[i]; });
         this.update_marker_style();
         // update legend style
         if (this.legend_el){
             this.legend_el.select(".line")
-                .style("stroke", function(d, i) {
-                    return that.get_element_color(d, i) || fill_color[i];
-                })
-                .style("opacity", function(d, i) { return opacities[i]; })
-                .style("fill", function(d, i) {
-                    return that.model.get("fill") === "none" ?
-                        "" : that.get_fill_color(d, i);
-                })
+              .style("stroke", function(d, i) {
+                  return that.get_element_color(d, i) || fill_color[i];
+              })
+              .style("opacity", function(d, i) { return opacities[i]; })
+              .style("fill", function(d, i) {
+                  return that.model.get("fill") === "none" ?
+                      "" : that.get_fill_color(d, i);
+              });
             this.legend_el.select(".dot")
-                .style("stroke", function(d, i) {
-                    return that.get_element_color(d, i) || fill_color[i];
-                })
-                .style("opacity", function(d, i) { return opacities[i]; })
-                .style("fill", function(d, i) {
-                    return that.get_element_color(d, i) || fill_color[i];
-                });
+              .style("stroke", function(d, i) {
+                  return that.get_element_color(d, i) || fill_color[i];
+              })
+              .style("opacity", function(d, i) { return opacities[i]; })
+              .style("fill", function(d, i) {
+                  return that.get_element_color(d, i) || fill_color[i];
+              });
             this.legend_el.select("text")
               .style("fill", function(d, i) {
                   return that.get_element_color(d, i) || fill_color[i];


### PR DESCRIPTION
Fixes #747

Also adds an example of an area chart in the Lines example notebook. 