### PR TITLE
fix: make pan and zoom work with Logscale

### DIFF
--- a/js/src/test/index.ts
+++ b/js/src/test/index.ts
@@ -7,4 +7,5 @@ import './lines';
 import './bars';
 import './utils';
 import './figure';
-import './interacts'
+import './interacts';
+require("../../css/bqplot.css");

--- a/js/src/test/interacts.ts
+++ b/js/src/test/interacts.ts
@@ -1,8 +1,16 @@
+import * as widgets from '@jupyter-widgets/base';
 import { expect } from 'chai';
 import {DummyManager} from './dummy-manager';
 import bqplot = require('..');
 import {create_model_bqplot, create_figure_scatter} from './widget-utils'
+import * as d3Timer from 'd3-timer';
 
+
+// text pixel coordinate
+const test_x = 200;
+const test_y = 250;
+const pixel_red = [255, 0, 0, 255];
+const pixel_black = [0, 0, 0, 255];
 
 describe("interacts >", () => {
     beforeEach(async function() {
@@ -51,5 +59,100 @@ describe("interacts >", () => {
         brush_interval_selector.set('selected', [1.5, 2.5])
         expect(scatter.model.get('selected')).to.deep.equal([0]);
     });
+
+
+    it("pan/zoom", async function() {
+        let x = {dtype: 'float32', value: new DataView((new Float32Array([0.5])).buffer)};
+        let y = {dtype: 'float32', value: new DataView((new Float32Array([2.5])).buffer)};
+        let {figure, scatter} = await create_figure_scatter(this.manager, x, y);
+        // scatter.model.set("default_size", 100*100);
+        scatter.model.set('default_size', 100*100);
+        scatter.model.set('colors', ['red']);
+        scatter.d3el.selectAll(".object_grp").data();
+
+        let panzoom = await create_model_bqplot(this.manager, 'PanZoom', 'panzoom', {
+            'scales': {'x': [figure.model.get('scale_x').toJSON()], 'y': [figure.model.get('scale_y').toJSON()]},
+        });
+        let panzoom_view = await figure.set_interaction(panzoom);
+        await panzoom_view.displayed;
+        await widgets.resolvePromisesDict(panzoom_view.scale_promises);
+
+        await figure.relayout();
+        // we want two cycles to make sure relayout is done (it is using requestAnimationFrame)
+        await new Promise(resolve => window.requestAnimationFrame(resolve));
+        await new Promise(resolve => window.requestAnimationFrame(resolve));
+
+        // first check if we have a red pixel in the center
+        let canvas = await figure.get_rendered_canvas();
+        let context = canvas.getContext("2d");
+        let pixel = context.getImageData(test_x*window.devicePixelRatio, test_y*window.devicePixelRatio, 1, 1);
+        expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_red);
+
+        // we pan to the right
+        panzoom_view._mousedown([0, 0])
+        await panzoom_view._mousemove([150, 0]);
+        d3Timer.timerFlush();
+
+        // and check if we find a red pixel there as well
+        canvas = await figure.get_rendered_canvas();
+        context = canvas.getContext("2d");
+        pixel = context.getImageData(test_x*window.devicePixelRatio, test_y*window.devicePixelRatio, 1, 1);
+        expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_black);
+
+        pixel = context.getImageData((test_x + 150)*window.devicePixelRatio, test_y*window.devicePixelRatio, 1, 1);
+        expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_red);
+
+
+        // check zooming
+        const scale_x = figure.model.get("scale_x");
+        const xmin = scale_x.get('min');
+        const xmax = scale_x.get('max');
+        await panzoom_view._zoom([test_x + 150, test_y], 10);
+        const xmin2 = scale_x.get('min');
+        const xmax2 = scale_x.get('max');
+        expect(xmin2).to.be.greaterThan(xmin);
+        expect(xmax2).to.be.lessThan(xmax);
+    });
+
+    it("pan/zoom log", async function() {
+        let x = {dtype: 'float32', value: new DataView((new Float32Array([1.])).buffer)};
+        let y = {dtype: 'float32', value: new DataView((new Float32Array([1.])).buffer)};
+        let {figure, scatter} = await create_figure_scatter(this.manager, x, y, false, true);
+        // scatter.model.set("default_size", 100*100);
+        scatter.model.set('default_size', 100*100);
+        scatter.model.set('colors', ['red']);
+        scatter.d3el.selectAll(".object_grp").data();
+
+        let panzoom = await create_model_bqplot(this.manager, 'PanZoom', 'panzoom', {
+            'scales': {'x': [figure.model.get('scale_x').toJSON()], 'y': [figure.model.get('scale_y').toJSON()]},
+        });
+        let panzoom_view = await figure.set_interaction(panzoom);
+        await panzoom_view.displayed;
+        await widgets.resolvePromisesDict(panzoom_view.scale_promises);
+
+        await figure.relayout();
+        // we want two cycles to make sure relayout is done (it is using requestAnimationFrame)
+        await new Promise(resolve => window.requestAnimationFrame(resolve));
+        await new Promise(resolve => window.requestAnimationFrame(resolve));
+        let canvas = await figure.get_rendered_canvas();
+        let context = canvas.getContext("2d");
+        let pixel = context.getImageData(test_x*window.devicePixelRatio, test_y*window.devicePixelRatio, 1, 1);
+        expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_red);
+
+        // we pan to the right
+        panzoom_view._mousedown([0, 0])
+        await panzoom_view._mousemove([150, 0]);
+        d3Timer.timerFlush();
+
+        // and check if we find a red pixel there as well
+        canvas = await figure.get_rendered_canvas();
+        context = canvas.getContext("2d");
+        pixel = context.getImageData(test_x*window.devicePixelRatio, test_y*window.devicePixelRatio, 1, 1);
+        expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_black);
+
+        pixel = context.getImageData((test_x + 150)*window.devicePixelRatio, test_y*window.devicePixelRatio, 1, 1);
+        expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_red);
+    });
+
 
 });

