### PR TITLE
Fix: Mark.selected should be a TypedArray / selection echo

### DIFF
--- a/js/src/Bars.ts
+++ b/js/src/Bars.ts
@@ -220,7 +220,7 @@ export class Bars extends Mark {
         }
 
         const abs_diff = this.x_pixels.map(function (elem) { return Math.abs(elem - pixel); });
-        this.model.set("selected", [abs_diff.indexOf(d3.min(abs_diff))]);
+        this.model.set("selected", new Uint32Array([abs_diff.indexOf(d3.min(abs_diff))]));
         this.touch();
     }
 
@@ -231,10 +231,10 @@ export class Bars extends Mark {
             return [];
         }
         const pixels = this.pixel_coords;
-        const indices = _.range(pixels.length);
+        const indices = new Uint32Array(_.range(pixels.length));
         // Here we only select bar groups. It shouldn't be too hard to select
         // individual bars, the `selected` attribute would then be a list of pairs.
-        const selected_groups = _.filter(indices, function (index) {
+        const selected_groups = indices.filter(index => {
             let bars = pixels[index];
             for (let i = 0; i < bars.length; i++) {
                 if (rect_selector(bars[i])) { return true; }
@@ -915,7 +915,7 @@ export class Bars extends Mark {
             }
         }
         this.model.set("selected",
-            ((selected.length === 0) ? null : selected),
+            ((selected.length === 0) ? null : new Uint32Array(selected)),
             { updated_view: this });
         this.touch();
         const e = d3GetEvent();

--- a/js/src/Boxplot.ts
+++ b/js/src/Boxplot.ts
@@ -234,8 +234,8 @@ export class Boxplot extends Mark {
             return [];
         }
         const pixels = this.pixel_coords;
-        const indices = _.range(pixels.length);
-        const selected = _.filter(indices, function(index) {
+        const indices = new Uint32Array(_.range(pixels.length));
+        const selected = indices.filter(index => {
             return rect_selector(pixels[index]);
         });
         this.update_selected_colors(selected)
@@ -254,7 +254,7 @@ export class Boxplot extends Mark {
         const abs_diff = this.x_pixels.map(function(elem) { return Math.abs(elem - pixel); });
         const sel_index = abs_diff.indexOf(d3.min(abs_diff));
 
-        this.model.set("selected", [sel_index]);
+        this.model.set("selected", new Uint32Array([sel_index]));
         this.update_selected_colors([sel_index]);
         this.touch();
         return sel_index;
@@ -373,7 +373,7 @@ export class Boxplot extends Mark {
             }
         }
         this.model.set("selected",
-                       ((selected.length === 0) ? null : selected),
+                       ((selected.length === 0) ? null : new Uint32Array(selected)),
                        {updated_view: this});
         this.touch();
         const e = d3GetEvent();

--- a/js/src/BrushSelector.ts
+++ b/js/src/BrushSelector.ts
@@ -366,7 +366,7 @@ export class BrushIntervalSelector extends BrushMixinXSelector {
 
     empty_selection() {
         this.update_mark_selected();
-        this.model.set("selected", []);
+        this.model.set("selected", new Uint32Array([]));
         this.touch();
     }
 

--- a/js/src/Hist.ts
+++ b/js/src/Hist.ts
@@ -415,8 +415,8 @@ export class Hist extends Mark {
             return [];
         }
         const pixels = this.pixel_coords;
-        const indices = _.range(pixels.length);
-        const selected_bins = _.filter(indices, function(index) {
+        const indices = new Uint32Array(_.range(pixels.length));
+        const selected_bins = indices.filter(index => {
             return rect_selector(pixels[index]);
         });
         this.model.set("selected", this.calc_data_indices(selected_bins));
@@ -433,7 +433,8 @@ export class Hist extends Mark {
 
         const x_data = this.model.get("sample");
         const num_intervals = intervals.length;
-        const selected = _.filter(_.range(x_data.length), function(index) {
+        const indices_data = new Uint32Array(_.range(x_data.length));
+        const selected = indices_data.filter(index => {
             const elem = x_data[index];
             for(let iter=0; iter < num_intervals; iter++) {
                 if(elem <= intervals[iter][1] && elem >= intervals[iter][0]) {

--- a/js/src/Lines.ts
+++ b/js/src/Lines.ts
@@ -271,8 +271,8 @@ export class Lines extends Mark {
             return [];
         }
         const pixels = this.pixel_coords;
-        const indices = _.range(pixels.length);
-        const selected = _.filter(indices, function(index) {
+        const indices = new Uint32Array(_.range(pixels.length));
+        const selected = indices.filter(index => {
             return point_selector(pixels[index]);
         });
         this.model.set("selected", selected);
@@ -288,7 +288,7 @@ export class Lines extends Mark {
 
         const index = Math.min(this.bisect(this.x_pixels, pixel),
           Math.max((this.x_pixels.length - 1), 0));
-        this.model.set("selected", [index]);
+        this.model.set("selected", new Uint32Array([index]));
         this.touch();
     }
 

--- a/js/src/OHLC.ts
+++ b/js/src/OHLC.ts
@@ -288,9 +288,9 @@ export class OHLC extends Mark {
             return selected;
         }
 
-        const indices = _.range(this.model.mark_data.length);
+        const indices = new Uint32Array(_.range(this.model.mark_data.length));
         const that = this;
-        const selected = _.filter(indices, function(index) {
+        const selected = indices.filter(index => {
             const elem = that.x_pixels[index];
             return (elem >= start_pxl && elem <= end_pxl);
         });

--- a/js/src/OHLC.ts
+++ b/js/src/OHLC.ts
@@ -308,7 +308,7 @@ export class OHLC extends Mark {
         this.update_selected_colors(idx_start, idx_end);
         this.model.set("selected", selected);
         this.touch();
-        return selected;
+        return super.invert_range(start_pxl, end_pxl);
     }
 
     invert_point(pixel) {

--- a/js/src/Pie.ts
+++ b/js/src/Pie.ts
@@ -477,7 +477,7 @@ export class Pie extends Mark {
             selected.push(index);
         }
         this.model.set("selected",
-            ((selected.length === 0) ? null : selected),
+            ((selected.length === 0) ? null : new Uint32Array(selected)),
             {updated_view: this});
         this.touch();
         const e = d3GetEvent();

--- a/js/src/ScatterBase.ts
+++ b/js/src/ScatterBase.ts
@@ -342,9 +342,9 @@ export abstract class ScatterBase extends Mark {
     }
 
     scatter_click_handler(args) {
-        const index = args.index;
+        const index : number = args.index;
         const idx = this.model.get("selected") || [];
-        let selected = Array.from(idx);
+        let selected : Array<number> = Array.from(idx);
         // index of bar i. Checking if it is already present in the list.
         const elem_index = selected.indexOf(index);
         // Replacement for "Accel" modifier.
@@ -370,7 +370,7 @@ export abstract class ScatterBase extends Mark {
             }
         }
         this.model.set("selected",
-                       ((selected.length === 0) ? null : selected),
+                       ((selected.length === 0) ? null : new Uint32Array(selected)),
                        {updated_view: this});
         this.touch();
         let e = d3GetEvent();
@@ -461,7 +461,7 @@ export abstract class ScatterBase extends Mark {
         const abs_diff = this.x_pixels.map((elem) => { return Math.abs(elem - pixel); });
         const sel_index = abs_diff.indexOf(d3.min(abs_diff));
 
-        this.model.set("selected", [sel_index]);
+        this.model.set("selected", new Uint32Array([sel_index]));
         this.touch();
     }
 
@@ -472,8 +472,8 @@ export abstract class ScatterBase extends Mark {
             return [];
         }
         const pixels = this.pixel_coords;
-        const indices = _.range(pixels.length);
-        const selected = _.filter(indices, function(index) {
+        const indices = new Uint32Array(_.range(pixels.length));
+        const selected = indices.filter(index => {
             return point_selector(pixels[index]);
         });
         this.model.set("selected", selected);

--- a/js/src/test/interacts.ts
+++ b/js/src/test/interacts.ts
@@ -2,7 +2,7 @@ import * as widgets from '@jupyter-widgets/base';
 import { expect } from 'chai';
 import {DummyManager} from './dummy-manager';
 import bqplot = require('..');
-import {create_model_bqplot, create_figure_scatter} from './widget-utils'
+import {create_model_bqplot, create_figure_scatter, create_figure_bars} from './widget-utils'
 import * as d3Timer from 'd3-timer';
 
 
@@ -35,7 +35,9 @@ describe("interacts >", () => {
         brush_selector_view.relayout()
         brush_selector.set('selected_x', [0.5, 1.5])
         brush_selector.set('selected_y', [2.5, 3.5])
-        expect(scatter.model.get('selected')).to.deep.equal([1]);
+        let indices = scatter.model.get('selected')
+        expect([...indices]).to.deep.equal([1]);
+        expect(indices).to.be.an.instanceof(Uint32Array)
     });
 
     it("brush interval selector basics", async function() {
@@ -55,9 +57,33 @@ describe("interacts >", () => {
         await brush_interval_selector_view.mark_views_promise;
         brush_interval_selector_view.relayout()
         brush_interval_selector.set('selected', [2.5, 3.5])
-        expect(scatter.model.get('selected')).to.deep.equal([1]);
+        expect([...scatter.model.get('selected')]).to.deep.equal([1]);
         brush_interval_selector.set('selected', [1.5, 2.5])
-        expect(scatter.model.get('selected')).to.deep.equal([0]);
+        expect([...scatter.model.get('selected')]).to.deep.equal([0]);
+    });
+
+    it("brush interval selector on bars", async function() {
+        let x = {dtype: 'float32', value: new DataView((new Float32Array([0,1])).buffer)};
+        let y = {dtype: 'float32', value: new DataView((new Float32Array([2,3])).buffer)};
+        let { figure, bars } = await create_figure_bars(this.manager, x, y);
+
+        let brush_interval_selector = await create_model_bqplot(this.manager, 'BrushIntervalSelector', 'brush_interval_selector_1', {
+            'scale': figure.model.get('scale_x').toJSON(), 'orientation': 'horizontal',
+            'marks': [bars.model.toJSON()]
+        });
+        let brush_interval_selector_view = await figure.set_interaction(brush_interval_selector);
+        await brush_interval_selector_view.displayed;
+        // all the events in figure are async, and we don't have access
+        // to the promises, so we manually call these methods
+        await brush_interval_selector_view.create_scales()
+        await brush_interval_selector_view.mark_views_promise;
+        brush_interval_selector_view.relayout()
+        d3Timer.timerFlush(); // this makes sure the animations are all executed
+        brush_interval_selector.set('selected', [0.9, 1.1])
+        expect([...bars.model.get('selected')]).to.deep.equal([1]);
+        brush_interval_selector.set('selected', [-0.1, 1.1])
+        expect([...bars.model.get('selected')]).to.deep.equal([0, 1]);
+        expect(bars.model.get('selected')).to.be.an.instanceof(Uint32Array)
     });
 
 


### PR DESCRIPTION
**Describe your changes**
The `Mark.selected` attribute should be a typed array. Although bqplot supports JSON/lists, they will be converted to a numpy array on the kernel side. This will then be seen as a change on the kernel and will be sent back to the frontend. This causes a lot of echoing, causing old selections to be visible in between.


**Testing performed**
ScatterBase and Hist are tested, the rest follows a similar pattern.

**Unrelated issue**
I also had to change the return value of OHCL, since TypeScript complained. I am not sure this is correct, since I don't understand this method. A review would be wise.