### PR TITLE
ci: publish to PyPI and npm via trusted publishers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master, 0.12.x ]
   pull_request:
     branches: '*'
+  release:
+    types: [published]
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
@@ -80,6 +82,11 @@ jobs:
         python setup.py sdist bdist_wheel
         cd dist
         sha256sum * | tee SHA256SUMS
+
+    - name: Twine check
+      run: |
+        pip install --upgrade twine
+        twine check dist/*.whl dist/*.tar.gz
 
     - name: Pack JavaScript package
       run: |
@@ -168,11 +175,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ['3.6', '3.9']
+        python: ['3.6', '3.9', '3.12']
         include:
           - python: '3.6'
             dist: 'bqplot*.tar.gz'
           - python: '3.9'
+            dist: 'bqplot*.whl'
+          - python: '3.12'
             dist: 'bqplot*.whl'
 
     steps:
@@ -244,3 +253,105 @@ jobs:
         run: |
          micromamba activate lab2
          jupyter labextension install dist/bqplot*.tgz --debug
+
+  publish-pypi:
+    runs-on: ubuntu-24.04
+    needs: [build, visual-regression-tests]
+    permissions:
+      id-token: write
+    environment:
+      name: ${{ github.event_name == 'release' && 'release-pypi' || '' }}
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ github.run_number }}
+          path: ./dist
+
+      - name: Keep only PyPI artifacts
+        run: |
+          rm -f dist/*.tgz dist/SHA256SUMS
+          ls -la dist/
+
+      - name: Verify tag matches wheel version
+        if: github.event_name == 'release'
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          WHEEL_VERSION=$(ls dist/bqplot-*.whl | sed -E 's|.*/bqplot-([^-]+)-.*\.whl|\1|')
+          echo "Release tag:    $TAG"
+          echo "Wheel version:  $WHEEL_VERSION"
+          if [ "$TAG" != "$WHEEL_VERSION" ]; then
+            echo "::error::Release tag '$TAG' does not match wheel version '$WHEEL_VERSION'"
+            exit 1
+          fi
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Twine check
+        run: |
+          python -m pip install --upgrade pip twine
+          twine check dist/*.whl dist/*.tar.gz
+
+      - name: Publish to PyPI (Trusted Publisher)
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-npm:
+    runs-on: ubuntu-24.04
+    needs: [build, visual-regression-tests]
+    permissions:
+      id-token: write
+      contents: read
+    environment:
+      name: ${{ github.event_name == 'release' && 'release-npm' || '' }}
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ github.run_number }}
+          path: ./dist
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm to a version that supports trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Show npm package version
+        run: |
+          NPM_VERSION=$(ls dist/bqplot-*.tgz | sed -E 's|.*/bqplot-(.+)\.tgz|\1|')
+          echo "Will publish bqplot@$NPM_VERSION"
+          echo "NPM_VERSION=$NPM_VERSION" >> "$GITHUB_ENV"
+
+      - name: Check npm version
+        id: npm_check
+        run: |
+          if npm view "bqplot@$NPM_VERSION" version > /dev/null 2>&1; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "bqplot@$NPM_VERSION is already on npm"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "bqplot@$NPM_VERSION not yet on npm"
+          fi
+
+      - name: Fail if releasing an already-published version
+        if: github.event_name == 'release' && steps.npm_check.outputs.already_published == 'true'
+        run: |
+          echo "::error::bqplot@$NPM_VERSION is already on npm; bump js/package.json before releasing"
+          exit 1
+
+      - name: npm publish (dry-run)
+        if: github.event_name != 'release' && steps.npm_check.outputs.already_published == 'false'
+        run: npm publish ./dist/bqplot-*.tgz --access public --dry-run
+
+      - name: Skip dry-run (version already published)
+        if: github.event_name != 'release' && steps.npm_check.outputs.already_published == 'true'
+        run: echo "::notice::bqplot@$NPM_VERSION is already on npm; skipping dry-run. Bump js/package.json on a release-prep PR to exercise the full publish flow."
+
+      - name: npm publish (Trusted Publisher)
+        if: github.event_name == 'release'
+        run: npm publish ./dist/bqplot-*.tgz --access public --provenance

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,29 +1,86 @@
-To release a new version of bqplot on PyPI:
+# Releasing bqplot
 
