### PR TITLE
Bind handdraw attr() function to "this"

### DIFF
--- a/js/src/HandDraw.ts
+++ b/js/src/HandDraw.ts
@@ -117,7 +117,7 @@ export class HandDraw extends Interaction {
             this.lines_view.d3el.select("#curve" + (this.line_index + 1))
                 .attr("d", function(d) {
                     return this.lines_view.line(xy_data);
-                });
+                }.bind(this));
             this.previous_pos = mouse_pos;
         }
     }


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #971*

**Describe your changes**
This ensures that the function used to select the correct `lines_view` curve in the HandDraw interactor has access to the collection of lines_view objects.

**Testing performed**
I verified that prior to this, the handdraw example (in #971) did not work, and that subsequent to it, it did.

**Additional context**
During the first click on a curve with this interactor, the line updates as the click is in-progress.  Subsequent clicks have the line disappear between mousedown and mouseup.
