### PR TITLE
Fix tooltips positioning

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -365,10 +365,6 @@ export class Figure extends DOMWidgetView {
 
     this.title.text(this.model.get('title'));
 
-    this.tooltip_div = d3
-      .select(document.createElement('div'))
-      .attr('class', 'tooltip_div');
-
     await this.create_figure_scales();
 
     this.axis_views = new ViewList(this.add_axis, this.remove_axis, this);


### PR DESCRIPTION
## References

Fix tooltip positioning.

In https://github.com/bqplot/bqplot/pull/1046 we might have mistakenly copy pasted the tooltip creation code block, which was breaking the positioning of the tooltip (the tooltip was not attached anymore to the positioning logic)