### PR TITLE
Fix: Render/resize the plot only if it is visible

### DIFF
--- a/js/src/test/dummy-manager.ts
+++ b/js/src/test/dummy-manager.ts
@@ -69,6 +69,10 @@ class DummyManager extends base.ManagerBase<HTMLElement> {
             view.on('remove', () => console.log('view removed', view));
             (<any>window).last_view = view
             view.trigger('displayed')
+
+            // @ts-ignore: This will tell the bqplot figure it can render
+            view.shown();
+
             return view.el;
         });
     }

--- a/js/src/test/widget-utils.ts
+++ b/js/src/test/widget-utils.ts
@@ -27,14 +27,6 @@ async function create_view(manager, model, options = {}) {
 }
 
 export
-async function create_widget(manager, name: string, id: string, args: Object) {
-    let model = await create_model_bqplot(manager, name, id, args)
-    let view = await manager.create_view(model);
-    await manager.display_view(undefined, view);
-    return {model: model, view:view};
-}
-
-export
 async function create_figure_scatter(manager, x, y, mega=false, log=false) {
     let layout = await create_model(manager, '@jupyter-widgets/base', 'LayoutModel', 'LayoutView', 'layout_figure1', {_dom_classes: '', width: '400px', height: '500px'})
     let scale_x;


### PR DESCRIPTION
This delays the rendering and the resize of the plot to when the plot is actually visible on the page.

It is using the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) for knowing if the plot is visible on the page or not

This fixes an issue when having bqplots in Tab widgets.

Fixes https://github.com/bloomberg/bqplot/issues/1023

This is related to https://github.com/jupyter-widgets/ipywidgets/issues/2605