--- a/js/src/test/widget-utils.ts
+++ b/js/src/test/widget-utils.ts
@@ -35,10 +35,17 @@ async function create_widget(manager, name: string, id: string, args: Object) {
 }
 
 export
-async function create_figure_scatter(manager, x, y, mega=false) {
+async function create_figure_scatter(manager, x, y, mega=false, log=false) {
     let layout = await create_model(manager, '@jupyter-widgets/base', 'LayoutModel', 'LayoutView', 'layout_figure1', {_dom_classes: '', width: '400px', height: '500px'})
-    let scale_x = await create_model_bqplot(manager, 'LinearScale', 'scale_x', {min:0, max:1, allow_padding: false})
-    let scale_y = await create_model_bqplot(manager, 'LinearScale', 'scale_y', {min:2, max:3, allow_padding: false})
+    let scale_x;
+    let scale_y;
+    if (log) {
+        scale_x = await create_model_bqplot(manager, 'LogScale', 'scale_x', {min:0.01, max:100, allow_padding: false})
+        scale_y = await create_model_bqplot(manager, 'LogScale', 'scale_y',  {min:0.1, max:10, allow_padding: false})
+    } else {
+        scale_x = await create_model_bqplot(manager, 'LinearScale', 'scale_x', {min:0, max:1, allow_padding: false})
+        scale_y = await create_model_bqplot(manager, 'LinearScale', 'scale_y', {min:2, max:3, allow_padding: false})
+    }
     // TODO: the default values for the ColorScale should not be required, but defined in the defaults method
     let scale_color = await create_model_bqplot(manager, 'ColorScale', 'scale_color', {scheme: 'RdYlGn', colors: []})
     let scales = {x: scale_x.toJSON(), y: scale_y.toJSON(), color: scale_color.toJSON()}


### PR DESCRIPTION
Fixes #536

**Describe your changes**
The PanZoom widget now does the operations in pixel space, and converts those back to the domain. This allows panning and zooming to work with LogScale. The methods are refactored a bit such that the pan and zoom can be invoked from the unittests.

**Testing performed**
Panning is tested in linear and log axes by tracking the red color of the single scatter. Zooming is tested by checking that the scale domain is modified.

**Additional context**
This came up when moving ipyvolume to use bqplot scales: https://github.com/maartenbreddels/ipyvolume/pull/281

where I was making an example where I can pan for both ipyvolume and bqplot .

screencapture:
![scales-log-linear-color](https://user-images.githubusercontent.com/1765949/68478208-aa2cc280-022f-11ea-9ff9-7c3ca483d52a.gif)
