### PR TITLE
Typescript target es2015->es2017

### DIFF
--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -4,7 +4,6 @@
       // "declaration": true,
       "esModuleInterop": true,
       "incremental": true,
-      "lib": ["es2015", "dom"],
       "module": "commonjs",
       "moduleResolution": "node",
       "noEmitOnError": true,
@@ -16,7 +15,7 @@
       "sourceMap": true,
       // "strict": true,
       "strictNullChecks": false,
-      "target": "es2015",
+      "target": "es2017",
       // "types": [],
     },
     "include": [


### PR DESCRIPTION
We figured in JupyterLab that any supported browser in the last 2 years or so now supports the es2017 emitted javascript (last one to support native async/await was Safari 10.1 in middle 2017).