### PR TITLE
fix: call super.process_hover/click consistently and without argument as array

### DIFF
--- a/js/src/Bars.ts
+++ b/js/src/Bars.ts
@@ -157,7 +157,7 @@ export class Bars extends Mark {
     }
 
     process_click(interaction) {
-        super.process_click.apply(this, [interaction]);
+        super.process_click(interaction);
         if (interaction === "select") {
             this.event_listeners.parent_clicked = this.reset_selection;
             this.event_listeners.element_clicked = this.bar_click_handler;

--- a/js/src/Boxplot.ts
+++ b/js/src/Boxplot.ts
@@ -315,7 +315,7 @@ export class Boxplot extends Mark {
     }
 
     process_click(interaction) {
-        super.process_click.apply(this, [interaction]);
+        super.process_click(interaction);
 
         if (interaction === "select") {
             this.event_listeners.parent_clicked = this.reset_selection;

--- a/js/src/Map.ts
+++ b/js/src/Map.ts
@@ -246,7 +246,7 @@ export class Map extends Mark {
     }
 
     process_click(interaction) {
-        super.process_click([interaction]);
+        super.process_click(interaction);
         if (interaction === "select") {
             this.event_listeners.parent_clicked = this.reset_selection;
             this.event_listeners.element_clicked = this.click_handler;
@@ -254,7 +254,7 @@ export class Map extends Mark {
     }
 
     process_hover(interaction) {
-        super.process_hover([interaction]);
+        super.process_hover(interaction);
         if(interaction === "tooltip") {
             this.event_listeners.mouse_over = () => {
                 this.mouseover_handler();

--- a/js/src/ScatterBase.ts
+++ b/js/src/ScatterBase.ts
@@ -304,7 +304,7 @@ export abstract class ScatterBase extends Mark {
     draw_elements(animate, elements_added) {}
 
     process_click(interaction) {
-        super.process_click([interaction]);
+        super.process_click(interaction);
         switch (interaction){
             case "add":
                 this.event_listeners.parent_clicked = this.add_element;


### PR DESCRIPTION
During the es6 transition ` ScatterBase.__super__.process_click.apply(this, [interaction]);`  was translated to `super.process_click.apply([interaction]);`, while we actually had to drop the array. This fixes the bug that causes tooltips now to appear on click, and makes the other calls consistent.