### PR TITLE
Expose/fix python2.7 issue with binary deserialization

### DIFF
--- a/bqplot/traits.py
+++ b/bqplot/traits.py
@@ -131,10 +131,13 @@ def array_from_json(value, obj=None):
             else:
                 return np.array(value)
         elif 'value' in value:
-            # this should not work
-            ar = np.frombuffer(value['value'], dtype=value['dtype']).reshape(value['shape'])
-            # this should
-            # ar = np.asarray(value['value'], dtype=value['dtype']).reshape(value['shape'])
+            try:
+                ar = np.frombuffer(value['value'], dtype=value['dtype']).reshape(value['shape'])
+            except AttributeError:
+                # in some python27/numpy versions it does not like the memoryview
+                # we go the .tobytes() route, but since i'm not 100% sure memory copying
+                # is happening or not, we one take this path if the above fails.
+                ar = np.frombuffer(value['value'].tobytes(), dtype=value['dtype']).reshape(value['shape'])
             if value.get('type') == 'date':
                 assert value['dtype'] == 'float64'
                 ar = ar.astype('datetime64[ms]')

--- a/bqplot/traits.py
+++ b/bqplot/traits.py
@@ -131,7 +131,10 @@ def array_from_json(value, obj=None):
             else:
                 return np.array(value)
         elif 'value' in value:
+            # this should not work
             ar = np.frombuffer(value['value'], dtype=value['dtype']).reshape(value['shape'])
+            # this should
+            # ar = np.asarray(value['value'], dtype=value['dtype']).reshape(value['shape'])
             if value.get('type') == 'date':
                 assert value['dtype'] == 'float64'
                 ar = ar.astype('datetime64[ms]')


### PR DESCRIPTION
The unittests should expose this on travis. It fails locally.