### PR TITLE
performance: avoid calling relayout too often

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -89,7 +89,7 @@ class Figure extends widgets.DOMWidgetView {
         });
     }
 
-    private renderImpl (args: any) {
+    private renderImpl () {
         const figureSize = this.getFigureSize();
         this.width = figureSize.width;
         this.height = figureSize.height;
@@ -253,11 +253,7 @@ class Figure extends widgets.DOMWidgetView {
 
             document.body.appendChild(this.tooltip_div.node());
             this.create_listeners();
-            if(args === undefined || args.add_to_dom_only !== true) {
-                //do not relayout if it is only being added to the DOM
-                //and not displayed.
-                this.relayout();
-            }
+
             // In the classic notebook, we should relayout the figure on
             // resize of the main window.
             window.addEventListener('resize', () => {

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -551,7 +551,10 @@ class Figure extends widgets.DOMWidgetView {
         super.processPhosphorMessage.apply(this, arguments);
         switch (msg.type) {
         case 'resize':
-            this.relayout();
+            const figureSize = this.getFigureSize();
+            if ((this.width !== figureSize.width) || (this.height !== figureSize.height)) {
+                this.relayout();
+            }
             break;
         }
     }

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -82,7 +82,11 @@ class Figure extends widgets.DOMWidgetView {
     }
 
     render () {
-        this.displayed.then(this.renderImpl.bind(this));
+        // we cannot use Promise.all here, since this.layoutPromise is resolved, and will be overwritten later on
+        this.displayed.then(() => {
+            // make sure we render after all layouts styles are set, since they can affect the size
+            this.layoutPromise.then(this.renderImpl.bind(this));
+        });
     }
 
     private renderImpl (args: any) {

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -256,8 +256,10 @@ class Figure extends widgets.DOMWidgetView {
 
             // In the classic notebook, we should relayout the figure on
             // resize of the main window.
-            window.addEventListener('resize', () => {
-                this.relayout();
+            const relayoutMethod = this.relayout.bind(this);
+            window.addEventListener('resize', relayoutMethod);
+            this.once('remove', () => {
+                window.removeEventListener('resize', relayoutMethod);
             });
 
             return Promise.all([mark_views_updated, axis_views_updated]);

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -554,11 +554,11 @@ class Figure extends widgets.DOMWidgetView {
     }
 
     relayout() {
-        const figureSize = this.getFigureSize();
-        this.width = figureSize.width;
-        this.height = figureSize.height;
-
-        window.requestAnimationFrame(() => {
+        const relayoutImpl = () => {
+            this.relayoutRequested = false; // reset relayout request
+            const figureSize = this.getFigureSize();
+            this.width = figureSize.width;
+            this.height = figureSize.height;
             // update ranges
             this.margin = this.model.get("fig_margin");
             this.update_plotarea_dimensions();
@@ -597,8 +597,12 @@ class Figure extends widgets.DOMWidgetView {
             this.trigger("margin_updated");
             this.update_legend();
             this.layout_webgl_canvas();
-        });
+        };
 
+        if (!this.relayoutRequested) {
+            this.relayoutRequested = true; // avoid scheduling a relayout twice
+            requestAnimationFrame(relayoutImpl.bind(this))
+        }
     }
 
     layout_webgl_canvas() {
@@ -975,6 +979,7 @@ class Figure extends widgets.DOMWidgetView {
     y_padding_arr: any;
 
     private _update_requested: boolean;
+    private relayoutRequested: boolean = false;
     // this is public for the test framework, but considered a private API
     public _initial_marks_created: Promise<any>;
     private _initial_marks_created_resolve: Function;

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -547,7 +547,6 @@ class Figure extends widgets.DOMWidgetView {
         super.processPhosphorMessage.apply(this, arguments);
         switch (msg.type) {
         case 'resize':
-        case 'after-attach':
             this.relayout();
             break;
         }

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -256,10 +256,12 @@ class Figure extends widgets.DOMWidgetView {
 
             // In the classic notebook, we should relayout the figure on
             // resize of the main window.
-            const relayoutMethod = this.relayout.bind(this);
-            window.addEventListener('resize', relayoutMethod);
+            this.debouncedRelayout = _.debounce(() => {
+                this.relayout();
+            }, 300);
+            window.addEventListener('resize', this.debouncedRelayout);
             this.once('remove', () => {
-                window.removeEventListener('resize', relayoutMethod);
+                window.removeEventListener('resize', this.debouncedRelayout);
             });
 
             return Promise.all([mark_views_updated, axis_views_updated]);
@@ -551,7 +553,7 @@ class Figure extends widgets.DOMWidgetView {
         case 'resize':
             const figureSize = this.getFigureSize();
             if ((this.width !== figureSize.width) || (this.height !== figureSize.height)) {
-                this.relayout();
+                this.debouncedRelayout();
             }
             break;
         }
@@ -953,6 +955,7 @@ class Figure extends widgets.DOMWidgetView {
     change_layout: any;
     clip_id: any;
     clip_path: any;
+    debouncedRelayout: any;
     fig_axes: any;
     fig_interaction: any;
     fig_marks: any;


### PR DESCRIPTION
**Describe your changes**
Figure.relayout is being called very often (5x at initial display), and unconditionally will do the work (call requestAnimation). These calls can stack up when resizing the window as well, leading to bad performance. We now keep track if the relayout was already requested, and will only schedule a new one when the last one is finished (similar to how we do it with webgl and in ipyvolume).

**Testing performed**
Tests pass, and tested in notebook. Putting a log statement in relayoutImpl shows 5 prints before, 2 after (so I think we can still improve even more if we want).

