### PR TITLE
Fix ordinal color scale

### DIFF
--- a/bqplot/scales.py
+++ b/bqplot/scales.py
@@ -559,4 +559,4 @@ class OrdinalColorScale(ColorScale):
     domain = List().tag(sync=True)
 
     _view_name = Unicode('OrdinalColorScale').tag(sync=True)
-    _model_name = Unicode('OrdinalScaleModel').tag(sync=True)
+    _model_name = Unicode('OrdinalColorScaleModel').tag(sync=True)

--- a/js/src/OrdinalColorScaleModel.ts
+++ b/js/src/OrdinalColorScaleModel.ts
@@ -1,0 +1,28 @@
+/* Copyright 2015 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OrdinalScaleModel } from './OrdinalScaleModel';
+import * as _ from 'underscore';
+
+export class OrdinalColorScaleModel extends OrdinalScaleModel {
+
+    defaults() {
+        return {...OrdinalScaleModel.prototype.defaults(),
+            _model_name: "OrdinalColorScaleModel",
+            _view_name: "OrdinalColorScale",
+            domain: [],
+        };
+    }
+}

--- a/js/src/OrdinalColorScaleModel.ts
+++ b/js/src/OrdinalColorScaleModel.ts
@@ -14,7 +14,6 @@
  */
 
 import { OrdinalScaleModel } from './OrdinalScaleModel';
-import * as _ from 'underscore';
 
 export class OrdinalColorScaleModel extends OrdinalScaleModel {
 

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -37,6 +37,7 @@ export * from './OrdinalScale';
 export * from './Label';
 export * from './LabelModel';
 export * from './OrdinalScaleModel';
+export * from './OrdinalColorScaleModel';
 export * from './BrushSelector';
 export * from './LassoSelector';
 export * from './PanZoom';


### PR DESCRIPTION
*Issue number of the reported bug or feature request: No existing issue on this*
This PR allows plots using OrdinalColorScale to render correctly on the front-end, using default values, without relying on the python backend to mutate OrdinalScaleModel.

**Describe your changes**
Added a OrdinalColorScaleModel.ts file which inherits from OrdinalScaleModel.ts.

**Testing performed**
Tested using generated static representation of various plots via sphinx

**Additional context**
Add any other context about your contribution here.
