### PR TITLE
Prevent unfriendly error message when running plt.plot

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -279,7 +279,7 @@ class Mark(Widget):
         handler(self, content)
 
     def _repr_mimebundle_(self, **kwargs):
-        return { 'text/plain': str(self) }
+        return {'text/plain': str(self)}
 
 
 @register_mark('bqplot.Lines')


### PR DESCRIPTION
Before:

<img width="1472" height="212" alt="Screenshot From 2025-12-08 16-49-11" src="https://github.com/user-attachments/assets/77621fd9-2a34-455e-ad00-773c2768611f" />

After:

<img width="1472" height="212" alt="Screenshot From 2025-12-08 16-44-37" src="https://github.com/user-attachments/assets/4f7fcb4b-77aa-411c-9ca6-e3430b03f62a" />
