### PR TITLE
Fix animation filename in introduction.rst

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -5,7 +5,7 @@ Introduction
 
 bqplot is a Grammar of Graphics-based interactive plotting framework for the Jupyter notebook.
 
-.. image:: ../../bqplot-screencast.gif
+.. image:: ../../wealth-of-nations.gif
 
 In bqplot, every single attribute of the plot is an interactive widget. This allows the user to integrate any plot with IPython widgets to create a complex and feature rich GUI from just a few simple lines of Python code.
 
@@ -13,7 +13,7 @@ Goals
 -----
 
  - provide a unified framework for 2-D visualizations with a pythonic API.
- -  provide a sensible API for adding user interactions (panning, zooming, selection, etc)
+ - provide a sensible API for adding user interactions (panning, zooming, selection, etc)
 
 Two APIs are provided
 


### PR DESCRIPTION
It seems `bqplot-screencast.gif` was renamed `wealth-of-nations.gif`
but the reference to the filename was not updated here.

See:
- https://github.com/bloomberg/bqplot/search?q=screencast&type=Commits
- https://github.com/bloomberg/bqplot/commits/057c51e6f657b8e78cf3694785ab4b7c3a25c4f5/bqplot-screencast.gif
- https://github.com/bloomberg/bqplot/blob/057c51e6f657b8e78cf3694785ab4b7c3a25c4f5/bqplot-screencast.gif