### PR TITLE
fix: close vbox as well as figure to avoid issues with voila

### DIFF
--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -155,7 +155,8 @@ def show(key=None, display_toolbar=True):
     if display_toolbar:
         if not hasattr(figure, 'pyplot'):
             figure.pyplot = Toolbar(figure=figure)
-        display(VBox([figure, figure.pyplot]))
+            figure.pyplot_vbox = VBox([figure, figure.pyplot])
+        display(figure.pyplot_vbox)
     else:
         display(figure)
 
@@ -232,6 +233,7 @@ def close(key):
     fig = figure_registry[key]
     if hasattr(fig, 'pyplot'):
         fig.pyplot.close()
+        fig.pyplot_vbox.close()
     fig.close()
     del figure_registry[key]
     del _context['scale_registry'][key]


### PR DESCRIPTION
To avoid issues with voila it is better to also close the vbox when calling pyplot.close:
https://github.com/jupyter-widgets/ipywidgets/issues/2585
https://github.com/voila-dashboards/voila/issues/433

