### PR TITLE
examples: correct link for FlexLine.ipynb

### DIFF
--- a/examples/Index.ipynb
+++ b/examples/Index.ipynb
@@ -78,7 +78,7 @@
     "* Bins: Backend histogram mark ([Object Model](Marks/Object%20Model/Bins.ipynb), [Pyplot](Marks/Pyplot/Bins.ipynb))\n",
     "* Boxplot: Boxplot mark ([Object Model](Marks/Object%20Model/Boxplot.ipynb), [Pyplot](Marks/Pyplot/Boxplot.ipynb))\n",
     "* Candles: OHLC mark ([Object Model](Marks/Object%20Model/Candles.ipynb), [Pyplot](Marks/Pyplot/Candles.ipynb))\n",
-    "* FlexLine: Flexible lines mark ([Object Model](Marks/Object%20Model/Flexline.ipynb), Pyplot)\n",
+    "* FlexLine: Flexible lines mark ([Object Model](Marks/Object%20Model/FlexLine.ipynb), Pyplot)\n",
     "* Graph: Network mark ([Object Model](Marks/Object%20Model/Graph.ipynb), Pyplot)\n",
     "* GridHeatMap: Grid heatmap mark ([Object Model](Marks/Object%20Model/GridHeatMap.ipynb), [Pyplot](Marks/Pyplot/GridHeatMap.ipynb))\n",
     "* HeatMap: Heatmap mark ([Object Model](Marks/Object%20Model/HeatMap.ipynb), [Pyplot](Marks/Pyplot/HeatMap.ipynb))\n",


### PR DESCRIPTION
Difference in capitalization results in a 404.