### PR TITLE
fix: brush selectors threw exception with no selection, fixed order of y test

### DIFF
--- a/js/src/BrushSelector.ts
+++ b/js/src/BrushSelector.ts
@@ -262,8 +262,14 @@ export class BrushSelector extends BrushMixinXYSelector {
             this.empty_selection();
         } else {
             const d0 = e.selection;
-            const pixel_extent_x = [d0[0][0], d0[1][0]];
-            const pixel_extent_y = [d0[1][1], d0[0][1]];
+            var pixel_extent_x = [d0[0][0], d0[1][0]];
+            var pixel_extent_y = [d0[1][1], d0[0][1]];
+
+            // d3 does not always (!) give the selection in [[xmin, xmax], [ymin, ymax]] order
+            // so we sort it to be sure
+            var sortFunction = (a: number, b: number) => a - b;
+            pixel_extent_x.sort(sortFunction)
+            pixel_extent_y.sort(sortFunction)
 
             const extent_x = pixel_extent_x.map(this.x_scale.scale.invert).sort(
                 (a: number, b: number) => a - b);
@@ -311,12 +317,14 @@ export class BrushSelector extends BrushMixinXYSelector {
         this.set_y_range([this.y_scale]);
 
         this.brush.extent([[0, 0], [this.width, this.height]]);
-        const range_x = this.model.get("selected_x").map(this.x_scale.scale).sort(
-            function(a, b) { return a - b; });
-        const range_y = this.model.get("selected_y").map(this.y_scale.scale).sort(
-            function(a, b) { return a - b; });
-        this.brush.move(this.d3el, [[range_x[0], range_y[0]], [range_x[1], range_y[1]]]);
-        this.brushsel = this.d3el.call(this.brush);
+        if(this.model.get("selected_x") && this.model.get("selected_y")) {
+            const range_x = this.model.get("selected_x").map(this.x_scale.scale).sort(
+                function(a, b) { return a - b; });
+            const range_y = this.model.get("selected_y").map(this.y_scale.scale).sort(
+                function(a, b) { return a - b; });
+            this.brush.move(this.d3el, [[range_x[0], range_y[0]], [range_x[1], range_y[1]]]);
+            this.brushsel = this.d3el.call(this.brush);
+        }
     }
 
     // TODO: check that we've properly overridden the mixin.
@@ -417,10 +425,12 @@ export class BrushIntervalSelector extends BrushMixinXSelector {
         this.set_range([this.scale]);
         this.brush.extent([[0, 0], [this.width, this.height]]);
 
-        const range = this.model.get("selected").map(this.scale.scale).sort(
-            function(a, b) { return a - b; });
-        this.brush.move(this.d3el, range);
-        this.brushsel = this.d3el.call(this.brush);
+        if(this.model.get("selected")) {
+            const range = this.model.get("selected").map(this.scale.scale).sort(
+                function(a, b) { return a - b; });
+            this.brush.move(this.d3el, range);
+            this.brushsel = this.d3el.call(this.brush);
+        }
     }
 
     reset() { }

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -21,6 +21,7 @@ import * as _ from 'underscore';
 import * as popperreference from './PopperReference';
 import popper from 'popper.js';
 import * as THREE from 'three';
+import { WidgetView } from '@jupyter-widgets/base';
 
 THREE.ShaderChunk['scales'] = require('raw-loader!../shaders/scales.glsl').default;
 
@@ -720,27 +721,28 @@ export class Figure extends widgets.DOMWidgetView {
         return [x_start, y_start];
     }
 
-    set_interaction(model) {
+    set_interaction(model) : Promise<WidgetView> {
         if (model) {
             // Sets the child interaction
-            const that = this;
-            model.state_change.then(function() {
+            return model.state_change.then(() => {
                 // Sets the child interaction
-                that.create_child_view(model).then(function(view) {
-                    if (that.interaction_view) {
-                        that.interaction_view.remove();
+                return this.create_child_view(model).then((view) => {
+                    if (this.interaction_view) {
+                        this.interaction_view.remove();
                     }
-                    that.interaction_view = view;
-                    that.interaction.node().appendChild(view.el);
-                    that.displayed.then(function() {
+                    this.interaction_view = view;
+                    this.interaction.node().appendChild(view.el);
+                    this.displayed.then(() => {
                         view.trigger("displayed");
                     });
+                    return view;
                 });
             });
         } else {
             if (this.interaction_view) {
                 this.interaction_view.remove();
             }
+            return Promise.resolve(null);
         }
     }
 

--- a/js/src/test/index.ts
+++ b/js/src/test/index.ts
@@ -7,3 +7,4 @@ import './lines';
 import './bars';
 import './utils';
 import './figure';
+import './interacts'

--- a/js/src/test/interacts.ts
+++ b/js/src/test/interacts.ts
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import {DummyManager} from './dummy-manager';
+import bqplot = require('..');
+import {create_model_bqplot, create_figure_scatter} from './widget-utils'
+
+
+describe("interacts >", () => {
+    beforeEach(async function() {
+        this.manager = new DummyManager({bqplot: bqplot});
+    });
+
+    it("brush selector basics", async function() {
+        let x = {dtype: 'float32', value: new DataView((new Float32Array([0,1])).buffer)};
+        let y = {dtype: 'float32', value: new DataView((new Float32Array([2,3])).buffer)};
+        let {figure, scatter} = await create_figure_scatter(this.manager, x, y);
+
+        let brush_selector = await create_model_bqplot(this.manager, 'BrushSelector', 'brush_selector_1', {
+            'x_scale': figure.model.get('scale_x').toJSON(), 'y_scale': figure.model.get('scale_y').toJSON(),
+            'marks': [scatter.model.toJSON()]
+        });
+        let brush_selector_view = await figure.set_interaction(brush_selector);
+        await brush_selector_view.displayed;
+        // all the events in figure are async, and we don't have access
+        // to the promises, so we manually call these methods
+        await brush_selector_view.create_scales()
+        await brush_selector_view.mark_views_promise;
+        brush_selector_view.relayout()
+        brush_selector.set('selected_x', [0.5, 1.5])
+        brush_selector.set('selected_y', [2.5, 3.5])
+        expect(scatter.model.get('selected')).to.deep.equal([1]);
+    });
+
+    it("brush interval selector basics", async function() {
+        let x = {dtype: 'float32', value: new DataView((new Float32Array([0,1])).buffer)};
+        let y = {dtype: 'float32', value: new DataView((new Float32Array([2,3])).buffer)};
+        let {figure, scatter} = await create_figure_scatter(this.manager, x, y);
+
+        let brush_interval_selector = await create_model_bqplot(this.manager, 'BrushIntervalSelector', 'brush_interval_selector_1', {
+            'scale': figure.model.get('scale_y').toJSON(), 'orientation': 'vertical',
+            'marks': [scatter.model.toJSON()]
+        });
+        let brush_interval_selector_view = await figure.set_interaction(brush_interval_selector);
+        await brush_interval_selector_view.displayed;
+        // all the events in figure are async, and we don't have access
+        // to the promises, so we manually call these methods
+        await brush_interval_selector_view.create_scales()
+        await brush_interval_selector_view.mark_views_promise;
+        brush_interval_selector_view.relayout()
+        brush_interval_selector.set('selected', [2.5, 3.5])
+        expect(scatter.model.get('selected')).to.deep.equal([1]);
+        brush_interval_selector.set('selected', [1.5, 2.5])
+        expect(scatter.model.get('selected')).to.deep.equal([0]);
+    });
+
+});


### PR DESCRIPTION
d3 seems to sometimes give the y-order of event.selection in reverse order, we now also sort the pixel coordinates.

Also, if the selections were empty, it would print out stack traces in the browser console, although this didn't cause an issue, it is not pretty. Tests are added to avoid regression.