### PR TITLE
Fix boxplot redraw issues

### DIFF
--- a/js/src/Boxplot.js
+++ b/js/src/Boxplot.js
@@ -282,6 +282,7 @@ var Boxplot = mark.Mark.extend({
     },
 
     prepareBoxPlots: function () {
+        // Sets plot data on this.plotData and this.outlierData
 
         var auto_detect_outliers = this.model.get("auto_detect_outliers") !== false;
         var x_scale = this.scales.x;
@@ -290,6 +291,7 @@ var Boxplot = mark.Mark.extend({
        // convert the domain data to the boxes to be drawn on the screen
        // find the quantiles, min/max and outliers for the box plot
         this.plotData = [];
+        this.outlierData = [];
         for(var i = 0; i<this.model.mark_data.length; ++i) {
             var values = this.model.mark_data[i];
 
@@ -306,7 +308,6 @@ var Boxplot = mark.Mark.extend({
             var lowerBound = displayValue.boxLower + 1.5 * iqr;
             var upperBound = displayValue.boxUpper - 1.5 * iqr;
 
-            displayValue.outliers = [];
             displayValue.whiskerMax = Number.MAX_VALUE;
             displayValue.whiskerMin = Number.MIN_VALUE;
 
@@ -316,7 +317,8 @@ var Boxplot = mark.Mark.extend({
 
                // Find the outlier
                if (auto_detect_outliers && (plotY > lowerBound || plotY  < upperBound)) {
-                    displayValue.outliers.push(plotY);
+                   this.outlierData.push({x: x_scale.scale(values[0]),
+                                          y: plotY});
                } else {
                     // Find the whisker points max and min from normal data.
                     // ( exclude the outliers )
@@ -329,7 +331,6 @@ var Boxplot = mark.Mark.extend({
                     }
                }
             }
-
             this.plotData.push(displayValue);
         }
     },
@@ -337,21 +338,22 @@ var Boxplot = mark.Mark.extend({
     draw: function() {
         this.set_ranges();
         var x_scale = this.scales.x;
-        // get the visual representation of boxplots
+        // get the visual representation of boxplots, set as state
         this.prepareBoxPlots();
-        var plotData = this.plotData;
 
         // Draw the visual elements with data which was bound
-        this.draw_mark_paths(".boxplot", this.d3el, plotData);
+        this.draw_mark_paths(".boxplot", this.d3el);
         // Keep the pixel coordinates of the boxes, for interactions.
         this.x_pixels = this.model.mark_data.map(function(el) { return x_scale.scale(el[0]) + x_scale.offset; });
         var width = this.get_box_width() / 2;
-        this.pixel_coords = plotData.map(function(d) { return [[d.x - width, d.x + width],
-                                                               [d.boxLower, d.boxUpper]] })
+        this.pixel_coords = this.plotData.map(function(d) { return [[d.x - width, d.x + width],
+                                                                    [d.boxLower, d.boxUpper]] })
     },
 
-    draw_mark_paths: function(parentClass, selector, plotData) {
+    draw_mark_paths: function(parentClass, selector) {
         var that = this;
+        var plotData = this.plotData;
+        var outlierData = this.outlierData;
 
         var mark_max_width = this.calculate_mark_max_width();
         var color = this.model.get("color");
@@ -488,25 +490,29 @@ var Boxplot = mark.Mark.extend({
               return "M"  + (x - width/2) + "," +  minY +  " L" + (x + width/2) + "," +  minY;
           });
 
+          boxplot.exit().remove();
+
           // Add the outliers group
-          var outliers = selector.selectAll(".outliers").selectAll("circle")
-              .data(function(d) { return d.outliers;});
+          var outliers = selector.selectAll(".outlier")
+              .data(outlierData);
 
-          //Individual outlier drawing spec
-          outliers.enter().append("circle").attr("class", "outlier");
+          // Add/remove elements as needed
+          outliers.enter()
+            .append("circle")
+              .attr("class", "outlier");
+          outliers.exit()
+            .remove();
 
-          selector.selectAll(".outlier").data(plotData)
+          // Set outlier data
+          selector.selectAll(".outlier").data(outlierData)
               .style("fill", this.model.get("outlier_fill_color"))
-              .attr("class", "outlier")
-              .attr("cx", 0)
+              .attr("cx", function(d) {
+                return d.x + xOffset;
+              })
               .attr("r", 3)
               .attr("cy", function(d) {
-                return (d);
+                return d.y;
               });
-
-          outliers.exit().remove();
-
-          boxplot.exit().remove();
 
           this.apply_styles(this.selected_indices);
     },

--- a/js/src/Boxplot.js
+++ b/js/src/Boxplot.js
@@ -405,7 +405,7 @@ var Boxplot = mark.Mark.extend({
             xOffset = scaleX.scale.rangeBand() / 2;
         }
 
-        selector.selectAll(".boxplot")
+        selector.selectAll(".boxplot").data(plotData)
             .style("stroke", this.model.get("stroke"))
             .style("opacity", color)
             .attr ("transform", function (d, i) {
@@ -415,7 +415,7 @@ var Boxplot = mark.Mark.extend({
        //Box
         var width = this.get_box_width();
 
-        selector.selectAll(".box")
+        selector.selectAll(".box").data(plotData)
             .style("fill", fillcolor)
             .attr("x", -width /2)
             .attr("width", width)
@@ -427,7 +427,7 @@ var Boxplot = mark.Mark.extend({
             });
 
         //Median line
-        selector.selectAll(".median_line")
+        selector.selectAll(".median_line").data(plotData)
             .style("stroke-width", 2)
             .attr("d", function(d, i) {
 
@@ -440,7 +440,7 @@ var Boxplot = mark.Mark.extend({
 
           //Max and Min Whiskers
           //Max to top of the Box
-          selector.selectAll(".whisker_max")
+          selector.selectAll(".whisker_max").data(plotData)
               .attr("d", function(d, i) {
 
               var x = 0;
@@ -453,7 +453,7 @@ var Boxplot = mark.Mark.extend({
               return  "5,5";
            });
 
-          selector.selectAll(".whisker_max_end")
+          selector.selectAll(".whisker_max_end").data(plotData)
               .attr("d", function(d, i) {
 
               var x = 0;
@@ -465,7 +465,7 @@ var Boxplot = mark.Mark.extend({
 
           //Min to the bottom of the box
           //Max to top of the Box
-          selector.selectAll(".whisker_min")
+          selector.selectAll(".whisker_min").data(plotData)
               .attr("d", function(d, i) {
 
               var x = 0;
@@ -478,7 +478,7 @@ var Boxplot = mark.Mark.extend({
               return  "5,5";
           });
 
-          selector.selectAll(".whisker_min_end")
+          selector.selectAll(".whisker_min_end").data(plotData)
               .attr("d", function(d, i) {
 
               var x = 0;
@@ -495,7 +495,7 @@ var Boxplot = mark.Mark.extend({
           //Individual outlier drawing spec
           outliers.enter().append("circle").attr("class", "outlier");
 
-          selector.selectAll(".outlier")
+          selector.selectAll(".outlier").data(plotData)
               .style("fill", this.model.get("outlier_fill_color"))
               .attr("class", "outlier")
               .attr("cx", 0)


### PR DESCRIPTION
The boxplot mark was previously not responding to various state changes (new data, domain changing, etc), as not all of the selections were rebinding the data to the DOM elements. 
Fixes issue in #710, and some issues noted in #698.