### PR TITLE
fix: Upgrade to raw-loader 2 (like jupyter lab)

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -46,7 +46,7 @@
     "less": "^3.8.1",
     "less-loader": "^4.1.0",
     "mocha": "^5.2.0",
-    "raw-loader": "^0.5.1",
+    "raw-loader": "~2.0.0",
     "rimraf": "^2.6.1",
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -22,7 +22,7 @@ import * as popperreference from './PopperReference';
 import popper from 'popper.js';
 import * as THREE from 'three';
 
-THREE.ShaderChunk['scales'] = require('raw-loader!../shaders/scales.glsl')
+THREE.ShaderChunk['scales'] = require('raw-loader!../shaders/scales.glsl').default;
 
 export class Figure extends widgets.DOMWidgetView {
 

--- a/js/src/ScatterGL.ts
+++ b/js/src/ScatterGL.ts
@@ -193,8 +193,8 @@ export class ScatterGL extends Mark {
                 stroke_width: {type: 'f', value: 1.5},
                 marker_scale: {type: 'f', value: 1.0}
             },
-            vertexShader: require('raw-loader!../shaders/scatter-vertex.glsl'),
-            fragmentShader: require('raw-loader!../shaders/scatter-fragment.glsl'),
+            vertexShader: require('raw-loader!../shaders/scatter-vertex.glsl').default,
+            fragmentShader: require('raw-loader!../shaders/scatter-fragment.glsl').default,
             transparent: true,
             depthTest: false,
             depthWrite: false,


### PR DESCRIPTION
This wayt we can load the shaders the same way.  This will allow bqplot to use WebGL within Jupyter lab.

raw-loader <2 was using common-js, so you could simply do:
```
require('raw-loader!../shaders/scales.glsl')
```
To get the shader string.

Jupyter lab uses raw-loader `~2.0.0`, which uses [ES module style](https://github.com/webpack-contrib/raw-loader/pull/69), requiring you to do:
```
require('raw-loader!../shaders/scales.glsl').default
```

@astrofrog solved this by supporting both cases in #859. However, if we upgrade the devDependencies in bqplot to raw-loader 2, we can use the latter case for bundle building and jupyter lab building.

Replaces #859 

