### PR TITLE
Fix WebGL plotting in Jupyter Lab

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -63,7 +63,8 @@
     "popper.js": "^1.0.0",
     "three": "^0.91.0",
     "topojson": "^1.6.24",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "raw-loader": "^0.5.1"
   },
   "files": [
     "dist/",

--- a/js/package.json
+++ b/js/package.json
@@ -63,8 +63,7 @@
     "popper.js": "^1.0.0",
     "three": "^0.91.0",
     "topojson": "^1.6.24",
-    "underscore": "^1.8.3",
-    "raw-loader": "^0.5.1"
+    "underscore": "^1.8.3"
   },
   "files": [
     "dist/",

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -22,7 +22,15 @@ import * as popperreference from './PopperReference';
 import popper from 'popper.js';
 import * as THREE from 'three';
 
-THREE.ShaderChunk['scales'] = require('raw-loader!../shaders/scales.glsl')
+const scales = require('raw-loader!../shaders/scales.glsl');
+
+// Recent versions of raw-loader return an object where the shader string can
+// be accessed via the 'default' property
+if (typeof scales === "string") {
+  THREE.ShaderChunk['scales'] = scales;
+} else {
+  THREE.ShaderChunk['scales'] = scales.default;
+}
 
 export class Figure extends widgets.DOMWidgetView {
 


### PR DESCRIPTION
This declares ``raw-loader`` as a runtime dependency since it is needed to load some of the shader code (specifically for the scales).

If we don't specify this, we are dependent on the default versions of raw-loader in notebook and lab which might be different - in particular, recent versions of raw-loader used by Jupyter Lab don't return a string when used with require() but instead return an object with a 'default' property, which causes issues in three.js.

Fixes https://github.com/bloomberg/bqplot/issues/858