### PR TITLE
add event listeners and classes to render tooltip for OHLC mark

### DIFF
--- a/js/src/OHLC.ts
+++ b/js/src/OHLC.ts
@@ -25,15 +25,19 @@ export class OHLC extends Mark {
         const base_creation_promise = super.render();
 
         const that = this;
+        this.display_el_classes = ["stick_body", "stick_tail", "stick_head"] ;
+
         this.displayed.then(function() {
             that.parent.tooltip_div.node().appendChild(that.tooltip_div.node());
             that.create_tooltip();
         });
 
         return base_creation_promise.then(function() {
+            that.event_listeners = {};
+            that.process_interactions();
             that.create_listeners();
-            that.draw(); },
-        null);
+            that.draw(); 
+        });
     }
 
     set_ranges() {
@@ -57,11 +61,24 @@ export class OHLC extends Mark {
         });
     }
 
+    /**
+     * Creates event listeners and binds them to rendered d3 elements
+     */
     create_listeners() {
-        super.create_listeners();
-        this.d3el.on("mouseover", _.bind(this.mouse_over, this))
-            .on("mousemove", _.bind(this.mouse_move, this))
-            .on("mouseout", _.bind(this.mouse_out, this));
+        super.create_listeners.apply(this);
+        this.d3el
+            .on("mouseover", _.bind(function() {
+                this.event_dispatcher("mouse_over");
+            }, this))
+            .on("mousemove", _.bind(function() {
+                this.event_dispatcher("mouse_move");
+            }, this))
+            .on("mouseout", _.bind(function() {
+                this.event_dispatcher("mouse_out");
+            }, this));
+
+        this.listenTo(this.model, "change:tooltip", this.create_tooltip);
+        this.listenTo(this.model, "change:interactions", this.process_interactions);
 
         this.listenTo(this.model, "change:stroke", this.update_stroke);
         this.listenTo(this.model, "change:stroke_width", this.update_stroke_width);


### PR DESCRIPTION
Signed-off-by: idafna <idafna@bloomberg.net>

**Describe your changes**
Added event listeners and relevant class names to monitor for tooltips to appear when hovering on OHLC marks.

**Testing performed**
No unit testing done, but tooltips now appear. 

** Code to test the feature **
```python
import bqplot as bqp
import numpy as np

price_data1 = [['2015-01-02 00:00:00', [161.31, 163.31, 161.0, 162.06]],
              ['2015-01-05 00:00:00', [161.27, 161.27, 159.19, 159.51]],
              ['2015-01-06 00:00:00', [159.67, 159.96, 155.17, 156.07]],
              ['2015-01-07 00:00:00', [157.2, 157.2, 154.03, 155.05]],
              ['2015-01-08 00:00:00', [156.24, 159.044, 155.55, 158.42]],
              ['2015-01-09 00:00:00', [158.42, 160.34, 157.25, 159.11]],
              ['2015-01-12 00:00:00', [159.0, 159.25, 155.76, 156.44]],
              ['2015-01-13 00:00:00', [157.26, 159.97, 155.68, 156.81]],
              ['2015-01-14 00:00:00', [154.86, 156.49, 153.74, 155.8]],
              ['2015-01-15 00:00:00', [156.69, 156.97, 154.16, 154.57]]]

price_data2 = [['2015-01-02 00:00:00', [111.39, 111.44, 107.35, 109.33]],
               ['2015-01-05 00:00:00', [108.29, 108.65, 105.41, 106.25]],
               ['2015-01-06 00:00:00', [106.54, 107.43, 104.63, 106.26]],
               ['2015-01-07 00:00:00', [107.2, 108.2, 106.695, 107.75]],
               ['2015-01-08 00:00:00', [109.23, 112.15, 108.7, 111.89]],
               ['2015-01-09 00:00:00', [112.67, 113.25, 110.21, 112.01]],
               ['2015-01-12 00:00:00', [112.6, 112.63, 108.8, 109.25]],
               ['2015-01-13 00:00:00', [111.43, 112.8, 108.91, 110.22]],
               ['2015-01-14 00:00:00', [109.04, 110.49, 108.5, 109.8]],
               ['2015-01-15 00:00:00', [110.0, 110.06, 106.66, 106.82]]]

# Split up the data into x and y points
from bqplot.traits import convert_to_date

dates1 = convert_to_date([d[0] for d in price_data1])
prices1 = [d[1] for d in price_data1]

dates2 = convert_to_date([d[0] for d in price_data2])
prices2 = [d[1] for d in price_data2]

sc_x = bqp.OrdinalScale()
sc_y = bqp.LinearScale()

ttip = bqp.Tooltip(fields=['open', 'high', 'low', 'close'], formats=['.2f']*4)

ax_x = bqp.Axis(label='X', scale=sc_x, tick_format='%d-%m-%Y')
ax_y = bqp.Axis(label='Y', scale=sc_y, orientation='vertical', tick_format='0.2f')

ohlc3 = bqp.OHLC(x=dates2, y=np.array(prices2) / 60, marker='candle', 
             scales={'x': sc_x, 'y': sc_y}, colors=['dodgerblue','orange'],
                tooltip=ttip)

bqp.Figure(axes=[ax_x, ax_y], marks=[ohlc3])
```
