### PR TITLE
Fix DateColorScale

### DIFF
--- a/js/src/ColorScaleModel.ts
+++ b/js/src/ColorScaleModel.ts
@@ -77,7 +77,7 @@ export class ColorScaleModel extends LinearScaleModel {
         const domain = [];
         for (let i = 0; i < n_colors; i++) {
             const j = this.reverse ? n_colors-1-i : i;
-            domain.push(scale(j));
+            domain.push(new Date(scale(j)));
         }
         return domain;
     }


### PR DESCRIPTION
The object returned by the `scale` function was always the same object, resulting in populating the Date domain with `n_colors` times the same date.