### PR TITLE
Figure: fix 'timing' issue with setting interact

### DIFF
--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -277,7 +277,11 @@ var Figure = widgets.DOMWidgetView.extend({
             that.model.on("change:title", that.update_title, that);
 
             that.model.on("change:interaction", function(model, value) {
-                this.set_interaction(value);
+                Promise.all(that.mark_views.views).then((views) => {
+                    // Like above:
+                    // This has to be done after the marks are created
+                    this.set_interaction(value);
+                })
             }, that);
 
             that.displayed.then(function(args) {


### PR DESCRIPTION
When doing
```
fig = Figure(...)
fig.interaction = ...
```
It used to follow a different code path compared to:
```
fig = Figure(interaction=...)
```
The former sometimes caused (together with https://github.com/bloomberg/bqplot/pull/754) an Infinity to end up at the yscale of the interaction, and would never be set again, causing NaN's to appear at `selected_y` exposing #751 and/or https://github.com/jupyter-widgets/traittypes/issues/30. 
This fixes it, by following the same code path as the latter example.
