### PR TITLE
fix: avoids CORS error when building css for svg screenshot

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -787,7 +787,13 @@ export class Figure extends widgets.DOMWidgetView {
             const sheets = document.styleSheets;
             let selector;
             for (let i = 0; i < sheets.length; i++) {
-                const rules: any = (sheets[i] as CSSStyleSheet).cssRules;
+                let rules: any = null;
+                // due to CORS we may have some sheets we cannot access, instead of checking we always try
+                try {
+                    rules = (sheets[i] as CSSStyleSheet).cssRules;
+                } catch(e) {
+                    // ignore CORS errors
+                }
                 if (rules) {
                     for (let j = 0; j < rules.length; j++) {
                         const rule = rules[j];


### PR DESCRIPTION
Closed #758


**Describe your changes**
We now silently ignore any CORS issues when getting the effective CSS for the svg screenshot

**Testing performed**
I inserted a custom stylesheet in the notebook to reproduce #758 and confirmed this fixes the issue.
