### PR TITLE
Silence brush events on programmatic changes

### DIFF
--- a/js/src/BrushSelector.js
+++ b/js/src/BrushSelector.js
@@ -85,10 +85,10 @@ var BaseBrushSelector = {
     },
 
     _update_brush: function() {
-        // Programmatically setting the brush does not redraw it. It is
-        // being redrawn below
+        // Redraw the brush
         this.brushsel = this.d3el.call(this.brush);
-        this.d3el.call(this.brush.event);
+        // Trigger brushstart-move-end events
+        // this.d3el.call(this.brush.event);
     },
 
     clear_brush: function() {


### PR DESCRIPTION
Stop calling `brush_start/move/end` on programmatic brush changes, and just redraw the brush. I can't think of a use case where we would want those events to be triggered. 

Fixes #771