### PR TITLE
Fix package.json for Jupyter Lab extension

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -65,10 +65,10 @@
   "files": [
     "dist/",
     "css/",
-    "src/",
+    "lib/",
     "shaders/"
   ],
   "jupyterlab": {
-    "extension": "src/jupyterlab-plugin"
+    "extension": "lib/jupyterlab-plugin"
   }
 }


### PR DESCRIPTION
I ran into issues when installing the latest developer version of the Lab extension with:

```
jupyter labextension install js
```

With these changes, I'm able to successfully install it.