-## Create a new environment for the release
+The release process is automated via GitHub Actions and trusted publishers.
+The legacy manual process is documented at the bottom of this file as a
+fallback.
+
+## Automated release flow
+
+Both PyPI and the npm package are published from the same artifact that the
+`build` job produces in CI, so what ships is exactly what was tested by the
+visual-regression suite.
+
+### One-time setup (already configured)
+
+- PyPI Trusted Publisher entry on https://pypi.org/manage/project/bqplot/settings/publishing/
+  pointing at workflow `build.yml` and environment `release-pypi`.
+- npm Trusted Publisher entry on npmjs.com pointing at workflow `build.yml`
+  and environment `release-npm`.
+- GitHub Environments `release-pypi` and `release-npm` configured in the
+  repo, optionally with required reviewers for an extra approval gate.
+
+### Cutting a release
+
+1. On the appropriate branch (`0.12.x` for the 0.12.x line, `master` for the
+   next major), bump the versions:
+   - `bqplot/_version.py` — Python package version (e.g. `0.12.46`)
+   - `js/package.json` — npm package version (e.g. `0.5.47`); also update
+     `js/package-lock.json` by running `yarn install`
+   - If the JS major/minor changed, update `__frontend_version__` in
+     `bqplot/_version.py` to match.
+
+2. Commit the bump and open a PR. Wait for CI to go green — the publish jobs
+   run in dry-run mode (`twine check`, `npm publish --dry-run`) so any
+   metadata problem is caught before release.
+
+3. Merge the PR.
+
+4. Create a GitHub Release on the merge commit:
+   - **Tag**: the Python version, no `v` prefix (e.g. `0.12.46`). The tag
+     must match `bqplot/_version.py` — CI will fail the publish step
+     otherwise.
+   - **Target**: the branch you merged into (e.g. `0.12.x`).
+   - **Title** and notes: as you like.
+
+5. Publishing the release fires the workflow with `event_name == 'release'`.
+   The workflow rebuilds the wheel/sdist/tgz, re-runs the visual-regression
+   tests on the built wheel, then `publish-pypi` and `publish-npm` upload
+   via OIDC. If you set required reviewers on the environments, GitHub will
+   pause for your approval before each upload.
+
+6. Update the [conda-forge feedstock](https://github.com/conda-forge/bqplot-feedstock/)
+   (still manual).
+
+### If a publish step fails
+
+The `dist/` artifact from the run is preserved on the workflow run page. Fix
+the underlying issue (typically a misconfigured trusted publisher entry on
+PyPI/npm), then click **Re-run failed jobs** — no rebuild or retag needed.
+
+---
+
+## Legacy manual release process (deprecated)
+
+Kept for reference / emergency use only. Prefer the automated flow above.
+
+### Create a new environment for the release
 
 ```sh
 conda create -c conda-forge --override-channels -y -n bqplotrelease "jupyterlab=3.2" "nodejs=16" twine ipywidgets pip jupyter_packaging "yarn<2"
 conda activate bqplotrelease
 ```
 
-## Check out a fresh copy of the repo
-
-We check out a fresh copy in a `release/` subdirectory to make sure we do not
-overwrite our development repo.
+### Check out a fresh copy of the repo
 
 ```sh
 mkdir -p release
 cd release
-# Delete any previous checkout we have here.
 rm -rf bqplot
-
-
-git clone git@github.com:bloomberg/bqplot.git
+git clone git@github.com:bqplot/bqplot.git
 cd bqplot
 ```
 
-## Release the npm package
+### Release the npm package
 
 ```sh
 cd js/
@@ -33,9 +90,10 @@ npm publish
 cd ..
 ```
 
-## Release the pypi package
+### Release the pypi package
 
-Update _version.py (bump both the python package version, and if needed, the Javascript version)
+Update `_version.py` (bump both the python package version, and if needed,
+the Javascript version).
 
 ```
 git clean -dfx
@@ -44,31 +102,23 @@ python setup.py bdist_wheel
 twine upload dist/*
 ```
 
-## Tag the repository
+### Tag the repository
 
-Check to make sure the only changes are to the `package.json`, `package-lock.json`, and `_version.py` files:
+Check that the only changes are to `package.json`, `package-lock.json`, and
+`_version.py`:
 
 ```sh
 git diff
 ```
 
-Commit the changes in git
+Commit and tag:
 
 ```sh
 git commit -sa -m "Release 0.12.42"
-```
-
-Tag the release
-
-```sh
 git tag [version, like 0.12.42]
-```
-
-Push the changes:
-```
 git push origin 0.12.x 0.12.42
 ```
 
-## Update the recipe on conda-forge and set the stable branch to the newly tagged commit
+### Update conda-forge
 
 Update the [conda-forge feedstock](https://github.com/conda-forge/bqplot-feedstock/).

--- a/bqplot/_version.py
+++ b/bqplot/_version.py
@@ -1,4 +1,4 @@
-version_info = (0, 12, 45, 'final', 0)
+version_info = (0, 12, 46, 'final', 0)
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bqplot",
-  "version": "0.5.46",
+  "version": "0.5.47",
   "description": "bqplot",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
## Summary

- Reuse the `dist/` artifact already produced by the `build` job (wheel, sdist, npm tarball) instead of rebuilding at release time. The artifact that visual regression tests validate is the one that gets uploaded.
- New `publish-pypi` and `publish-npm` jobs gated on `[build, visual-regression-tests]`. They run on every PR/push in dry-run mode (`twine check`, `npm publish --dry-run`) and only do real uploads when triggered by a `release: published` event, via OIDC trusted publishers (no `PYPI_TOKEN` or `NPM_TOKEN`).
- Version-sanity check on real release: fails if the GitHub Release tag doesn't match the wheel version, or if the npm version is already published.
- Added `twine check dist/*` to the `build` job so PR CI catches metadata issues early.

Inspired by the test/release workflows in [solara](https://github.com/widgetti/solara/blob/master/.github/workflows/test.yaml) and [ipyvuetify](https://github.com/widgetti/ipyvuetify/blob/master/.github/workflows/test.yml).

## One-time setup (already done by maintainer)

- PyPI Trusted Publisher entry added at https://pypi.org/manage/project/bqplot/settings/publishing/ (workflow `build.yml`, environment `release-pypi`).
- npm Trusted Publisher entry added on npmjs.com (workflow `build.yml`, environment `release-npm`).
- GitHub Environments `release-pypi` and `release-npm` created in the repo.

## Release flow after this lands

1. Bump `bqplot/_version.py` and `js/package.json`, commit, push.
2. Cut a GitHub Release with tag matching the Python version (e.g. `0.12.46`, no `v` prefix).
3. Workflow builds, tests, version-checks, then publishes via OIDC. If required reviewers are set on the environments, GitHub pauses for approval before each upload.

## Test plan

- [ ] PR CI runs `build`, then `publish-pypi` (dry-run) and `publish-npm` (dry-run) without any environment-approval prompt and without touching the registries.
- [ ] `twine check` passes on the built wheel/sdist.
- [ ] `npm publish --dry-run` reports the expected tarball contents.
- [ ] First real release of 0.12.46 uploads to both registries via OIDC. (Verifies the trusted-publisher config; if it fails, re-run the failed job after fixing the registry-side config — the dist artifact is preserved.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)