### PR TITLE
fix: ColorScale can miss events because render does not return a Promise

### DIFF
--- a/js/src/ColorAxis.ts
+++ b/js/src/ColorAxis.ts
@@ -35,7 +35,7 @@ class ColorBar extends Axis {
         this.ordinal = false;
         this.num_ticks = this.model.get("num_ticks");
         const that = this;
-        scale_promise.then(function() {
+        return scale_promise.then(function() {
             that.create_listeners();
             that.tick_format = that.generate_tick_formatter();
             that.set_scales_range();


### PR DESCRIPTION
*fixes: #981*

**Describe your changes**
Render should return a promise, otherwise, the Figure will not wait before sending events, causing the ColorAxis to miss them, which in turn causes a layout issue.

**Testing performed**
This is a timing issue, which only happens when there are many browser tabs open, or other forms of delay. This cannot be unit tested as it. It is however not observed to occur with this change.

