### PR TITLE
bqplot 0.12.3, npm package 0.5.3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,40 +1,71 @@
 To release a new version of bqplot on PyPI:
 
-## Cleanup the repository
+## Create a new environment for the release
 
-git clean -fdx
+```sh
+conda create -c conda-forge --override-channels -y -n bqplotrelease jupyterlab nodejs twine ipywidgets pip
+conda activate bqplotrelease
+```
+
+## Check out a fresh copy of the repo
+
+We check out a fresh copy in a `release/` subdirectory to make sure we do not
+overwrite our development repo.
+
+```sh
+mkdir -p release
+cd release
+# Delete any previous checkout we have here.
+rm -rf bqplot
+
+
+git clone git@github.com:bloomberg/bqplot.git
+cd bqplot
+```
 
 ## Release the npm package
 
+```sh
 cd js/
 npm version [Major/minor/patch]
 npm install
 npm publish
+cd ..
+```
 
 ## Release the pypi package
 
-Update _version.py (set release version, remove 'dev')
+Update _version.py (bump both the python package version, and if needed, the Javascript version)
+
+```
 git clean -dfx
 python setup.py sdist
 python setup.py bdist_wheel
 twine upload dist/*
+```
 
 ## Tag the repository
 
-git add and git commit
-git tag -a X.X.X -m 'comment'
-git push upstream
-git push upstream --tags
+Check to make sure the only changes are to the `package.json`, `package-lock.json`, and `_version.py` files:
+
+```sh
+git diff
+```
+
+Commit the changes in git
+
+```sh
+git commit -sa
+```
+
+Tag the release
+
+```sh
+git tag [version, like 0.12.4]
+```
+
+Push your change to a new PR and ask for a review to merge the PR.
 
 ## Update the recipe on conda-forge and set the stable branch to the newly tagged commit
 
-git checkout stable
-git reset master
-git push upstream stable
-
-## Back to dev
-
-git checkout master
-Update _version.py (add 'dev' and increment minor)
-git add and git commit
-git push upstream master
+Update the [conda-forge feedstock](https://github.com/conda-forge/bqplot-feedstock/).

--- a/bqplot/_version.py
+++ b/bqplot/_version.py
@@ -1,8 +1,8 @@
-version_info = (0, 12, 2, 'final', 0)
+version_info = (0, 12, 3, 'final', 0)
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 
 __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
   '' if version_info[3]=='final' else _specifier_[version_info[3]]+str(version_info[4]))
 
-__frontend_version__ = '^0.5.2'
+__frontend_version__ = '^0.5.3'

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bqplot",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bqplot",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "bqplot",
   "author": {
     "name": "BQPlot Development team",


### PR DESCRIPTION
This is the tagged published release commit for bqplot 0.12.3, npm package 0.5.3.

dist/bqplot-0.12.3-py2.py3-none-any.whl
md5: e0829197d0287783f30419a56d210814
sha1: c33cd72452c0035f194293bde5fa855d87d55f51
sha256: b1b9664c4faaae91ec3773b1083bfa97108a4d6556109afed2ebaeab8c5c83b6

dist/bqplot-0.12.3.tar.gz
md5: 78520772cc1aa7770bcf02eaadf81541
sha1: 7e262468ff2189b3de397b86315e63206a213337
sha256: 7292b57694ebe8347e48e16bd47449bbd886f9c2c238b744ed59871960451b59

CC @kaiayoung 