### PR TITLE
Auto width for bqplot figures

### DIFF
--- a/js/less/bqplot.less
+++ b/js/less/bqplot.less
@@ -107,7 +107,7 @@
 .bqplot {
     box-sizing: border-box;
     display: flex;
-    width: 640px;
+    width: auto;
     height: 480px;
 }
 .bqplot > .svg-background {

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -83,15 +83,13 @@ export class Figure extends widgets.DOMWidgetView {
             return_value["width"] = suggested_width;
             return_value["height"] = suggested_height;
         } else if (ratio > max_ratio) {
-            // The available space is too oblong horizontally.
-            // Use all vertical space and compute width based on maximum
-            // aspect ratio.
+            // Too much horizontal space
+            // Use all vertical space and compute width from max aspect ratio.
             return_value["height"] = suggested_height;
             return_value["width"] = suggested_height * max_ratio;
          } else { // ratio < min_ratio
-            // The available space is too oblong vertically.
-            // Use all horizontal space and compute height based on minimum
-            // aspect ratio.
+            // Too much vertical space
+            // Use all horizontal space and compute height from min aspect ratio.
             return_value["width"] = suggested_width;
             return_value["height"] = suggested_width / min_ratio;
         }


### PR DESCRIPTION
This PR removes the natural width of `bqplot`, which was `640px` and replaces it with `auto`.

This will make bqplot figures stretch horizontally in flexbox layouts, such as output areas and nested vboxes. People who were trying to obtain that behavior were generally setting `width` to `100%` causing the figure to overflow its container because of margins, and scrollbars to be displayed. With this change, this should not be required anymore.

Before:

![bqplot-normal-width](https://user-images.githubusercontent.com/2397974/66918433-a2f30a00-f01f-11e9-8407-b18eb71eb8de.png)

After:

![bqplot-full-width](https://user-images.githubusercontent.com/2397974/66917201-3bd45600-f01d-11e9-88e2-a1969ef8d6e5.png)

cc @kaiayoung @cquah @maartenbreddels @martinRenou @jasongrout 