### PR TITLE
Update to work in JupyterLab 2.0

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -56,7 +56,9 @@
     "webpack-cli": "^3.0.8"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^2.0.0",
+    "@jupyter-widgets/base": "^2 || ^3",
+    "@phosphor/messaging": "^1",
+    "@phosphor/widgets": "^1",
     "d3": "^5.7.0",
     "d3-selection-multi": "^1.0.1",
     "is-typedarray": "^1.0.0",


### PR DESCRIPTION
I think this is all that is needed to get bqplot to work in JupyterLab 2.0 while still having it work in JupyterLab 1.x.

Notice that I added some phosphor dependencies, which are needed (we are importing from phosphor, but didn't list phosphor as a dependency).

Is there a reason for not having `@jupyter-widgets/base@^1` as a dependency, just curious? In other words, a version of `^1 || ^2 || ^3`?