### PR TITLE
fix: screenshot CSS was missing CSS variables

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -844,9 +844,9 @@ export class Figure extends widgets.DOMWidgetView {
             svg.setAttribute("version", "1.1");
             svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
             svg.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
-            const computedStyle = window.getComputedStyle(this.el);
-            svg.style.background = computedStyle.background;
+            svg.style.background = window.getComputedStyle(document.body).background;
 
+            const computedStyle = window.getComputedStyle(this.el);
             var cssCode = get_css(this.el, ["\.theme-dark", "\.theme-light", ".bqplot > ", ":root"]) + "\n";
             // extract all CSS variables, and generate a piece of css to define the variables
             var cssVariables = cssCode.match(/(--\w[\w-]*)/g) || [];

--- a/js/src/test/index.ts
+++ b/js/src/test/index.ts
@@ -7,5 +7,7 @@ import './lines';
 import './bars';
 import './utils';
 import './figure';
-import './interacts';
-require("../../css/bqplot.css");
+import './interacts'
+
+require('@jupyter-widgets/controls/css/widgets.css');
+require('../../css/bqplot.css');

--- a/js/src/test/interacts.ts
+++ b/js/src/test/interacts.ts
@@ -10,7 +10,7 @@ import * as d3Timer from 'd3-timer';
 const test_x = 200;
 const test_y = 250;
 const pixel_red = [255, 0, 0, 255];
-const pixel_black = [0, 0, 0, 255];
+const pixel_background = [255, 255, 255, 255];
 
 describe("interacts >", () => {
     beforeEach(async function() {
@@ -97,7 +97,7 @@ describe("interacts >", () => {
         canvas = await figure.get_rendered_canvas();
         context = canvas.getContext("2d");
         pixel = context.getImageData(test_x*window.devicePixelRatio, test_y*window.devicePixelRatio, 1, 1);
-        expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_black);
+        expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_background);
 
         pixel = context.getImageData((test_x + 150)*window.devicePixelRatio, test_y*window.devicePixelRatio, 1, 1);
         expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_red);
@@ -148,7 +148,7 @@ describe("interacts >", () => {
         canvas = await figure.get_rendered_canvas();
         context = canvas.getContext("2d");
         pixel = context.getImageData(test_x*window.devicePixelRatio, test_y*window.devicePixelRatio, 1, 1);
-        expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_black);
+        expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_background);
 
         pixel = context.getImageData((test_x + 150)*window.devicePixelRatio, test_y*window.devicePixelRatio, 1, 1);
         expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_red);


### PR DESCRIPTION
**Describe your changes**
From the CSS, I now extract the variables used, get the computed values, and define those css variables in the generated css.

**Testing performed**
Manually call fig.save_svg and test if the output matches the classical notebook. Maybe a good idea to also test in Lab, with dark mode.
