### PR TITLE
Fix testing and enable many tests

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -58,6 +58,12 @@ export class Figure extends widgets.DOMWidgetView {
         this.el.appendChild(this.renderer.domElement);
         this.el.appendChild(svg_interaction)
 
+        // For testing we need to know when the mark_views is created, the tests
+        // can wait for this promise.
+        this._initial_marks_created = new Promise((resolve) => {
+            this._initial_marks_created_resolve = resolve;
+        });
+
         super.initialize.apply(this, arguments);
     }
 
@@ -239,6 +245,7 @@ export class Figure extends widgets.DOMWidgetView {
                 // Update Interaction layer
                 // This has to be done after the marks are created
                 that.set_interaction(that.model.get("interaction"));
+                that._initial_marks_created_resolve()
             });
 
             that.axis_views = new widgets.ViewList(that.add_axis, null, that);
@@ -958,5 +965,8 @@ export class Figure extends widgets.DOMWidgetView {
     y_padding_arr: any;
 
     private _update_requested: boolean;
+    // this is public for the test framework, but considered a private API
+    public _initial_marks_created: Promise<any>;
+    private _initial_marks_created_resolve: Function;
 
 }

--- a/js/src/test/bars.ts
+++ b/js/src/test/bars.ts
@@ -10,7 +10,7 @@ describe("bars >", () => {
         this.manager = new DummyManager({bqplot: bqplot});
     });
 
