### PR TITLE
Fixed padding in ordinal scale

### DIFF
--- a/js/src/OrdinalScale.ts
+++ b/js/src/OrdinalScale.ts
@@ -28,9 +28,11 @@ export class OrdinalScale extends Scale {
     }
 
     set_range(range, padding) {
-       padding = (padding === undefined) ? 0 : padding;
-       this.scale.range(range, padding, padding / 2.0);
-       this.offset = (this.scale.domain().length === 0) ? 0 : this.scale.range() / 2.0;
+        padding = (padding === undefined) ? 0 : padding;
+        this.scale.range(range);
+        this.scale.paddingInner(padding);
+        this.scale.paddingOuter(padding / 2.0);
+        this.offset = (this.scale.domain().length === 0) ? 0 : this.scale.range() / 2.0;
     }
 
     expand_domain(old_range, new_range) {
@@ -47,7 +49,9 @@ export class OrdinalScale extends Scale {
         unpadded_scale.range(old_range);
         const outer_padding = (unpadded_scale.range().length > 0) ?
             Math.abs((new_range[1] - old_range[1]) / unpadded_scale.bandwidth()) : 0;
-        this.scale.range(new_range, 0.0, outer_padding);
+        this.scale.range(new_range);
+        this.scale.paddingInner(0.0);
+        this.scale.paddingOuter(outer_padding);
     }
 
     invert(pixel) {


### PR DESCRIPTION
Fixes #871 
Fixes #872 

Notice that an axis with `OrdinalScale` does not add extra ticks when outer padding is set.