### PR TITLE
Keep `ScatterGL` in sync when an axis scale's type changes at runtime

### DIFF
--- a/js/karma.conf.js
+++ b/js/karma.conf.js
@@ -36,11 +36,11 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['ChromeHeadless'],
-    customLauncher: {
-      ChromeHeadless: {
+    browsers: ['ChromeHeadlessCI'],
+    customLaunchers: {
+      ChromeHeadlessCI: {
         base: 'ChromeHeadless',
-        flags: ['--headless', '--remote-debugging-port=9222'],
+        flags: ['--no-sandbox', '--enable-unsafe-swiftshader'],
       },
     },
     // if true, Karma captures browsers, runs the tests and exits

--- a/js/src/ScatterGL.ts
+++ b/js/src/ScatterGL.ts
@@ -502,6 +502,17 @@ export class ScatterGL extends Mark {
     this.parent.update_gl();
   }
 
+  update_material_scales() {
+    const scaleTypeMap = { date: 1, linear: 1, log: 2 };
+    const x_scale = this.scales.x ? this.scales.x : this.parent.scale_x;
+    const y_scale = this.scales.y ? this.scales.y : this.parent.scale_y;
+    this.scatter_material.defines[`SCALE_TYPE_x`] =
+      scaleTypeMap[x_scale.model.type];
+    this.scatter_material.defines[`SCALE_TYPE_y`] =
+      scaleTypeMap[y_scale.model.type];
+    this.scatter_material.needsUpdate = true;
+  }
+
   render_gl() {
     this.set_ranges();
     const fig = this.parent;
@@ -552,6 +563,8 @@ export class ScatterGL extends Mark {
     this.camera.bottom = 0;
     this.camera.top = fig.plotarea_height;
     this.camera.updateProjectionMatrix();
+
+    this.update_material_scales();
 
     this.scatter_material.uniforms['range_x'].value = range_x;
     this.scatter_material.uniforms['range_y'].value = [range_y[1], range_y[0]]; // flipped coordinates in WebGL


### PR DESCRIPTION
`ScatterGL` renders points via a WebGL shader (`shaders/scales.glsl`, `shaders/scatter-vertex.glsl`) that uses compile-time preprocessor directives to pick between a linear and a log transform:

```glsl
#if SCALE_TYPE_x == 2
    vec4 p = scale_transform_log(...);
#else
    vec4 p = scale_transform_linear(...);
#endif
```

(see https://github.com/bloomberg/bqplot/blob/861aa219a216281c0dc3d910701815949e5b5615/js/shaders/scatter-vertex.glsl#L104-L113)

The `SCALE_TYPE_x` / `SCALE_TYPE_y` defines are set from `scales.x.model.type` at the point where the three.js `ShaderMaterial` is first constructed, and never refreshed afterwards. That was fine when the only way to "switch to log" was to replace the scale object entirely (which triggered a full re-init).

However, I've developed a new scale and axis implementation in [bqplot-linlog](https://github.com/glue-viz/bqplot-linlog) can mutate its own type at runtime — which flips `model.type` between `linear` and `log` without replacing the scale. However, when doing this `ScatterGL` gets left behind: the axis ticks and SVG marks update, but the GL points keep drawing with whichever transform happened to be compiled in at init time.

`LinesGL` in [bqplot-image-gl](https://github.com/glue-viz/bqplot-image-gl) already handles this correctly via its own per-frame shader update (see [here](https://github.com/glue-viz/bqplot-image-gl/blob/v1.9.2/js/lib/linesgl.js#L147-L169 )). This PR brings `ScatterGL` in line with the same pattern.

To reproduce this, you can run the following in a notebook:

```python
import numpy as np, ipywidgets as widgets
from bqplot import Figure, Scatter, ScatterGL, Lines
from bqplot_image_gl import LinesGL
from bqplot_linlog import LinLogScale, LinLogAxis

rng = np.random.default_rng(0)
x = np.logspace(0, 2, 400)
y = x * np.exp(0.25 * rng.standard_normal(x.size))

x_scale = LinLogScale(); y_scale = LinLogScale()
scales = {'x': x_scale, 'y': y_scale}

def make(MarkCls, title):
    m = MarkCls(x=x, y=y, scales=scales)
    return Figure(marks=[m], title=title,
                  axes=[LinLogAxis(scale=x_scale, label='x'),
                        LinLogAxis(scale=y_scale, orientation='vertical', label='y')],
                  layout=widgets.Layout(width='420px', height='320px'))

grid = widgets.GridBox([make(Scatter,'Scatter'), make(ScatterGL,'ScatterGL'),
                        make(Lines,'Lines'),     make(LinesGL,'LinesGL')],
                       layout=widgets.Layout(grid_template_columns='repeat(2, 440px)'))
toggle = widgets.ToggleButtons(options=['linear','log'], value='linear')
def flip(c): x_scale.mode = y_scale.mode = c['new']
toggle.observe(flip, names='value')
widgets.VBox([toggle, grid])
```

Flip the toggle to `log`. Without the fix, `ScatterGL` visibly diverges from `Scatter`:
<img width="813" height="592" alt="Screenshot 2026-04-23 at 11 57 15" src="https://github.com/user-attachments/assets/460ce51a-c1dc-4f06-adc5-872336560a55" />

With the fix, they stay identical:

<img width="819" height="605" alt="Screenshot 2026-04-23 at 11 57 40" src="https://github.com/user-attachments/assets/784bfe01-c5be-4d0b-a52e-ae0494740067" />

I opened this to 0.12.x since the code no longer exists in master - if this is accepted I can open a similar PR to bqplot-gl, but wanted to also fix it here since it is a bug which is affecting us.