### PR TITLE
fix: use z-index:0 for all layers to not overlap with higher z-index elements

### DIFF
--- a/js/less/bqplot.less
+++ b/js/less/bqplot.less
@@ -119,10 +119,10 @@
 .bqplot > canvas {
     position: absolute;
     pointer-events: none;
-    z-index: 1;
+    z-index: 0;
 }
 .bqplot > svg {
-    z-index: 2;
+    z-index: 0;
     font: 11px sans-serif;
     user-select: none;
     -ms-user-select: none;


### PR DESCRIPTION
There was no need to use z-index > 0, and it can interfere with other DOM
elements, example:
https://github.com/voila-dashboards/voila-vuetify/issues/24

![image](https://user-images.githubusercontent.com/1765949/69967227-42a92080-1518-11ea-8fbf-1542afa10ee0.png)

**Describe your changes**
The WebGL and the main figure DOM element now have `z-index:0`, instead of 1 and 2 respectively. This renders exactly the same, since they are DOM siblings.

**Testing performed**
Tested in voila-vuetify to confirm it does not overlap anymore, and tested the Scatter notebook to see if all the interactions still work.