-    it.skip("create 1d", async function() {
+    it("create 1d", async function() {
         let x = {dtype: 'float32', value: new DataView((new Float32Array([0,1])).buffer)};
         let y = {dtype: 'float32', value: new DataView((new Float32Array([2,3])).buffer)};
         let objects = await create_figure_bars(this.manager, x, y);
@@ -27,7 +27,7 @@ describe("bars >", () => {
         expect(heights).to.deep.equal([height*2/3, height]);
     });
 
-    it.skip("create 2d classic", async function() {
+    it("create 2d classic", async function() {
         let x = [0,0.5,1];
         let y = [[2,2.0,3], [2.0, 2.5, 3.5]];
         let objects = await create_figure_bars(this.manager, x, y);
@@ -62,7 +62,7 @@ describe("bars >", () => {
         expect(heights).to.deep.equal([h0, h0, h0, h3, h2, h4]);
     });
 
-    it.skip("create 2d binary", async function() {
+    it("create 2d binary", async function() {
         let x = {dtype: 'float32', value: new DataView((new Float32Array([0,0.5,1])).buffer), shape: [3]};
         let y = {dtype: 'float32', value: new DataView((new Float32Array([2,2.0,3, 2.0,2.5,3.5])).buffer), shape: [2,3]};
         let objects = await create_figure_bars(this.manager, x, y);

--- a/js/src/test/lines.ts
+++ b/js/src/test/lines.ts
@@ -30,7 +30,7 @@ describe("lines >", () => {
         expect(paths).to.deep.equal([`M${width*1/4},${height}L${width*3/4},0`]);
     });
 
-    it.skip("create 1d", async function() {
+    it("create 1d", async function() {
         let x = {dtype: 'float32', value: new DataView((new Float32Array([0,1])).buffer)};
         let y = {dtype: 'float32', value: new DataView((new Float32Array([2,3])).buffer)};
         let objects = await create_figure_lines(this.manager, x, y);
@@ -49,7 +49,7 @@ describe("lines >", () => {
         expect(paths).to.deep.equal([`M0,${height}L${width},0`]);
     });
 
-    it.skip("create 2d classic", async function() {
+    it("create 2d classic", async function() {
         let x = [[0,0.5,1], [0.5, 0.5, 1.]];
         let y = [[2,2.0,3], [2.0, 2.5, 3.]];
         let objects = await create_figure_lines(this.manager, x, y);
@@ -79,7 +79,7 @@ describe("lines >", () => {
         expect(paths).to.deep.equal([`M0,${height}L${width/2},${height}L${width},0`, `M${width/2},${height}L${width/2},${height/2}L${width},0`]);
     });
 
-    it.skip("create 2d binary", async function() {
+    it("create 2d binary", async function() {
         let x = {dtype: 'float32', value: new DataView((new Float32Array([0.0,0.5,1.0, 0.5,0.5,1.0])).buffer), shape: [2,3]};
         let y = {dtype: 'float32', value: new DataView((new Float32Array([2.0,2.0,3.0, 2.0,2.5,3.0])).buffer), shape: [2,3]};
         let objects = await create_figure_lines(this.manager, x, y);
@@ -109,7 +109,7 @@ describe("lines >", () => {
         expect(paths).to.deep.equal([`M0,${height}L${width/2},${height}L${width},0`, `M${width/2},${height}L${width/2},${height/2}L${width},0`]);
     });
 
-    it.skip("create 2d binary shared x", async function() {
+    it("create 2d binary shared x", async function() {
         let x = {dtype: 'float32', value: new DataView((new Float32Array([0.0,0.5,1.0])).buffer), shape: [3]};
         let y = {dtype: 'float32', value: new DataView((new Float32Array([2.0,2.0,3.0, 2.0,2.5,3.0])).buffer), shape: [2,3]};
         let objects = await create_figure_lines(this.manager, x, y);

--- a/js/src/test/scatter.ts
+++ b/js/src/test/scatter.ts
@@ -10,7 +10,7 @@ describe("scatter >", () => {
         this.manager = new DummyManager({bqplot: bqplot});
     });
 
-    it.skip("create", async function() {
+    it("create", async function() {
         let x = {dtype: 'float32', value: new DataView((new Float32Array([0,1])).buffer)};
         let y = {dtype: 'float32', value: new DataView((new Float32Array([2,3])).buffer)};
         let objects = await create_figure_scatter(this.manager, x, y);
@@ -28,7 +28,7 @@ describe("scatter >", () => {
         expect(transforms).to.deep.equal([`translate(0, ${height})`, `translate(${width}, 0)`]);
     });
 
-    it.skip("computed fill", async function() {
+    it("computed fill", async function() {
         let x = [0, 1];
         let y = [2, 3];
         let objects = await create_figure_scatter(this.manager, x, y);

--- a/js/src/test/scatter.ts
+++ b/js/src/test/scatter.ts
@@ -34,7 +34,7 @@ describe("scatter >", () => {
         let objects = await create_figure_scatter(this.manager, x, y);
         let scatter = objects.scatter;
 
-        let getFills = () => scatter.d3el.selectAll(".object_grp .element")[0].map((el) => ((el.getAttribute('style')||'').match(/fill: (\w*)/)||[null,null])[1]);
+        let getFills = () => scatter.d3el.selectAll(".object_grp .element").nodes().map((el) => ((el.getAttribute('style')||'').match(/fill: (\w*)/)||[null,null])[1]);
         expect(getFills()).to.deep.equal(['steelblue', 'steelblue']);
 
         scatter.model.set('unselected_style', {'fill': 'orange', 'stroke': 'none'});

--- a/js/src/test/widget-utils.ts
+++ b/js/src/test/widget-utils.ts
@@ -63,6 +63,7 @@ async function create_figure_scatter(manager, x, y, mega=false) {
     }
     let figure  = await create_view(manager, figureModel);
     await manager.display_view(undefined, figure);
+    await figure._initial_marks_created;
     return {figure: figure, scatter: await figure.mark_views.views[0]}
 }
 
@@ -95,6 +96,7 @@ async function create_figure_lines(manager, x, y, default_scales={}) {
     }
     let figure  = await create_view(manager, figureModel);
     await manager.display_view(undefined, figure);
+    await figure._initial_marks_created;
     return {figure: figure, lines: await figure.mark_views.views[0]}
 }
 export
@@ -124,5 +126,6 @@ async function create_figure_bars(manager, x, y) {
     }
     let figure  = await create_view(manager, figureModel);
     await manager.display_view(undefined, figure);
+    await figure._initial_marks_created;
     return {figure: figure, bars: await figure.mark_views.views[0]}
 }


### PR DESCRIPTION
In 8eb8b163abe9ee6306f6918067e2f36c1caef2ef the typescript target was moved to es2017. Somehow with my local chrome (74.0.3729.157 on osx) this caused `figure.mark_views` not to be undefined in the unittest. The only explaination I can think of is the rules for when promises are resolved have changed with es2017.

The changes from 8eb8b163abe9ee6306f6918067e2f36c1caef2ef did not enter into #661 (mistake with rebasing?) and never triggered failing karma tests. This was fixed in c3a075f33a3fac39e3347da4cd1ba7881e7902d1, however PR #853 did not fail on Travis, this may be explained by chrome headless being older and maybe having different rules for when Promises are resolved.

The first commit solves this by explicitly creating a promise that will be resolved when the mark_views is created, which is much more robust. After this fix, all the test could be enabled again.