### PR TITLE
Refactor `process_interactions` into the `Mark` base class, and provide bugfixes for new d3.

### DIFF
--- a/js/src/Bars.js
+++ b/js/src/Bars.js
@@ -163,8 +163,6 @@ var Bars = mark.Mark.extend({
                 this.event_listeners.parent_clicked = this.reset_selection;
                 this.event_listeners.element_clicked = this.bar_click_handler;
             }
-        } else {
-            this.reset_click();
         }
 
     },

--- a/js/src/Bars.js
+++ b/js/src/Bars.js
@@ -153,16 +153,11 @@ var Bars = mark.Mark.extend({
         });
     },
 
-    process_interactions: function() {
-        Bars.__super__.process_interactions.apply(this);
-        const interactions = this.model.get("interactions");
-
-        if(interactions.click !== undefined &&
-          interactions.click !== null) {
-            if (interactions.click === "select") {
-                this.event_listeners.parent_clicked = this.reset_selection;
-                this.event_listeners.element_clicked = this.bar_click_handler;
-            }
+    process_click: function(interaction) {
+        Bars.__super__.process_click.apply(this, [interaction]);
+        if (interaction === "select") {
+            this.event_listeners.parent_clicked = this.reset_selection;
+            this.event_listeners.element_clicked = this.bar_click_handler;
         }
 
     },

--- a/js/src/Bars.js
+++ b/js/src/Bars.js
@@ -14,6 +14,9 @@
  */
 
 var d3 = Object.assign({}, require("d3-array"), require("d3-scale"), require("d3-selection-multi"));
+// Hack to fix problem with webpack providing multiple d3 objects
+d3.getEvent = function(){return require("d3-selection").event}.bind(this);
+
 var _ = require("underscore");
 var mark = require("./Mark");
 var utils = require("./utils");
@@ -151,57 +154,19 @@ var Bars = mark.Mark.extend({
     },
 
     process_interactions: function() {
+        Bars.__super__.process_interactions.apply(this);
         var interactions = this.model.get("interactions");
-        if(_.isEmpty(interactions)) {
-            //set all the event listeners to blank functions
-            this.reset_interactions();
+
+        if(interactions.click !== undefined &&
+          interactions.click !== null) {
+            if (interactions.click === "select") {
+                this.event_listeners.parent_clicked = this.reset_selection;
+                this.event_listeners.element_clicked = this.bar_click_handler;
+            }
+        } else {
+            this.reset_click();
         }
-        else {
-            if(interactions.click !== undefined &&
-              interactions.click !== null) {
-                if(interactions.click === "tooltip") {
-                    this.event_listeners.element_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                } else if (interactions.click === "select") {
-                    this.event_listeners.parent_clicked = this.reset_selection;
-                    this.event_listeners.element_clicked = this.bar_click_handler;
-                }
-            } else {
-                this.reset_click();
-            }
-            if(interactions.hover !== undefined &&
-              interactions.hover !== null) {
-                if(interactions.hover === "tooltip") {
-                    this.event_listeners.mouse_over = this.refresh_tooltip;
-                    this.event_listeners.mouse_move = this.move_tooltip;
-                    this.event_listeners.mouse_out = this.hide_tooltip;
-                }
-            } else {
-                this.reset_hover();
-            }
-            if(interactions.legend_click !== undefined &&
-              interactions.legend_click !== null) {
-                if(interactions.legend_click === "tooltip") {
-                    this.event_listeners.legend_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                }
-            } else {
-                this.event_listeners.legend_clicked = function() {};
-            }
-            if(interactions.legend_hover !== undefined &&
-              interactions.legend_hover !== null) {
-                if(interactions.legend_hover === "highlight_axes") {
-                    this.event_listeners.legend_mouse_over = _.bind(this.highlight_axes, this);
-                    this.event_listeners.legend_mouse_out = _.bind(this.unhighlight_axes, this);
-                }
-            } else {
-                this.reset_legend_hover();
-            }
-        }
+
     },
 
     realign: function() {
@@ -315,7 +280,7 @@ var Bars = mark.Mark.extend({
         // Since we will assign the enter and update selection of bar_groups to
         // itself, we may remove exit selection first.
         bar_groups.exit().remove();
-        
+
         bar_groups = bar_groups.enter()
           .append("g")
           .attr("class", "bargroup")
@@ -603,7 +568,7 @@ var Bars = mark.Mark.extend({
         elements = elements.filter(function(data, index) {
             return indices.indexOf(index) !== -1;
         });
-        elements.selectAll(".bar").style(style);
+        elements.selectAll(".bar").styles(style);
     },
 
     set_default_style: function(indices) {
@@ -632,13 +597,13 @@ var Bars = mark.Mark.extend({
         // index of bar i. Checking if it is already present in the list.
         var elem_index = selected.indexOf(index);
         // Replacement for "Accel" modifier.
-        var accelKey = d3.event.ctrlKey || d3.event.metaKey;
+        var accelKey = d3.getEvent().ctrlKey || d3.getEvent().metaKey;
         if(elem_index > -1 && accelKey) {
             // if the index is already selected and if accel key is
             // pressed, remove the element from the list
             selected.splice(elem_index, 1);
         } else {
-            if(d3.event.shiftKey) {
+            if(d3.getEvent().shiftKey) {
                 //If shift is pressed and the element is already
                 //selected, do not do anything
                 if(elem_index > -1) {
@@ -677,10 +642,7 @@ var Bars = mark.Mark.extend({
                        ((selected.length === 0) ? null : selected),
                        {updated_view: this});
         this.touch();
-        if(!d3.event) {
-            d3.event = window.event;
-        }
-        var e = d3.event;
+        var e = d3.getEvent();
         if(e.cancelBubble !== undefined) { // IE
             e.cancelBubble = true;
         }

--- a/js/src/Bars.js
+++ b/js/src/Bars.js
@@ -155,7 +155,7 @@ var Bars = mark.Mark.extend({
 
     process_interactions: function() {
         Bars.__super__.process_interactions.apply(this);
-        var interactions = this.model.get("interactions");
+        const interactions = this.model.get("interactions");
 
         if(interactions.click !== undefined &&
           interactions.click !== null) {

--- a/js/src/BarsModel.js
+++ b/js/src/BarsModel.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-var d3 = Object.assign({}, require("d3-array"), require("d3-scale"));
+var d3 = Object.assign({}, require("d3-array"), require("d3-scale"), require("d3-scale-chromatic"));
 var _ = require("underscore");
 var markmodel = require("./MarkModel");
 var serialize = require('./serialize')
@@ -21,6 +21,7 @@ var serialize = require('./serialize')
 var BarsModel = markmodel.MarkModel.extend({
 
     defaults: function() {
+        console.log(d3.schemeCategory10, require("d3-array"), require("d3-scale"));
         return _.extend(markmodel.MarkModel.prototype.defaults(), {
             _model_name: "BarsModel",
             _view_name: "Bars",

--- a/js/src/BarsModel.js
+++ b/js/src/BarsModel.js
@@ -21,7 +21,6 @@ var serialize = require('./serialize')
 var BarsModel = markmodel.MarkModel.extend({
 
     defaults: function() {
-        console.log(d3.schemeCategory10, require("d3-array"), require("d3-scale"));
         return _.extend(markmodel.MarkModel.prototype.defaults(), {
             _model_name: "BarsModel",
             _view_name: "Bars",

--- a/js/src/Boxplot.js
+++ b/js/src/Boxplot.js
@@ -173,7 +173,7 @@ var Boxplot = mark.Mark.extend({
         elements = elements.filter(function(data, index) {
             return indices.indexOf(index) != -1;
         });
-        elements.style(style);
+        elements.styles(style);
     },
 
     set_default_style: function(indices) {
@@ -212,7 +212,7 @@ var Boxplot = mark.Mark.extend({
         for(var key in style_dict) {
             clearing_style[key] = null;
         }
-        elements.style(clearing_style);
+        elements.styles(clearing_style);
     },
 
     style_updated: function(new_style, indices) {

--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -314,21 +314,21 @@ var Figure = widgets.DOMWidgetView.extend({
     },
 
     title_style_updated: function() {
-        this.title.style(this.model.get("title_style"));
+        this.title.styles(this.model.get("title_style"));
     },
 
     background_style_updated: function() {
-        this.bg.style(this.model.get("background_style"));
+        this.bg.styles(this.model.get("background_style"));
     },
 
     legend_style_updated: function() {
         this.fig_marks.selectAll(".g_legend").selectAll(".axis").selectAll("rect")
-            .style(this.model.get("legend_style"));
+            .styles(this.model.get("legend_style"));
     },
 
     legend_text_updated: function() {
         this.fig_marks.selectAll(".g_legend").selectAll("text.legendtext")
-            .style(this.model.get("legend_text"));
+            .styles(this.model.get("legend_text"));
     },
 
     create_figure_scales: function() {

--- a/js/src/Graph.js
+++ b/js/src/Graph.js
@@ -510,7 +510,7 @@ var Graph = mark.Mark.extend({
         for(var key in style_dict) {
             clearing_style[key] = null;
         }
-        nodes.style(clearing_style);
+        nodes.styles(clearing_style);
     },
 
     set_style_on_elements: function(style, indices) {
@@ -527,7 +527,7 @@ var Graph = mark.Mark.extend({
         nodes = nodes.filter(function(data, index) {
             return indices.indexOf(index) !== -1;
         });
-        nodes.style(style);
+        nodes.styles(style);
     },
 
     compute_view_padding: function() {

--- a/js/src/Graph.js
+++ b/js/src/Graph.js
@@ -367,7 +367,7 @@ var Graph = mark.Mark.extend({
 
     process_interactions: function() {
         Graph.__super__.process_interactions.apply(this);
-        var interactions = this.model.get("interactions");
+        const interactions = this.model.get("interactions");
 
         if(interactions.click !== undefined &&
            interactions.click !== null) {

--- a/js/src/Graph.js
+++ b/js/src/Graph.js
@@ -366,36 +366,17 @@ var Graph = mark.Mark.extend({
     },
 
     process_interactions: function() {
+        Graph.__super__.process_interactions.apply(this);
         var interactions = this.model.get("interactions");
-        if(_.isEmpty(interactions)) {
-            //set all the event listeners to blank functions
-            this.reset_interactions();
-        } else {
-            if(interactions.click !== undefined &&
-               interactions.click !== null) {
-                if(interactions.click === "tooltip") {
-                    this.event_listeners.element_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                } else if (interactions.click == "select") {
-                    this.event_listeners.parent_clicked = this.reset_selection;
-                    this.event_listeners.element_clicked = this.click_handler;
-                }
-            } else {
-                this.reset_click();
-            }
-            if(interactions.hover !== undefined &&
-              interactions.hover !== null) {
-                if(interactions.hover === "tooltip") {
-                    this.event_listeners.mouse_over = this.refresh_tooltip;
-                    this.event_listeners.mouse_move = this.move_tooltip;
-                    this.event_listeners.mouse_out = this.hide_tooltip;
-                }
-            } else {
-                this.reset_hover();
+
+        if(interactions.click !== undefined &&
+           interactions.click !== null) {
+            if (interactions.click == "select") {
+                this.event_listeners.parent_clicked = this.reset_selection;
+                this.event_listeners.element_clicked = this.click_handler;
             }
         }
+
     },
 
     reset_hover: function() {

--- a/js/src/Graph.js
+++ b/js/src/Graph.js
@@ -365,18 +365,12 @@ var Graph = mark.Mark.extend({
         });
     },
 
-    process_interactions: function() {
-        Graph.__super__.process_interactions.apply(this);
-        const interactions = this.model.get("interactions");
-
-        if(interactions.click !== undefined &&
-           interactions.click !== null) {
-            if (interactions.click == "select") {
-                this.event_listeners.parent_clicked = this.reset_selection;
-                this.event_listeners.element_clicked = this.click_handler;
-            }
+    process_click: function(interaction) {
+        Graph.__super__.process_click.apply(this, [interaction]);
+        if (interaction === "select") {
+            this.event_listeners.parent_clicked = this.reset_selection;
+            this.event_listeners.element_clicked = this.click_handler;
         }
-
     },
 
     reset_hover: function() {

--- a/js/src/GridHeatMap.js
+++ b/js/src/GridHeatMap.js
@@ -594,17 +594,13 @@ var GridHeatMap = mark.Mark.extend({
         return this.scales.color.scale(dat.color);
     },
 
-    process_interactions: function() {
-        GridHeatMap.__super__.process_interactions.apply(this);
-        const interactions = this.model.get("interactions");
-
-        if(interactions.click !== undefined &&
-          interactions.click !== null) {
-            if (interactions.click == 'select') {
-                this.event_listeners.parent_clicked = this.reset_selection;
-                this.event_listeners.element_clicked = this.click_handler;
-            }
+    process_click: function(interaction) {
+        GridHeatMap.__super__.process_click.apply(this, [interaction]);
+        if (interaction === 'select') {
+            this.event_listeners.parent_clicked = this.reset_selection;
+            this.event_listeners.element_clicked = this.click_handler;
         }
+
     },
 });
 

--- a/js/src/GridHeatMap.js
+++ b/js/src/GridHeatMap.js
@@ -595,34 +595,14 @@ var GridHeatMap = mark.Mark.extend({
     },
 
     process_interactions: function() {
-        var interactions = this.model.get("interactions");
-        if(_.isEmpty(interactions)) {
-            //set all the event listeners to blank functions
-            this.reset_interactions();
-        } else {
-            if(interactions.click !== undefined &&
-              interactions.click !== null) {
-                if(interactions.click === "tooltip") {
-                    this.event_listeners.element_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                } else if (interactions.click == 'select') {
-                    this.event_listeners.parent_clicked = this.reset_selection;
-                    this.event_listeners.element_clicked = this.click_handler;
-                }
-            } else {
-                this.reset_click();
-            }
-            if(interactions.hover !== undefined &&
-              interactions.hover !== null) {
-                if(interactions.hover === "tooltip") {
-                    this.event_listeners.mouse_over = this.refresh_tooltip;
-                    this.event_listeners.mouse_move = this.move_tooltip;
-                    this.event_listeners.mouse_out = this.hide_tooltip;
-                }
-            } else {
-                this.reset_hover();
+        GridHeatMap.__super__.process_interactions.apply(this);
+        const interactions = this.model.get("interactions");
+
+        if(interactions.click !== undefined &&
+          interactions.click !== null) {
+            if (interactions.click == 'select') {
+                this.event_listeners.parent_clicked = this.reset_selection;
+                this.event_listeners.element_clicked = this.click_handler;
             }
         }
     },

--- a/js/src/HeatMap.js
+++ b/js/src/HeatMap.js
@@ -98,8 +98,6 @@ var HeatMap = mark.Mark.extend({
 
     click_handler: function (args) {},
 
-    process_interactions: function (args) {},
-
     relayout: function() {
         this.set_ranges();
         this.compute_view_padding();

--- a/js/src/Hist.js
+++ b/js/src/Hist.js
@@ -277,7 +277,7 @@ var Hist = mark.Mark.extend({
                                      this.calc_data_indices(selected)),
                                     {updated_view: this});
         this.touch();
-        var e = d3.event;
+        var e = d3.getEvent();
         if(e.cancelBubble !== undefined) { // IE
             e.cancelBubble = true;
         }

--- a/js/src/Hist.js
+++ b/js/src/Hist.js
@@ -85,16 +85,11 @@ var Hist = mark.Mark.extend({
         });
     },
 
-    process_interactions: function() {
-        Hist.__super__.process_interactions.apply(this);
-        const interactions = this.model.get("interactions");
-
-        if(interactions.click !== undefined &&
-          interactions.click !== null) {
-            if (interactions.click === "select") {
-                this.event_listeners.parent_clicked = this.reset_selection;
-                this.event_listeners.element_clicked = this.bar_click_handler;
-            }
+    process_click: function(interaction) {
+        Hist.__super__.process_click.apply(this, [interaction]);
+        if (interaction === "select") {
+            this.event_listeners.parent_clicked = this.reset_selection;
+            this.event_listeners.element_clicked = this.bar_click_handler;
         }
     },
 

--- a/js/src/Hist.js
+++ b/js/src/Hist.js
@@ -86,54 +86,14 @@ var Hist = mark.Mark.extend({
     },
 
     process_interactions: function() {
-        var interactions = this.model.get("interactions");
-        if(_.isEmpty(interactions)) {
-            //set all the event listeners to blank functions
-            this.reset_interactions();
-        } else {
-            if(interactions.click !== undefined &&
-              interactions.click !== null) {
-                if(interactions.click === "tooltip") {
-                    this.event_listeners.element_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                } else if (interactions.click === "select") {
-                    this.event_listeners.parent_clicked = this.reset_selection;
-                    this.event_listeners.element_clicked = this.bar_click_handler;
-                }
-            } else {
-                this.reset_click();
-            }
-            if(interactions.hover !== undefined &&
-              interactions.hover !== null) {
-                if(interactions.hover === "tooltip") {
-                    this.event_listeners.mouse_over = this.refresh_tooltip;
-                    this.event_listeners.mouse_move = this.move_tooltip;
-                    this.event_listeners.mouse_out = this.hide_tooltip;
-                }
-            } else {
-                this.reset_hover();
-            }
-            if(interactions.legend_click !== undefined &&
-              interactions.legend_click !== null) {
-                if(interactions.legend_click === "tooltip") {
-                    this.event_listeners.legend_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                }
-            } else {
-                this.event_listeners.legend_clicked = function() {};
-            }
-            if(interactions.legend_hover !== undefined &&
-              interactions.legend_hover !== null) {
-                if(interactions.legend_hover === "highlight_axes") {
-                    this.event_listeners.legend_mouse_over = _.bind(this.highlight_axes, this);
-                    this.event_listeners.legend_mouse_out = _.bind(this.unhighlight_axes, this);
-                }
-            } else {
-                this.reset_legend_hover();
+        Hist.__super__.process_interactions.apply(this);
+        const interactions = this.model.get("interactions");
+
+        if(interactions.click !== undefined &&
+          interactions.click !== null) {
+            if (interactions.click === "select") {
+                this.event_listeners.parent_clicked = this.reset_selection;
+                this.event_listeners.element_clicked = this.bar_click_handler;
             }
         }
     },

--- a/js/src/Hist.js
+++ b/js/src/Hist.js
@@ -15,6 +15,9 @@
 
 var _ = require("underscore");
 var d3 = Object.assign({}, require("d3-array"), require("d3-selection"));
+// Hack to fix problem with webpack providing multiple d3 objects
+d3.getEvent = function(){return require("d3-selection").event}.bind(this);
+
 var utils = require("./utils");
 var mark = require("./Mark");
 
@@ -268,13 +271,13 @@ var Hist = mark.Mark.extend({
         // index of bar i. Checking if it is already present in the list.
         var elem_index = selected.indexOf(index);
         // Replacement for "Accel" modifier.
-        var accelKey = d3.event.ctrlKey || d3.event.metaKey;
+        var accelKey = d3.getEvent().ctrlKey || d3.getEvent().metaKey;
         if(elem_index > -1 && accelKey) {
             // if the index is already selected and if accel key is
             // pressed, remove the element from the list
             selected.splice(elem_index, 1);
         } else {
-            if(d3.event.shiftKey) {
+            if(d3.getEvent().shiftKey) {
                 //If shift is pressed and the element is already
                 //selected, do not do anything
                 if(elem_index > -1) {
@@ -314,9 +317,6 @@ var Hist = mark.Mark.extend({
                                      this.calc_data_indices(selected)),
                                     {updated_view: this});
         this.touch();
-        if(!d3.event) {
-            d3.event = window.event;
-        }
         var e = d3.event;
         if(e.cancelBubble !== undefined) { // IE
             e.cancelBubble = true;
@@ -371,7 +371,7 @@ var Hist = mark.Mark.extend({
           });
 
         new_legend.merge(this.legend_el);
-        
+
         var max_length = d3.max(this.model.get("labels"), function(d) {
             return d.length;
         });

--- a/js/src/HistModel.js
+++ b/js/src/HistModel.js
@@ -14,7 +14,7 @@
  */
 
 var _ = require("underscore");
-var d3 = Object.assign({}, require("d3-array"), require("d3-scale"));
+var d3 = Object.assign({}, require("d3-array"), require("d3-scale"), require("d3-scale-chromatic"));
 var markmodel = require("./MarkModel");
 var serialize = require('./serialize')
 

--- a/js/src/Lines.js
+++ b/js/src/Lines.js
@@ -484,7 +484,7 @@ var Lines = mark.Mark.extend({
         this.area
           .x(function(d) { return x_scale.scale(d.x) + x_scale.offset; })
           .y1(function(d) { return y_scale.scale(d.y) + y_scale.offset; })
-        
+
         if (fill == "bottom") {
             this.area.y0(this.parent.plotarea_height);
         } else if (fill == "top") {
@@ -676,45 +676,6 @@ var Lines = mark.Mark.extend({
         this.compute_view_padding();
         this.d3el.selectAll(".dot").attr("d", this.dot.size(marker_size));
     },
-
-    process_interactions: function() {
-        var interactions = this.model.get("interactions");
-        if(_.isEmpty(interactions)) {
-            //set all the event listeners to blank functions
-            this.reset_interactions();
-        } else {
-            if(interactions.click !== undefined &&
-              interactions.click !== null) {
-                if(interactions.click === "tooltip") {
-                    this.event_listeners.element_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                }
-            } else {
-                this.reset_click();
-            }
-            if(interactions.hover !== undefined &&
-              interactions.hover !== null) {
-                if(interactions.hover === "tooltip") {
-                    this.event_listeners.mouse_over = this.refresh_tooltip;
-                    this.event_listeners.mouse_move = this.move_tooltip;
-                    this.event_listeners.mouse_out = this.hide_tooltip;
-                }
-            } else {
-                this.reset_hover();
-            }
-            if(interactions.legend_hover !== undefined &&
-              interactions.legend_hover !== null) {
-                if(interactions.legend_hover === "highlight_axes") {
-                    this.event_listeners.legend_mouse_over = _.bind(this.highlight_axes, this);
-                    this.event_listeners.legend_mouse_out = _.bind(this.unhighlight_axes, this);
-                }
-            } else {
-                this.reset_legend_hover();
-            }
-        }
-    }
 });
 
 module.exports = {

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -248,30 +248,27 @@ var Map = mark.Mark.extend({
         });
     },
 
-    process_interactions: function() {
-        Map.__super__.process_interactions.apply(this);
-        const interactions = this.model.get("interactions");
-
-        if(interactions.click !== undefined &&
-           interactions.click !== null) {
-            if (interactions.click === "select") {
-                this.event_listeners.parent_clicked = this.reset_selection;
-                this.event_listeners.element_clicked = this.click_handler;
-            }
+    process_click: function(interaction) {
+        Map.__super__.process_click.apply(this, [interaction]);
+        if (interaction === "select") {
+            this.event_listeners.parent_clicked = this.reset_selection;
+            this.event_listeners.element_clicked = this.click_handler;
         }
-        if(interactions.hover !== undefined &&
-          interactions.hover !== null) {
-            if(interactions.hover === "tooltip") {
-                this.event_listeners.mouse_over = function() {
-                    this.mouseover_handler();
-                    return this.refresh_tooltip();
-                };
-                this.event_listeners.mouse_move = this.move_tooltip;
-                this.event_listeners.mouse_out = function() {
-                    this.mouseout_handler();
-                    return this.hide_tooltip();
-                };
-            }
+    },
+
+    process_hover: function(interaction) {
+        Map.__super__.process_hover.apply(this, [interaction]);
+        if(interaction === "tooltip") {
+            this.event_listeners.mouse_over = function() {
+                this.mouseover_handler();
+                return this.refresh_tooltip();
+            };
+            this.event_listeners.mouse_move = this.move_tooltip;
+            this.event_listeners.mouse_out = function() {
+                this.mouseout_handler();
+                return this.hide_tooltip();
+            };
+
         }
 
     },

--- a/js/src/Map.js
+++ b/js/src/Map.js
@@ -249,54 +249,31 @@ var Map = mark.Mark.extend({
     },
 
     process_interactions: function() {
-        var interactions = this.model.get("interactions");
-        if(_.isEmpty(interactions)) {
-            //set all the event listeners to blank functions
-            this.reset_interactions();
-        }
-        else {
-            if(interactions.click !== undefined &&
-               interactions.click !== null) {
-                if(interactions.click === "tooltip") {
-                    this.event_listeners.element_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                } else if (interactions.click === "select") {
-                    this.event_listeners.parent_clicked = this.reset_selection;
-                    this.event_listeners.element_clicked = this.click_handler;
-                }
-            } else {
-                this.reset_click();
-            }
-            if(interactions.hover !== undefined &&
-              interactions.hover !== null) {
-                if(interactions.hover === "tooltip") {
-                    this.event_listeners.mouse_over = function() {
-                        this.mouseover_handler();
-                        return this.refresh_tooltip();
-                    };
-                    this.event_listeners.mouse_move = this.move_tooltip;
-                    this.event_listeners.mouse_out = function() {
-                        this.mouseout_handler();
-                        return this.hide_tooltip();
-                    };
-                }
-            } else {
-                this.reset_hover();
-            }
-            if(interactions.legend_click !== undefined &&
-              interactions.legend_click !== null) {
-                if(interactions.legend_click === "tooltip") {
-                    this.event_listeners.legend_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                }
-            } else {
-                this.event_listeners.legend_clicked = function() {};
+        Map.__super__.process_interactions.apply(this);
+        const interactions = this.model.get("interactions");
+
+        if(interactions.click !== undefined &&
+           interactions.click !== null) {
+            if (interactions.click === "select") {
+                this.event_listeners.parent_clicked = this.reset_selection;
+                this.event_listeners.element_clicked = this.click_handler;
             }
         }
+        if(interactions.hover !== undefined &&
+          interactions.hover !== null) {
+            if(interactions.hover === "tooltip") {
+                this.event_listeners.mouse_over = function() {
+                    this.mouseover_handler();
+                    return this.refresh_tooltip();
+                };
+                this.event_listeners.mouse_move = this.move_tooltip;
+                this.event_listeners.mouse_out = function() {
+                    this.mouseout_handler();
+                    return this.hide_tooltip();
+                };
+            }
+        }
+
     },
 
     change_selected_fill: function() {

--- a/js/src/Mark.js
+++ b/js/src/Mark.js
@@ -18,6 +18,13 @@ var d3 = Object.assign({}, require("d3-array"), require("d3-selection"), require
 d3.getEvent = function(){return require("d3-selection").event}.bind(this);
 var _ = require("underscore");
 
+
+// Check that value is defined and not null
+function is_defined(value){
+    return value !== null && value !== undefined;
+};
+
+
 var Mark = widgets.WidgetView.extend({
 
     initialize : function() {
@@ -368,6 +375,50 @@ var Mark = widgets.WidgetView.extend({
     reset_legend_hover: function() {
         this.event_listeners.legend_mouse_over = function() {};
         this.event_listeners.legend_mouse_out = function() {};
+    },
+
+    process_interactions: function() {
+        //configure default interactions
+        const interactions = this.model.get("interactions");
+        const that = this;
+        if (is_defined(interactions.click)) {
+            if(interactions.click === "tooltip") {
+                this.event_listeners.element_clicked = function() {
+                    return that.refresh_tooltip(true);
+                };
+                this.event_listeners.parent_clicked = this.hide_tooltip;
+            }
+        } else {
+            this.reset_click();
+        }
+        if(is_defined(interactions.hover)) {
+            if(interactions.hover === "tooltip") {
+                this.event_listeners.mouse_over = this.refresh_tooltip;
+                this.event_listeners.mouse_move = this.move_tooltip;
+                this.event_listeners.mouse_out = this.hide_tooltip;
+            }
+        } else {
+            this.reset_hover();
+        }
+
+        if(is_defined(interactions.legend_click)) {
+            if(interactions.legend_click === "tooltip") {
+                this.event_listeners.legend_clicked = function() {
+                    return that.refresh_tooltip(true);
+                };
+                this.event_listeners.parent_clicked = this.hide_tooltip;
+            }
+        } else {
+            this.event_listeners.legend_clicked = function() {};
+        }
+        if(is_defined(interactions.legend_hover)) {
+            if(interactions.legend_hover === "highlight_axes") {
+                this.event_listeners.legend_mouse_over = _.bind(this.highlight_axes, this);
+                this.event_listeners.legend_mouse_out = _.bind(this.unhighlight_axes, this);
+            }
+        } else {
+            this.reset_legend_hover();
+        }
     },
 
     mouse_over: function() {

--- a/js/src/Mark.js
+++ b/js/src/Mark.js
@@ -372,50 +372,73 @@ var Mark = widgets.WidgetView.extend({
         this.event_listeners.mouse_out = function() {};
     },
 
+    reset_legend_click: function() {
+        this.event_listeners.legend_clicked = function() {};
+    },
+
     reset_legend_hover: function() {
         this.event_listeners.legend_mouse_over = function() {};
         this.event_listeners.legend_mouse_out = function() {};
     },
 
+    process_click: function(interaction){
+        const that = this;
+        if(interaction === "tooltip") {
+            this.event_listeners.element_clicked = function() {
+                return that.refresh_tooltip(true);
+            };
+            this.event_listeners.parent_clicked = this.hide_tooltip;
+        }
+    },
+
+    process_hover: function(interaction){
+        if(interaction === "tooltip") {
+            this.event_listeners.mouse_over = this.refresh_tooltip;
+            this.event_listeners.mouse_move = this.move_tooltip;
+            this.event_listeners.mouse_out = this.hide_tooltip;
+        }
+    },
+
+    process_legend_click: function(interaction) {
+        const that = this;
+        if(interaction === "tooltip") {
+            this.event_listeners.legend_clicked = function() {
+                return that.refresh_tooltip(true);
+            };
+            this.event_listeners.parent_clicked = this.hide_tooltip;
+        }
+    },
+
+    process_legend_hover: function(interaction){
+        if(interaction === "highlight_axes") {
+            this.event_listeners.legend_mouse_over = _.bind(this.highlight_axes, this);
+            this.event_listeners.legend_mouse_out = _.bind(this.unhighlight_axes, this);
+        }
+    },
+
     process_interactions: function() {
         //configure default interactions
         const interactions = this.model.get("interactions");
-        const that = this;
+
         if (is_defined(interactions.click)) {
-            if(interactions.click === "tooltip") {
-                this.event_listeners.element_clicked = function() {
-                    return that.refresh_tooltip(true);
-                };
-                this.event_listeners.parent_clicked = this.hide_tooltip;
-            }
+            this.process_click(interactions.click);
         } else {
             this.reset_click();
         }
+
         if(is_defined(interactions.hover)) {
-            if(interactions.hover === "tooltip") {
-                this.event_listeners.mouse_over = this.refresh_tooltip;
-                this.event_listeners.mouse_move = this.move_tooltip;
-                this.event_listeners.mouse_out = this.hide_tooltip;
-            }
+            this.process_hover(interactions.hover);
         } else {
             this.reset_hover();
         }
 
         if(is_defined(interactions.legend_click)) {
-            if(interactions.legend_click === "tooltip") {
-                this.event_listeners.legend_clicked = function() {
-                    return that.refresh_tooltip(true);
-                };
-                this.event_listeners.parent_clicked = this.hide_tooltip;
-            }
+            this.process_legend_click(interactions.legend_click);
         } else {
-            this.event_listeners.legend_clicked = function() {};
+            this.reset_legend_click();
         }
         if(is_defined(interactions.legend_hover)) {
-            if(interactions.legend_hover === "highlight_axes") {
-                this.event_listeners.legend_mouse_over = _.bind(this.highlight_axes, this);
-                this.event_listeners.legend_mouse_out = _.bind(this.unhighlight_axes, this);
-            }
+            this.process_legend_hover(interactions.legend_hover);
         } else {
             this.reset_legend_hover();
         }

--- a/js/src/Mark.js
+++ b/js/src/Mark.js
@@ -222,6 +222,7 @@ var Mark = widgets.WidgetView.extend({
     },
 
     apply_styles: function(style_arr) {
+        console.log("Apply styles");
         if(style_arr === undefined || style_arr == null) {
             style_arr = [this.selected_style, this.unselected_style];
         }

--- a/js/src/Mark.js
+++ b/js/src/Mark.js
@@ -222,7 +222,6 @@ var Mark = widgets.WidgetView.extend({
     },
 
     apply_styles: function(style_arr) {
-        console.log("Apply styles");
         if(style_arr === undefined || style_arr == null) {
             style_arr = [this.selected_style, this.unselected_style];
         }

--- a/js/src/MarketMap.js
+++ b/js/src/MarketMap.js
@@ -90,7 +90,7 @@ var MarketMap = figure.Figure.extend({
           .attr("class", "mainheading")
           .attrs({x: (0.5 * (this.plotarea_width)), y: -(this.margin.top / 2.0), dy: "1em"})
           .text(this.model.get("title"));
-        this.title.style(this.model.get("title_style"));
+        this.title.styles(this.model.get("title_style"));
 
         var scale_creation_promise = this.create_scale_views();
         scale_creation_promise.then(function() {
@@ -169,7 +169,7 @@ var MarketMap = figure.Figure.extend({
 
     update_title: function(model, value) {
         this.title.text(this.model.get("title"))
-           .style(this.model.get("title_style"));
+           .styles(this.model.get("title_style"));
     },
 
     relayout: function() {
@@ -401,7 +401,7 @@ var MarketMap = figure.Figure.extend({
             new_groups.append("text")
                 .classed("market_map_text", true)
                 .styles({"text-anchor": "middle", 'fill' :'black', "pointer-events": "none"})
-                .style(that.model.get("font_style"));
+                .styles(that.model.get("font_style"));
 
             groups = new_groups.merge(groups);
 
@@ -481,7 +481,7 @@ var MarketMap = figure.Figure.extend({
 
     update_font_style: function(model, value) {
         this.svg.selectAll(".market_map_text")
-            .style(value);
+            .styles(value);
     },
 
     update_map_colors: function() {

--- a/js/src/PanZoom.js
+++ b/js/src/PanZoom.js
@@ -79,7 +79,7 @@ var PanZoom = interaction.Interaction.extend({
     mousedown: function () {
         var scales = this.model.get("scales");
         this.active = true;
-        this.d3el.style({"cursor": "move"});
+        this.d3el.styles({"cursor": "move"});
         this.previous_pos = d3.mouse(this.el);
         // A copy of the original domains is required to avoid additional
         // drift when Paning.
@@ -159,9 +159,9 @@ var PanZoom = interaction.Interaction.extend({
             var mouse_pos = d3.mouse(this.el);
             if (delta) {
                 if (delta > 0) {
-                    this.d3el.style({"cursor": "zoom-in"});
+                    this.d3el.styles({"cursor": "zoom-in"});
                 } else {
-                    this.d3el.style({"cursor": "zoom-out"});
+                    this.d3el.styles({"cursor": "zoom-out"});
                 }
                 var scales = this.model.get("scales");
                 var that = this;

--- a/js/src/Pie.js
+++ b/js/src/Pie.js
@@ -430,7 +430,7 @@ var Pie = mark.Mark.extend({
         for(var key in style_dict) {
             clearing_style[key] = null;
         }
-        elements.style(clearing_style);
+        elements.styles(clearing_style);
     },
 
     set_style_on_elements: function(style, indices) {
@@ -443,7 +443,7 @@ var Pie = mark.Mark.extend({
         elements = elements.filter(function(data, index) {
             return indices.indexOf(index) !== -1;
         });
-        elements.style(style);
+        elements.styles(style);
     },
 
     set_default_style: function(indices) {

--- a/js/src/Pie.js
+++ b/js/src/Pie.js
@@ -265,7 +265,8 @@ var Pie = mark.Mark.extend({
             })
             .each(function(d) {
                 this._current = d;
-            });
+            }).on("click", function(d, i) {
+            return that.event_dispatcher("element_clicked", {data: d, index: i});});
 
         slices.transition("draw").duration(animation_duration)
             .attrTween("d", function(d) {
@@ -364,10 +365,6 @@ var Pie = mark.Mark.extend({
 
             polylines.exit().remove();
         }
-
-        slices.on("click", function(d, i) {
-            return that.event_dispatcher("element_clicked", {data: d, index: i});
-        });
 
         this.update_labels();
         this.update_values();

--- a/js/src/Pie.js
+++ b/js/src/Pie.js
@@ -146,17 +146,13 @@ var Pie = mark.Mark.extend({
         });
     },
 
-    process_interactions: function() {
-        Pie.__super__.process_interactions.apply(this);
-        const interactions = this.model.get("interactions");
-
-        if(interactions.click !== undefined &&
-          interactions.click !== null) {
-            if (interactions.click === "select") {
-                this.event_listeners.parent_clicked = this.reset_selection;
-                this.event_listeners.element_clicked = this.click_handler;
-            }
+    process_click: function(interaction) {
+        Pie.__super__.process_click.apply(this, [interaction]);
+        if (interaction === "select") {
+            this.event_listeners.parent_clicked = this.reset_selection;
+            this.event_listeners.element_clicked = this.click_handler;
         }
+
     },
 
     relayout: function() {

--- a/js/src/Pie.js
+++ b/js/src/Pie.js
@@ -14,6 +14,8 @@
  */
 
 var d3 = Object.assign({}, require("d3-array"), require("d3-format"), require("d3-interpolate"), require("d3-shape"));
+// Hack to fix problem with webpack providing multiple d3 objects
+d3.getEvent = function(){return require("d3-selection").event}.bind(this);
 var mark = require("./Mark");
 var utils = require("./utils");
 var _ = require("underscore");
@@ -462,13 +464,13 @@ var Pie = mark.Mark.extend({
             // index of slice i. Checking if it is already present in the list.
         var elem_index = selected.indexOf(index);
         // Replacement for "Accel" modifier.
-        var accelKey = d3.event.ctrlKey || d3.event.metaKey;
+        var accelKey = d3.getEvent().ctrlKey || d3.getEvent().metaKey;
         if(elem_index > -1 && accelKey) {
             // if the index is already selected and if accel key is
             // pressed, remove the element from the list
             selected.splice(elem_index, 1);
         } else {
-            if(d3.event.shiftKey) {
+            if(d3.getEvent().shiftKey) {
                 //If shift is pressed and the element is already
                 //selected, do not do anything
                 if(elem_index > -1) {
@@ -500,10 +502,7 @@ var Pie = mark.Mark.extend({
             ((selected.length === 0) ? null : selected),
             {updated_view: this});
         this.touch();
-        if(!d3.event) {
-            d3.event = window.event;
-        }
-        var e = d3.event;
+        var e = d3.getEvent();
         if(e.cancelBubble !== undefined) { // IE
             e.cancelBubble = true;
         }

--- a/js/src/Pie.js
+++ b/js/src/Pie.js
@@ -145,54 +145,14 @@ var Pie = mark.Mark.extend({
     },
 
     process_interactions: function() {
-        var interactions = this.model.get("interactions");
-        if(_.isEmpty(interactions)) {
-            //set all the event listeners to blank functions
-            this.reset_interactions();
-        } else {
-            if(interactions.click !== undefined &&
-              interactions.click !== null) {
-                if(interactions.click === "tooltip") {
-                    this.event_listeners.element_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                } else if (interactions.click === "select") {
-                    this.event_listeners.parent_clicked = this.reset_selection;
-                    this.event_listeners.element_clicked = this.click_handler;
-                }
-            } else {
-                this.reset_click();
-            }
-            if(interactions.hover !== undefined &&
-              interactions.hover !== null) {
-                if(interactions.hover === "tooltip") {
-                    this.event_listeners.mouse_over = this.refresh_tooltip;
-                    this.event_listeners.mouse_move = this.move_tooltip;
-                    this.event_listeners.mouse_out = this.hide_tooltip;
-                }
-            } else {
-                this.reset_hover();
-            }
-            if(interactions.legend_click !== undefined &&
-              interactions.legend_click !== null) {
-                if(interactions.legend_click === "tooltip") {
-                    this.event_listeners.legend_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                }
-            } else {
-                this.event_listeners.legend_clicked = function() {};
-            }
-            if(interactions.legend_hover !== undefined &&
-              interactions.legend_hover !== null) {
-                if(interactions.legend_hover === "highlight_axes") {
-                    this.event_listeners.legend_mouse_over = _.bind(this.highlight_axes, this);
-                    this.event_listeners.legend_mouse_out = _.bind(this.unhighlight_axes, this);
-                }
-            } else {
-                this.reset_legend_hover();
+        Pie.__super__.process_interactions.apply(this);
+        const interactions = this.model.get("interactions");
+
+        if(interactions.click !== undefined &&
+          interactions.click !== null) {
+            if (interactions.click === "select") {
+                this.event_listeners.parent_clicked = this.reset_selection;
+                this.event_listeners.element_clicked = this.click_handler;
             }
         }
     },

--- a/js/src/PieModel.js
+++ b/js/src/PieModel.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-var d3 = Object.assign({}, require("d3-scale"));
+var d3 = Object.assign({}, require("d3-scale"), require("d3-scale-chromatic"));
 var _ = require("underscore");
 var markmodel = require("./MarkModel");
 var serialize = require('./serialize')

--- a/js/src/ScatterBase.js
+++ b/js/src/ScatterBase.js
@@ -314,7 +314,7 @@ var ScatterBase = mark.Mark.extend({
     process_interactions: function() {
         ScatterBase.__super__.process_interactions.apply(this);
 
-        var interactions = this.model.get("interactions");
+        const interactions = this.model.get("interactions");
 
         if(interactions.click !== undefined &&
            interactions.click !== null) {

--- a/js/src/ScatterBase.js
+++ b/js/src/ScatterBase.js
@@ -312,61 +312,28 @@ var ScatterBase = mark.Mark.extend({
     draw_elements: function(animate, elements_added) {},
 
     process_interactions: function() {
+        ScatterBase.__super__.process_interactions.apply(this);
+
         var interactions = this.model.get("interactions");
-        if(_.isEmpty(interactions)) {
-            //set all the event listeners to blank functions
-            this.reset_interactions();
-        } else {
-            if(interactions.click !== undefined &&
-               interactions.click !== null) {
-                if(interactions.click === "tooltip") {
-                    this.event_listeners.element_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                } else if (interactions.click === "add") {
+
+        if(interactions.click !== undefined &&
+           interactions.click !== null) {
+            switch (interactions.click){
+                case "add":
                     this.event_listeners.parent_clicked = this.add_element;
                     this.event_listeners.element_clicked = function() {};
-                } else if (interactions.click === "delete") {
+                    break;
+                case "delete":
                     this.event_listeners.parent_clicked = function() {};
                     this.event_listeners.element_clicked = this.delete_element;
-                } else if (interactions.click == 'select') {
-   		            this.event_listeners.parent_clicked = this.reset_selection;
-		            this.event_listeners.element_clicked = this.scatter_click_handler;
-	        }
-            } else {
-                this.reset_click();
+                    break;
+                case "select":
+                    this.event_listeners.parent_clicked = this.reset_selection;
+                    this.event_listeners.element_clicked = this.scatter_click_handler;
+                    break;
             }
-            if(interactions.hover !== undefined &&
-              interactions.hover !== null) {
-                if(interactions.hover === "tooltip") {
-                    this.event_listeners.mouse_over = this.refresh_tooltip;
-                    this.event_listeners.mouse_move = this.move_tooltip;
-                    this.event_listeners.mouse_out = this.hide_tooltip;
-                }
-            } else {
-                this.reset_hover();
-            }
-            if(interactions.legend_click !== undefined &&
-              interactions.legend_click !== null) {
-                if(interactions.legend_click === "tooltip") {
-                    this.event_listeners.legend_clicked = function() {
-                        return this.refresh_tooltip(true);
-                    };
-                    this.event_listeners.parent_clicked = this.hide_tooltip;
-                }
-            } else {
-                this.event_listeners.legend_clicked = function() {};
-            }
-            if(interactions.legend_hover !== undefined &&
-              interactions.legend_hover !== null) {
-                if(interactions.legend_hover === "highlight_axes") {
-                    this.event_listeners.legend_mouse_over = _.bind(this.highlight_axes, this);
-                    this.event_listeners.legend_mouse_out = _.bind(this.unhighlight_axes, this);
-                }
-            } else {
-                this.reset_legend_hover();
-            }
+        } else {
+            this.reset_click();
         }
     },
 

--- a/js/src/ScatterBase.js
+++ b/js/src/ScatterBase.js
@@ -332,8 +332,6 @@ var ScatterBase = mark.Mark.extend({
                     this.event_listeners.element_clicked = this.scatter_click_handler;
                     break;
             }
-        } else {
-            this.reset_click();
         }
     },
 

--- a/js/src/ScatterBase.js
+++ b/js/src/ScatterBase.js
@@ -311,27 +311,21 @@ var ScatterBase = mark.Mark.extend({
 
     draw_elements: function(animate, elements_added) {},
 
-    process_interactions: function() {
-        ScatterBase.__super__.process_interactions.apply(this);
-
-        const interactions = this.model.get("interactions");
-
-        if(interactions.click !== undefined &&
-           interactions.click !== null) {
-            switch (interactions.click){
-                case "add":
-                    this.event_listeners.parent_clicked = this.add_element;
-                    this.event_listeners.element_clicked = function() {};
-                    break;
-                case "delete":
-                    this.event_listeners.parent_clicked = function() {};
-                    this.event_listeners.element_clicked = this.delete_element;
-                    break;
-                case "select":
-                    this.event_listeners.parent_clicked = this.reset_selection;
-                    this.event_listeners.element_clicked = this.scatter_click_handler;
-                    break;
-            }
+    process_click: function(interaction) {
+        ScatterBase.__super__.process_click.apply(this, [interaction]);
+        switch (interaction){
+            case "add":
+                this.event_listeners.parent_clicked = this.add_element;
+                this.event_listeners.element_clicked = function() {};
+                break;
+            case "delete":
+                this.event_listeners.parent_clicked = function() {};
+                this.event_listeners.element_clicked = this.delete_element;
+                break;
+            case "select":
+                this.event_listeners.parent_clicked = this.reset_selection;
+                this.event_listeners.element_clicked = this.scatter_click_handler;
+                break;
         }
     },
 

--- a/js/src/SquareMarketMap.js
+++ b/js/src/SquareMarketMap.js
@@ -54,14 +54,14 @@ var SquareMarketMap = widgets.DOMWidgetView.extend({
             .enter().append("div")
             .attr("class", "node")
             .call(this.position)
-            .style({
+            .styles({
                 "background": function(d, i) {
                     return d.children ? color(d.name): null;
                 },
                 "border": "solid white"
             })
             .text(function(d) { return d.children ? null : d.name; })
-            .style({
+            .styles({
                 'font': '11px sans-serif',
                 'position': 'absolute',
                 'text-align': 'center',


### PR DESCRIPTION
This PR moves the `process_interactions` function into `Mark`, in order to reduce code duplication. By calling `Mark.process_interactions` from `__super__`, this does mean that some branches are executed twice - once for the base class, and then overridden in the child, but I think this is acceptable. Most of this overriding is caused by the child class hooking into the click event, which could be removed by using a method overload instead.

I introduced a small helper function in `Mark` which I didn't re-use it in the other mark classes, to test for `value !== null && value !== undefined`. Having spoken with @maartenbreddels, a longer term solution would be to use lodash, but I thought that beyond the scope of this PR.

As well as refactoring this code, there are also some bugfixes which prevented testing along the way. Although it's bad practice to mix goals in a PR, my opinion was that they were small changes and I'm pretty sure that they're broken in master. As part of this, I've re-used the runtime resolution of `d3.event` with `d3.getEvent`. I'm under the impression that webpack is causing this bug, but I'm not proficient enough with webpack to really know how to solve it.