### PR TITLE
Refactor Figure sizing logic

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -219,7 +219,7 @@ class Figure extends widgets.DOMWidgetView {
             const axis_views_updated = this.axis_views.update(this.model.get("axes"));
 
             // TODO: move to the model
-            this.model.on_some_change(["fig_margin", "min_aspect_ration", "max_aspect_ratio"], this.relayout, this);
+            this.model.on_some_change(["fig_margin", "min_aspect_ratio", "max_aspect_ratio"], this.relayout, this);
             this.model.on_some_change(["padding_x", "padding_y"], () => {
                 this.figure_padding_x = this.model.get("padding_x");
                 this.figure_padding_y = this.model.get("padding_y");

--- a/js/src/MarketMap.ts
+++ b/js/src/MarketMap.ts
@@ -35,12 +35,10 @@ export class MarketMap extends Figure {
 
     render(options?) {
         this.id = widgets.uuid();
-        const min_width = String(this.model.get("layout").get("min_width"));
-        const min_height = String(this.model.get("layout").get("min_height"));
 
-        const impl_dimensions = this._get_height_width(min_height.slice(0, -2), min_width.slice(0, -2));
-        this.width = impl_dimensions["width"];
-        this.height = impl_dimensions["height"];
+        const figureSize = this.getFigureSize();
+        this.width = figureSize.width;
+        this.height = figureSize.height;
 
         this.scales = {};
         this.set_top_el_style();
@@ -187,9 +185,9 @@ export class MarketMap extends Figure {
     relayout() {
         const that = this;
 
-        const impl_dimensions = this._get_height_width(this.el.clientHeight, this.el.clientWidth);
-        this.width = impl_dimensions["width"];
-        this.height = impl_dimensions["height"];
+        const figureSize = this.getFigureSize();
+        this.width = figureSize.width;
+        this.height = figureSize.height;
 
         window.requestAnimationFrame(function () {
             // update ranges


### PR DESCRIPTION
**Describe your changes**
Before this change, the Figure was rendered once with a default size of `640x480` before `this.el` was even attached to the DOM. And there was a resize when the element is actually attached to the page.

After the change, the Figure waits for `this.el` to be attached before doing any rendering, and it renders in the available space specified by the CSS rules (width: auto, height: 480 by default). This prevents doing an extra resize, and it prevents the figure to take a first hardcoded size.