### PR TITLE
add ability to disable bar chart stroke outline

### DIFF
--- a/js/src/Bars.js
+++ b/js/src/Bars.js
@@ -414,7 +414,7 @@ var Bars = mark.Mark.extend({
         var stroke = this.model.get("stroke");
         var opacities = this.model.get("opacities");
         this.d3el.selectAll(".bar")
-            .style("stroke", stroke)
+            .style("stroke", stroke || "none")
             .style("opacity", function(d, i) {
             return opacities[i];
         });


### PR DESCRIPTION
When bar stroke is set to None as `Bars(stroke=None)`, a black outline is still shown. This PR fixes the issue by making sure stroke style set to `"none"`