### PR TITLE
Fixed OrdinalScale padding

### DIFF
--- a/js/src/OrdinalScale.ts
+++ b/js/src/OrdinalScale.ts
@@ -46,7 +46,7 @@ export class OrdinalScale extends Scale {
         // happens, the labels are placed at the center of the bins
 
         const unpadded_scale = this.scale.copy();
-        unpadded_scale.range(old_range);
+        unpadded_scale.range(old_range).paddingInner(0).paddingOuter(0);
         const outer_padding = (unpadded_scale.range().length > 0) ?
             Math.abs((new_range[1] - old_range[1]) / unpadded_scale.bandwidth()) : 0;
         this.scale.range(new_range);


### PR DESCRIPTION
Fixes #871 for good.

The new bandwidth was computed with old padding, resulting in wrong bandwith. This is due to the migration d3 v3 -> d3 v5, each call to `scale.rangeBands(r)` should be replaced with `scale.range(r).paddingInner(0).paddingOuter(0)` if `scale` is an ordinal scale for which inner padding and outer padding have already been specified.

cc @martinRenou @SylvainCorlay 
