### PR TITLE
Relayout figures after show events.

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -551,8 +551,9 @@ class Figure extends widgets.DOMWidgetView {
         super.processPhosphorMessage.apply(this, arguments);
         switch (msg.type) {
         case 'resize':
+        case 'after-show':
             const figureSize = this.getFigureSize();
-            if ((this.width !== figureSize.width) || (this.height !== figureSize.height)) {
+            if (this.pWidget.isVisible && ((this.width !== figureSize.width) || (this.height !== figureSize.height))) {
                 this.debouncedRelayout();
             }
             break;

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -552,9 +552,12 @@ class Figure extends widgets.DOMWidgetView {
         switch (msg.type) {
         case 'resize':
         case 'after-show':
-            const figureSize = this.getFigureSize();
-            if (this.pWidget.isVisible && ((this.width !== figureSize.width) || (this.height !== figureSize.height))) {
-                this.debouncedRelayout();
+            if (this.pWidget.isVisible) {
+                const figureSize = this.getFigureSize();
+                if ((this.width !== figureSize.width) || (this.height !== figureSize.height)) {
+                    this.debouncedRelayout();
+                }
+    
             }
             break;
         }


### PR DESCRIPTION
Fixes #1023

**Describe your changes**
Relayout a figure on the after-show event. Also, optimize a bit by not laying out figures that are known to be invisible (for example, in a background tab or accordion slot.

**Testing performed**

```python
from ipywidgets import Tab
from bqplot import pyplot as plt
f=plt.figure()
plt.plot([1,2,3], [1,2,3])
g=plt.figure()
plt.plot([3,2,1], [1,2,3])
Tab(children=[f, g])
```

Currently the plot in the non-active tab is rendered in a minimal size and not updated. This updates that plot when it is shown by activating a tab. This also optimizes a bit by not redrawing the figures in non-active tabs as the frame is resized.

**Additional context**

This is an alternative fix to https://github.com/bloomberg/bqplot/pull/1029. It is not as fancy (i.e., it doesn't use the browser visibility primitives), but it is much simpler.
