### PR TITLE
Adds a precomputed statistics option to the boxplot

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -904,6 +904,8 @@ class Boxplot(Mark):
         If set to None, box_with is auto calculated
     auto_detect_outliers: bool (default: True)
         Flag to toggle outlier auto-detection
+    precomputed_statistics: bool (default: True)
+        Flag to toggle precomputed values for y
 
     Data Attributes
 
@@ -944,6 +946,7 @@ class Boxplot(Mark):
         .tag(sync=True, display_name='Opacities')
     box_width = Int(None, min=5, allow_none=True).tag(sync=True, display_name='Box Width')
     auto_detect_outliers = Bool(True).tag(sync=True, display_name='Auto-detect Outliers')
+    precomputed_statistics = Bool(True).tag(sync=True, display_name='Precomputed Statistics')
 
     _view_name = Unicode('Boxplot').tag(sync=True)
     _model_name = Unicode('BoxplotModel').tag(sync=True)

--- a/js/src/BoxplotModel.ts
+++ b/js/src/BoxplotModel.ts
@@ -36,7 +36,8 @@ export class BoxplotModel extends MarkModel {
             outlier_fill_color: "gray",
             opacities: [],
             box_width: null, // auto calculate box width
-            auto_detect_outliers: true
+            auto_detect_outliers: true,
+            precomputed_statistics: true
         };
     }
 


### PR DESCRIPTION
**Describe your changes**
Adds a precomputed_statistics option to the bqplot graph which allows a user to pass 
the quantiles and outliers as the y variable [q0, q25, q50 q75, q100, outlier1, outlier2, ... outlierN] 
and set the precomputed_statistics flag.

**Testing performed**
Still working on testing this, need some feedback on the implementation.

**Additional context**

