### PR TITLE
Fix: MarketMap not rendering and axis positioning in 0.13.0

### DIFF
--- a/bqplot/market_map.py
+++ b/bqplot/market_map.py
@@ -98,7 +98,7 @@ class MarketMap(DOMWidget):
 
     Attributes
     ----------
-    map_margin: dict (default: {top=50, bottom=50, left=50, right=50})
+    fig_margin: dict (default: {top=50, bottom=50, left=50, right=50})
         Dictionary containing the top, bottom, left and right margins. The user
         is responsible for making sure that the width and height are greater
         than the sum of the margins.
@@ -179,7 +179,7 @@ class MarketMap(DOMWidget):
     scales = Dict().tag(sync=True, **widget_serialization)
     axes = List().tag(sync=True, **widget_serialization)
     color = Array([]).tag(sync=True, **array_serialization)
-    map_margin = Dict(dict(top=50, right=50, left=50, bottom=50))\
+    fig_margin = Dict(dict(top=50, right=50, left=50, bottom=50))\
         .tag(sync=True)
 
     layout = LayoutTraitType(kw=dict(min_width='125px'))\

--- a/js/src/MarketMap.ts
+++ b/js/src/MarketMap.ts
@@ -116,7 +116,7 @@ export class MarketMap extends Figure {
       .attr('class', 'mainheading')
       .text(this.model.get('title'));
     applyAttrs(this.title, {
-      x: 0.5 * this.width,
+      x: 0.5 * this.plotareaWidth,
       y: -(this.margin.top / 2.0),
       dy: '1em',
     });
@@ -155,10 +155,10 @@ export class MarketMap extends Figure {
   }
 
   update_plotarea_dimensions() {
-    this.width = this.width - this.margin.left - this.margin.right;
-    this.height = this.height - this.margin.top - this.margin.bottom;
-    this.column_width = parseFloat((this.width / this.num_cols).toFixed(2));
-    this.row_height = parseFloat((this.height / this.num_rows).toFixed(2));
+    const plotarea_width = this.plotareaWidth;
+    const plotarea_height = this.plotareaHeight;
+    this.column_width = parseFloat((plotarea_width / this.num_cols).toFixed(2));
+    this.row_height = parseFloat((plotarea_height / this.num_rows).toFixed(2));
   }
 
   reset_drawing_controls() {
@@ -254,7 +254,7 @@ export class MarketMap extends Figure {
         'translate(' + that.margin.left + ',' + that.margin.top + ')'
       );
       applyAttrs(that.title, {
-        x: 0.5 * that.width,
+        x: 0.5 * that.plotareaWidth,
         y: -(that.margin.top / 2.0),
         dy: '1em',
       });

--- a/js/src/MarketMapModel.ts
+++ b/js/src/MarketMapModel.ts
@@ -53,7 +53,7 @@ export class MarketMapModel extends WidgetModel {
       scales: {},
       axes: [],
       color: [],
-      map_margin: {
+      fig_margin: {
         top: 50,
         right: 50,
         left: 50,


### PR DESCRIPTION
Fixes a bug introduced after updating to 0.13.0 affecting the display of MarketMap figure and axis position.

#### Reproduce bug

On version 0.13.0, running cell 3 of notebook `examples/Marks/Object Model/Market Map.ipynb` renders blank. After fixing the rendering issue, cell 9 of the same notebook has axis mispositioned (see images below).

<!--
Thanks for contributing to bqplot!
Please fill out the following items to submit a pull request.
-->

## References
None
<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
<!-- Describe the code changes and how they address the issue. -->

- Rename `map_margin` to `fig_margin` in market_map.py and MarketMapModel.ts to match getter in Figure.ts 

- Fix axis position by replacing `this.width`/`this.height` with `this.plotareaWidth`/`this.plotareaHeight` in MarketMap.ts


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

#### Before
<img width="2063" height="1041" alt="Screenshot 2026-05-05 185335" src="https://github.com/user-attachments/assets/e986eede-52cd-4925-a0e3-55dc5c7bfe7a" />

#### After
<img width="2060" height="1039" alt="Screenshot 2026-05-06 021512" src="https://github.com/user-attachments/assets/66777ea3-6413-4bb8-9940-6905ce249181" />

#### Before
<img width="2003" height="806" alt="Screenshot 2026-05-05 191903" src="https://github.com/user-attachments/assets/2bf5ae77-a782-4424-ae25-8105181f4076" />

#### After
<img width="2019" height="800" alt="Screenshot 2026-05-05 185522" src="https://github.com/user-attachments/assets/b36fa9ab-0020-4886-8db7-5c7075c4ff54" />


## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to bqplot public APIs. -->