### PR TITLE
Remove six dependency in traits.py

### DIFF
--- a/bqplot/traits.py
+++ b/bqplot/traits.py
@@ -32,7 +32,7 @@ import numpy as np
 import pandas as pd
 import warnings
 import datetime as dt
-import six
+
 
 # Date
 
@@ -162,7 +162,7 @@ def array_to_json(ar, obj=None, force_contiguous=True):
 
     if ar.dtype.kind == 'O':
         # Try to serialize the array of objects
-        is_string = np.vectorize(lambda x: isinstance(x, six.string_types))
+        is_string = np.vectorize(lambda x: isinstance(x, str))
         is_timestamp = np.vectorize(lambda x: isinstance(x, pd.Timestamp))
         is_array_like = np.vectorize(lambda x: isinstance(x, (list, np.ndarray)))
 


### PR DESCRIPTION
Replaces `six.string_types` with `str`, as Python 3 is now required.  
This removes an obsolete dependency and simplifies the code.

<!--
Thanks for contributing to bqplot!
Please fill out the following items to submit a pull request.
-->

## References

None

## Code changes

- Removed import of `six` in `bqplot/traits.py`
- Replaced `six.string_types` with native `str`

## User-facing changes

None

## Backwards-incompatible changes

None

