### PR TITLE
Fix reset_hover method name collision

### DIFF
--- a/js/src/Graph.ts
+++ b/js/src/Graph.ts
@@ -321,7 +321,7 @@ export class Graph extends Mark {
             this.hover_handler({"data": d, "index": i});
         }, this));
         this.nodes.on("mouseout", _.bind(function() {
-            this.reset_hover();
+            this.reset_hover_points();
         }, this));
     }
 
@@ -372,7 +372,7 @@ export class Graph extends Mark {
         }
     }
 
-    reset_hover() {
+    reset_hover_points() {
         this.links.style("opacity", 1);
         this.model.set("hovered_point", null);
         this.hovered_index = null;

--- a/js/src/Mark.ts
+++ b/js/src/Mark.ts
@@ -353,29 +353,22 @@ export abstract class Mark extends widgets.WidgetView {
         }
     }
 
-    reset_interactions() {
-        this.reset_click();
-        this.reset_hover();
-        this.reset_legend_hover();
-        this.event_listeners.legend_clicked = function() {};
-    }
-
     reset_click() {
         this.event_listeners.element_clicked = function() {};
         this.event_listeners.parent_clicked = function() {};
     }
 
-    reset_hover() {
+    private reset_hover() {
         this.event_listeners.mouse_over = function() {};
         this.event_listeners.mouse_move = function() {};
         this.event_listeners.mouse_out = function() {};
     }
 
-    reset_legend_click() {
+    private reset_legend_click() {
         this.event_listeners.legend_clicked = function() {};
     }
 
-    reset_legend_hover() {
+    private reset_legend_hover() {
         this.event_listeners.legend_mouse_over = function() {};
         this.event_listeners.legend_mouse_out = function() {};
     }

--- a/js/src/ScatterBase.ts
+++ b/js/src/ScatterBase.ts
@@ -289,7 +289,7 @@ export abstract class ScatterBase extends Mark {
             this.scatter_hover_handler({"data": d, "index": i});
         });
         elements_added.on("mouseout", () => {
-            this.reset_hover();
+            this.reset_hover_points();
         });
 
         this.draw_elements(animate, elements_added)
@@ -322,7 +322,7 @@ export abstract class ScatterBase extends Mark {
         }
     }
 
-    reset_hover() {
+    reset_hover_points() {
         this.model.set("hovered_point", null);
         this.hovered_index = null;
         this.touch();


### PR DESCRIPTION
Fixes #896

There was a collision in method names:
- in `Mark.ts`, the `reset_hover` is supposed to remove the hover event function
- in `ScatterBase.ts` and `Graph.ts` which inherits from `Mark.ts`, the `reset_hover` is supposed to reset the hovered points stored in the model

This PR:
- Puts the `reset_hover` method private in `Mark.ts` in order to prevent overriding it.
- Renames `reset_hover` into `reset_hover_points` in `ScatterBase.ts` and `Graph.ts`
- Removes the unused `reset_interactions` method