### PR TITLE
Add default sizing for a figure in tooltip

### DIFF
--- a/js/less/bqplot.less
+++ b/js/less/bqplot.less
@@ -284,6 +284,10 @@
     -moz-user-select: var(--bq-mark-tooltip--moz-user-select);
     background-color: var(--bq-mark-tooltip-background-color);
 }
+.mark_tooltip > .bqplot.figure {
+  width: 427px;
+  height: 320px;
+}
 .mark_tooltip td{
     border: var(--bq-mark-tooltip-td-border);
 }


### PR DESCRIPTION
This will give a default size to the figure when added in a tooltip. The size used is 2/3 of the old natural size, which was 640/480

![tooltip](https://user-images.githubusercontent.com/21197331/76855524-9cc4bc00-6851-11ea-9fb6-b341de11ec29.png)
