### PR TITLE
Fix error with `invert` not being a d3's Ordinal scale method

### DIFF
--- a/js/src/BrushSelector.ts
+++ b/js/src/BrushSelector.ts
@@ -268,12 +268,12 @@ export class BrushSelector extends BrushMixinXYSelector {
             // d3 does not always (!) give the selection in [[xmin, xmax], [ymin, ymax]] order
             // so we sort it to be sure
             var sortFunction = (a: number, b: number) => a - b;
-            pixel_extent_x.sort(sortFunction)
-            pixel_extent_y.sort(sortFunction)
+            pixel_extent_x.sort(sortFunction);
+            pixel_extent_y.sort(sortFunction);
 
-            const extent_x = pixel_extent_x.map(this.x_scale.scale.invert).sort(
+            const extent_x = pixel_extent_x.map(this.x_scale.invert.bind(this.x_scale)).sort(
                 (a: number, b: number) => a - b);
-            const extent_y = pixel_extent_y.map(this.y_scale.scale.invert).sort(
+            const extent_y = pixel_extent_y.map(this.y_scale.invert.bind(this.y_scale)).sort(
                 (a: number, b: number) => a - b);
 
             this.update_mark_selected(pixel_extent_x, pixel_extent_y);
@@ -377,7 +377,7 @@ export class BrushIntervalSelector extends BrushMixinXSelector {
             this.empty_selection();
         } else {
             const pixel_extent = e.selection;
-            const extent = pixel_extent.map(this.scale.scale.invert).sort(
+            const extent = pixel_extent.map(this.scale.invert.bind(this.scale)).sort(
                 (a, b) => a - b);
             this.update_mark_selected(pixel_extent);
 
@@ -608,7 +608,7 @@ export class MultiSelector extends BrushMixinXSelector {
             this.touch();
         } else {
             const selected = utils.deepCopy(this.model.get("_selected"));
-            selected[this.get_label(item)] = extent.map(this.scale.scale.invert);
+            selected[this.get_label(item)] = extent.map(this.scale.invert.bind(this.scale));
             this.update_mark_selected(extent);
             this.model.set("_selected", selected);
             this.touch();

--- a/js/src/ScatterBase.ts
+++ b/js/src/ScatterBase.ts
@@ -561,12 +561,12 @@ export abstract class ScatterBase extends Mark {
 
         if (!this.model.get("restrict_y")){
             const x = this.model.get('x').slice(); // copy
-            x[i] = x_scale.scale.invert(d[0]);
+            x[i] = x_scale.invert(d[0]);
             this.model.set("x", x);
         }
         if (!this.model.get("restrict_x")){
             const y = this.model.get('y').slice()
-            y[i] = y_scale.scale.invert(d[1]);
+            y[i] = y_scale.invert(d[1]);
             this.model.set("y", y);
         }
         this.touch();
@@ -663,8 +663,8 @@ export abstract class ScatterBase extends Mark {
         const yn = new y.constructor(y.length+1)
         xn.set(x)
         yn.set(y)
-        xn[x.length] = x_scale.scale.invert(curr_pos[0]);
-        yn[y.length] = y_scale.scale.invert(curr_pos[1]);
+        xn[x.length] = x_scale.invert(curr_pos[0]);
+        yn[y.length] = y_scale.invert(curr_pos[1]);
         this.model.set("x", xn);
         this.model.set("y", yn);
         this.touch();


### PR DESCRIPTION
Related to #780 